### PR TITLE
Add ability to increment (rather than overwrite) values to listener framework

### DIFF
--- a/wholecell/listeners/listener.py
+++ b/wholecell/listeners/listener.py
@@ -6,6 +6,8 @@ Listener
 @date: Created 5/10/2014
 """
 
+from enum import Enum
+
 class Listener(object):
 	_name = None
 
@@ -86,3 +88,7 @@ class Listener(object):
 	@classmethod
 	def name(cls):
 		return cls._name
+
+class WriteMethod(Enum):
+	update = 1
+	increment = 2

--- a/wholecell/processes/process.py
+++ b/wholecell/processes/process.py
@@ -19,6 +19,8 @@ import warnings
 import wholecell.states.bulk_molecules
 import wholecell.states.unique_molecules
 
+from wholecell.listeners.listener import WriteMethod
+
 class Process(object):
 	""" Process """
 
@@ -96,7 +98,7 @@ class Process(object):
 
 	# TODO: consider an object-oriented interface to reading/writing to listeners
 	# that way, processes would use object handles instead of strings
-	def writeToListener(self, listenerName, attributeName, value):
+	def writeToListener(self, listenerName, attributeName, value, writeMethod = WriteMethod.update):
 		if listenerName not in self._sim.listeners.viewkeys():
 			warnings.warn("The {} process attempted to write {} to the {} listener, but there is no listener with that name.".format(
 				self._name,
@@ -113,9 +115,17 @@ class Process(object):
 					attributeName,
 					listenerName
 					))
-
 			else:
-				setattr(listener, attributeName, value)
+				if writeMethod == WriteMethod.update:
+					setattr(listener, attributeName, value)
+				elif writeMethod == WriteMethod.increment:
+					setattr(listener, attributeName, getattr(listener, attributeName) + value)
+				else:
+					raise warnings.warn("The {} process attempted to write {} to the {} listener, but used an invalid write method: {}".format(
+						self._name,
+						attributeName,
+						listenerName,
+						writeMethod))
 
 
 	def readFromListener(self, listenerName, attributeName):


### PR DESCRIPTION
This adds a new writeMethod parameter to writeToListener(...), allowing values
stored in the listener to be incremented rather than overwritten, and thus allowing
different submodels to update the same listener attribute. This is required to
add a new listener submodel per the tutorial.
