### PR TITLE
Add ability to append to a numpy ndarray when writing to listener.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ launcher_*
 block_*
 FW.json
 
+# Sublime Files #
+# ###############
+*.sublime-*
 
 # Misc #
 ########

--- a/wholecell/listeners/listener.py
+++ b/wholecell/listeners/listener.py
@@ -92,3 +92,4 @@ class Listener(object):
 class WriteMethod(Enum):
 	update = 1
 	increment = 2
+	append = 3

--- a/wholecell/processes/process.py
+++ b/wholecell/processes/process.py
@@ -18,6 +18,7 @@ import warnings
 
 import wholecell.states.bulk_molecules
 import wholecell.states.unique_molecules
+import numpy as np
 
 from wholecell.listeners.listener import WriteMethod
 
@@ -120,6 +121,15 @@ class Process(object):
 					setattr(listener, attributeName, value)
 				elif writeMethod == WriteMethod.increment:
 					setattr(listener, attributeName, getattr(listener, attributeName) + value)
+				elif writeMethod == WriteMethod.append:
+					data = getattr(listener, attributeName)
+					if isinstance(data, np.ndarray):
+						setattr(listener, attributeName, np.append(data, value, axis=0))
+					else:
+						warnings.warn("The {} process attempted to append to {} on the {} listener, but it is not an ndarray".format(
+							self._name,
+							attributeName,
+							listenerName))
 				else:
 					raise warnings.warn("The {} process attempted to write {} to the {} listener, but used an invalid write method: {}".format(
 						self._name,


### PR DESCRIPTION
Turns out some attributes are arrays of values, so we need to append
new ones rather than just incrementing. Commit also adds sublime
project files to .gitignore.
