### PR TITLE
Issue #84 - shell logger time precision

### DIFF
--- a/wholecell/loggers/shell.py
+++ b/wholecell/loggers/shell.py
@@ -29,7 +29,7 @@ class Shell(wholecell.loggers.logger.Logger):
 		self.headerFreq = 50
 
 		self.columnSpecs = [
-			{"header": "Time (s)", "target": "Simulation", "property": "time", "length": 8, "format": "d", "sum": False},
+			{"header": "Time (s)", "target": "Simulation", "property": "time", "length": 8, "format": ".2f", "sum": False},
 			]
 
 		self.columnHeaders = columnHeaders
@@ -110,7 +110,7 @@ class Shell(wholecell.loggers.logger.Logger):
 					string.append(SPACER)
 
 				string.append(("%" + str(columnSize) + "s") % columnHeader)
-			
+
 			strings.append(''.join(string))
 
 		self._header = '\n'.join(strings) + '\n'
@@ -150,7 +150,7 @@ class Shell(wholecell.loggers.logger.Logger):
 
 			else:
 				targetType, targetName = column["target"].split(":")
-				
+
 				target = {
 					"State":sim.states,
 					"Process":sim.processes,


### PR DESCRIPTION
This addresses issue #84 by adding two decimals of precision to the displayed value.  I would have just pushed this to master, but I'm not certain how others use the shell logger for development (if at all).  Don't want a sudden output change to throw someone off.  Example output (compare with example in issue):
```
Time (s)  Dry mass     Dry mass      Protein          RNA    Small mol     Expected
              (fg)  fold change  fold change  fold change  fold change  fold change
========  ========  ===========  ===========  ===========  ===========  ===========
    0.00    402.97        1.000        1.000        1.000        1.000        1.000
    0.20    403.07        1.000        1.000        1.000        1.000        1.000
    0.40    403.14        1.000        1.000        1.000        1.001        1.000
    0.60    403.18        1.001        1.000        1.000        1.001        1.000
    0.80    403.22        1.001        1.000        1.000        1.001        1.000
    1.00    403.33        1.001        1.000        1.000        1.002        1.000
    1.89    403.58        1.002        1.001        1.001        1.003        1.000
    2.79    403.66        1.002        1.001        1.001        1.003        1.001
    3.68    403.90        1.002        1.001        1.001        1.004        1.001
    4.57    403.95        1.002        1.001        1.001        1.004        1.001
    5.46    404.18        1.003        1.002        1.002        1.005        1.001
    6.36    404.27        1.003        1.002        1.002        1.005        1.002
    7.25    404.47        1.004        1.002        1.002        1.006        1.002
    8.14    404.61        1.004        1.002        1.002        1.007        1.002
    9.04    404.78        1.004        1.002        1.002        1.007        1.002
    9.93    404.94        1.005        1.003        1.003        1.008        1.003
```