### PR TITLE
Update pycharm style to insert tab character for other files (.tsv)

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,10 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="USE_TAB_CHARACTER" value="true" />
+      </value>
+    </option>
     <option name="RIGHT_MARGIN" value="79" />
     <option name="SOFT_MARGINS" value="72,79" />
     <Python>


### PR DESCRIPTION
Needed to change settings in the shared file to allow insertion of \t in other files so that .tsv files can be edited properly in pycharm