### PR TITLE
Change cached sim data copy to prevent copying permissions (read-only)

### DIFF
--- a/wholecell/fireworks/firetasks/fitSimData.py
+++ b/wholecell/fireworks/firetasks/fitSimData.py
@@ -24,8 +24,8 @@ class FitSimDataTask(FireTaskBase):
 					shutil.copyfile(self["cached_data"], self["output_data"])
 					print "Copied sim data from cache (modified %s)" % time.ctime(os.path.getctime(self["cached_data"]))
 					return
-				except:
-					print "Warning: could not copy cached sim data, running fitter"
+				except Exception as exc:
+					print "Warning: could not copy cached sim data due to exception (%s), running fitter" % (exc)
 
 			if self["cpus"] > 1:
 				print "Warning: running fitter in parallel with %i processes - ensure there are enough cpus_per_task allocated" % self["cpus"]


### PR DESCRIPTION
shutil.copy2 will also copy permissions so the sim_data object becomes read only in the output directory.  The cached version is read-only to help prevent someone from accidentally changing it since it is shared among everyone but it can create issues with rerunning the fitter firework if the output file is read-only.  shutil.copyfile should create the new file with write permissions