### PR TITLE
Update seed for mccFormComplexesWithPrebuiltMatrices at each time step

### DIFF
--- a/models/ecoli/processes/complexation.py
+++ b/models/ecoli/processes/complexation.py
@@ -21,6 +21,9 @@ import numpy as np
 import wholecell.processes.process
 from wholecell.utils.mc_complexation import mccBuildMatrices, mccFormComplexesWithPrebuiltMatrices
 
+# Maximum unsigned int value + 1 for randint() to seed srand from C stdlib
+RAND_MAX = 2**32
+
 class Complexation(wholecell.processes.process.Process):
 	""" Complexation """
 
@@ -51,7 +54,7 @@ class Complexation(wholecell.processes.process.Process):
 		# Macromolecule complexes are requested
 		updatedMoleculeCounts = mccFormComplexesWithPrebuiltMatrices(
 			moleculeCounts,
-			self.randomState.randint(1e9),
+			self.randomState.randint(RAND_MAX),
 			self.stoichMatrix,
 			*self.prebuiltMatrices
 			)
@@ -65,7 +68,7 @@ class Complexation(wholecell.processes.process.Process):
 		# Macromolecule complexes are formed from their subunits
 		updatedMoleculeCounts = mccFormComplexesWithPrebuiltMatrices(
 			moleculeCounts,
-			self.randomState.randint(1e9),
+			self.randomState.randint(RAND_MAX),
 			self.stoichMatrix,
 			*self.prebuiltMatrices
 			)


### PR DESCRIPTION
Currently the process uses `self.seed` to seed the mccFormComplexesWithPrebuiltMatrices which is cython compiled code that sets `srand()` with the seed passed.  `self.seed` is fixed for an entire generation so there can be a bias to which complexes get formed at each time step depending on the random sequence generated by `self.seed`.  I don't expect this to have a huge impact on outcome and I don't think this solution is as random of a solution as possible but it is certainly an improvement.  From a quick inspection it looks like about a third of the time the `self.seed` produces the same molecule counts as generating the new seed.