### PR TITLE
Fix paths for git commands to capture metadata

### DIFF
--- a/runscripts/fw_queue.py
+++ b/runscripts/fw_queue.py
@@ -26,10 +26,11 @@ import cPickle
 
 def run_cmd(cmd):
 	environ = {
-	"PATH": os.environ["PATH"],
-	"LANG": "C",
-	"LC_ALL": "C",
-	}
+		"PATH": os.environ["PATH"],
+		"LD_LIBRARY_PATH": os.environ["LD_LIBRARY_PATH"],
+		"LANG": "C",
+		"LC_ALL": "C",
+		}
 	out = subprocess.Popen(cmd, stdout = subprocess.PIPE, env=environ).communicate()[0]
 	return out
 


### PR DESCRIPTION
With Sherlock 2, we've been getting the following error when running `fw_queue.py`:
```
git: error while loading shared libraries: libcrypto.so.41: cannot open shared object file: No such file or directory
```
With the Sherlock 2 git module we need to include another path so that it finds the shared library and can retrieve the appropriate metadata.

Additionally fixed some formatting with indents of the other lines.