### PR TITLE
Fix bug #133 by using Python's portable random()

### DIFF
--- a/wholecell/tests/utils/test_mc_complexation.py
+++ b/wholecell/tests/utils/test_mc_complexation.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Test polymerize_new.py
 
@@ -7,30 +5,19 @@ Test polymerize_new.py
 @organization: Covert Lab, Department of Chemical Engineering, Stanford University
 @date: Created 6/23/2014
 """
+
+from __future__ import absolute_import
+from __future__ import division
+
 from wholecell.utils.mc_complexation import mccBuildMatrices, mccFormComplexesWithPrebuiltMatrices
 
 import numpy as np
+import numpy.testing as npt
 
 import nose.plugins.attrib as noseAttrib
-import nose.tools as noseTools
 import unittest
 
 class Test_mc_complexation(unittest.TestCase):
-	
-
-	@classmethod
-	def setUpClass(cls):
-		pass
-
-	@classmethod
-	def tearDownClass(cls):
-		pass
-
-	def setUp(self):
-		pass
-
-	def tearDown(self):
-		pass
 
 	@noseAttrib.attr('complexationTest')
 	@noseAttrib.attr('smalltest')
@@ -43,24 +30,18 @@ class Test_mc_complexation(unittest.TestCase):
 								 [ 0,  0,  0,  1]], dtype=np.int64)
 
 		moleculeIndexes, overlappingReactions = mccBuildMatrices(stoichMatrix)
-		
-		self.assertTrue(
-			np.all(
-				moleculeIndexes == np.array([[ 0,  1, -1],
-											[ 0,  2, -1],
-											[ 1,  2,  3],
-											[ 4,  5, -1]])
-				)
-			)
 
-		self.assertTrue(
-			np.all(
-				overlappingReactions == np.array([[ 0,  1, 2],
-											[ 0,  1, 2],
-											[ 0,  1, 2],
-											[ 3,  -1, -1]])
-				)
-			)
+		npt.assert_equal(moleculeIndexes,
+			np.array([[ 0,  1, -1],
+					  [ 0,  2, -1],
+					  [ 1,  2,  3],
+					  [ 4,  5, -1]]))
+
+		npt.assert_equal(overlappingReactions,
+			np.array([[ 0,  1,  2],
+					  [ 0,  1,  2],
+					  [ 0,  1,  2],
+					  [ 3, -1, -1]]))
 
 
 	@noseAttrib.attr('complexationTest')
@@ -72,11 +53,10 @@ class Test_mc_complexation(unittest.TestCase):
 								 [ 0,  0,  1,  0],
 								 [ 0,  0,  0, -1],
 								 [ 0,  0,  0,  1]], dtype=np.int64)
-		seed = 0
+		seed = 2
 		test_moleculeCounts = np.array([[0, 6, 8, 0, 0, 0],
 									[10, 0, 0, 0, 0, 0],
 									[0, 0, 0, 3, 3, 0]], dtype=np.int64)
-
 
 		expected_updatedMoleculeCounts = np.array([[0, 0, 2, 6, 0, 0],
 									[0, 0, 1, 3, 0, 0],
@@ -92,8 +72,4 @@ class Test_mc_complexation(unittest.TestCase):
 				*prebuiltMatrices
 				)
 
-			self.assertTrue(
-				np.all(
-						updatedMoleculeCounts == expected_updatedMoleculeCounts[i]
-					)
-				)
+			npt.assert_equal(updatedMoleculeCounts, expected_updatedMoleculeCounts[i])


### PR DESCRIPTION
… instead of the C++ `stdlib::rand()`, to get portable results.

NOTE: In wholecell/utils/mc_complexation.pyx, importing the
Python-standard `random` doesn’t work since there’s a package-local
random.py. Adding
`from __future__ import absolute_import` fixes that!