### PR TITLE
Add exception handling for WC_ANALYZE_FAST option in analysis scripts

### DIFF
--- a/wholecell/fireworks/firetasks/analysisMultiGen.py
+++ b/wholecell/fireworks/firetasks/analysisMultiGen.py
@@ -33,6 +33,7 @@ class AnalysisMultiGenTask(FireTaskBase):
 
 		if "WC_ANALYZE_FAST" in os.environ:
 			pool = mp.Pool(processes = 8)
+			results = {}
 
 		exception = False
 		exceptionFileList = []
@@ -51,7 +52,7 @@ class AnalysisMultiGenTask(FireTaskBase):
 				)
 
 			if "WC_ANALYZE_FAST" in os.environ:
-				pool.apply_async(run_function, args = (mod.main, args, f))
+				results.update({f: pool.apply_async(run_function, args = (mod.main, args, f))})
 			else:
 				print "%s: Running %s" % (time.ctime(), f)
 				try:
@@ -66,6 +67,11 @@ class AnalysisMultiGenTask(FireTaskBase):
 		if "WC_ANALYZE_FAST" in os.environ:
 			pool.close()
 			pool.join()
+			for f, result in results.items():
+				if not result.successful():
+					exception = True
+					exceptionFileList += [f]
+
 		timeTotal = time.time() - startTime
 
 		if exception:
@@ -82,3 +88,6 @@ def run_function(f, args, name):
 		f(*args)
 	except KeyboardInterrupt:
 		import sys; sys.exit(1)
+	except Exception as e:
+		traceback.print_exc()
+		raise Exception(e)

--- a/wholecell/fireworks/firetasks/analysisSingle.py
+++ b/wholecell/fireworks/firetasks/analysisSingle.py
@@ -33,6 +33,7 @@ class AnalysisSingleTask(FireTaskBase):
 
 		if "WC_ANALYZE_FAST" in os.environ:
 			pool = mp.Pool(processes = 8)
+			results = {}
 
 		exception = False
 		exceptionFileList = []
@@ -51,7 +52,7 @@ class AnalysisSingleTask(FireTaskBase):
 				)
 
 			if "WC_ANALYZE_FAST" in os.environ:
-				pool.apply_async(run_function, args = (mod.main, args, f))
+				results.update({f: pool.apply_async(run_function, args = (mod.main, args, f))})
 			else:
 				print "%s: Running %s" % (time.ctime(), f)
 				try:
@@ -66,6 +67,11 @@ class AnalysisSingleTask(FireTaskBase):
 		if "WC_ANALYZE_FAST" in os.environ:
 			pool.close()
 			pool.join()
+			for f, result in results.items():
+				if not result.successful():
+					exception = True
+					exceptionFileList += [f]
+
 		timeTotal = time.time() - startTime
 
 		if exception:
@@ -82,3 +88,6 @@ def run_function(f, args, name):
 		f(*args)
 	except KeyboardInterrupt:
 		import sys; sys.exit(1)
+	except Exception as e:
+		traceback.print_exc()
+		raise Exception(e)


### PR DESCRIPTION
The PR builder was not catching errors in analysis scripts because it runs them in parallel with WC_ANALYZE_FAST and doesn't handle exceptions.  I added exception handling so it should run all of the scripts and print the stack trace for each script that raises an exception and then flag the overall firetask at the end so the build fails.