### PR TITLE
Fix chromosome issues due to updated packages

### DIFF
--- a/models/ecoli/sim/initial_conditions.py
+++ b/models/ecoli/sim/initial_conditions.py
@@ -221,13 +221,12 @@ def initializeReplication(bulkMolCntr, uniqueMolCntr, sim_data):
 	sequences = sim_data.process.replication.replication_sequences
 	sequenceElongations = np.array(sequenceLength, dtype=np.int64)
 	massIncreaseDna = computeMassIncrease(
-			np.tile(sequences,(len(sequenceIdx) / 4,1)),
+			np.tile(sequences,(len(sequenceIdx) // 4,1)),
 			sequenceElongations,
 			sim_data.process.replication.replicationMonomerWeights.asNumber(units.fg)
 			)
 
 	# Update the attributes of replicating DNA polymerases
-	oricCenter = sim_data.constants
 	dnaPoly = uniqueMolCntr.objectsNew('dnaPolymerase', len(sequenceIdx))
 	dnaPoly.attrIs(
 		sequenceIdx = np.array(sequenceIdx),

--- a/wholecell/sim/divide_cell.py
+++ b/wholecell/sim/divide_cell.py
@@ -361,10 +361,10 @@ def divideUniqueMolecules(uniqueMolecules, randomState, chromosome_counts, sim):
 			if replicationForks >= 2:
 				for index in [0,1,2,3]:
 					# if not possible to have uneven number of partial chromosomes
-					num_index = d2_dividedAttributesDict['sequenceIdx'][replicationRoundIndexes] == index
+					num_index = (chrom_dict['sequenceIdx'] == index) & replicationRoundIndexes
 					new_value = np.zeros(num_index.sum())
 					for fork in range(replicationForks):
-						new_value[fork * new_value.size / replicationForks:(fork + 1) * new_value.size / replicationForks] = fork
+						new_value[fork * new_value.size // replicationForks:(fork + 1) * new_value.size // replicationForks] = fork
 
 					d2_dividedAttributesDict['chromosomeIndex'][num_index] = new_value
 


### PR DESCRIPTION
A couple changes to get the AA condition to work with the new packages.  These chunks of code only run with additional chromosomes in the AA condition so it wasn't caught before.  The `chromosomeIndex` error is troubling because it was obviously setting incorrect values before and I also noticed it only sets it for one daughter (the other is an array of all 0's).  I can't tell if it actually has an impact on the simulation but it looks like a lot of this file is a work in progress so I'll submit another PR to clean up some other chromosome issues.