### PR TITLE
Create line_profile decorator

### DIFF
--- a/wholecell/utils/profiler.py
+++ b/wholecell/utils/profiler.py
@@ -3,6 +3,7 @@ File for profiling tools
 '''
 
 from line_profiler import LineProfiler
+from functools import wraps
 
 def line_profile(func):
 	'''
@@ -21,6 +22,7 @@ def line_profile(func):
 			...
 	'''
 
+	@wraps(func)
 	def wrapper(*args, **kwargs):
 		lp = LineProfiler()
 		try:


### PR DESCRIPTION
After John's comment in #174, I thought I'd make a decorator to get a line profile of any function we want.  I couldn't find a good way to do this without running something with kernprof but if someone knows of a better way we can just drop this.  Functionality is pretty simple:

```python
from wholecell.utils.profiler import line_profile

@line_profile
def function_to_profile():
    ...
```

Any time `function_to_profile` is called, a line by line trace will be printed.
