### PR TITLE
Refactor chromosome division and tracking of active DNAPs & OriC's - debugging

### DIFF
--- a/models/ecoli/processes/chromosome_replication.py
+++ b/models/ecoli/processes/chromosome_replication.py
@@ -169,11 +169,9 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 				)
 
 			# Calculate and set attributes of newly created oriCs
-			oriCsNew.attrIs(
-				chromosomeIndex=chromosomeIndexOriC
-				# New OriC's share the index of the old OriC's they were
-				# replicated from
-				)
+            # New OriC's share the index of the old OriC's they were
+            # replicated from
+			oriCsNew.attrIs(chromosomeIndex=chromosomeIndexOriC)
 
 		# Write data from this module to a listener
 		self.writeToListener("ReplicationData", "criticalMassPerOriC",

--- a/models/ecoli/sim/initial_conditions.py
+++ b/models/ecoli/sim/initial_conditions.py
@@ -208,12 +208,8 @@ def initializeReplication(bulkMolCntr, uniqueMolCntr, sim_data):
 		C, D, tau, replication_length)
 	n_dnap = sequenceIdx.size
 
-	if n_oric != 0:
-		# Add oriCs as unique molecules and set attributes
-		oriC = uniqueMolCntr.objectsNew('originOfReplication', n_oric)
-		oriC.attrIs(
-			chromosomeIndex = chromosomeIndexOriC,
-			)
+	oriC = uniqueMolCntr.objectsNew('originOfReplication', n_oric)
+	oriC.attrIs(chromosomeIndex = chromosomeIndexOriC)
 
 	if n_dnap != 0:
 		# Update mass to account for DNA strands that have already been elongated


### PR DESCRIPTION
Sorry about my carelessness - my recent merge was causing daily builds with AA and anaerobic conditions to fail. These commits should turn them back to normal.

- AA: It looks like my assumption that a single cell cannot contain three or more chromosomes at a given time does not hold for some generations of cells growing under AA conditions. I've updated chromosome replication such that it can handle two or more chromosomes dividing simultaneously. I couldn't catch this before the merge because this happens only once every few generations.

- anaerobic: In initial_conditions.py, a function was returning prematurely without setting the number of initial OriC's to one.