### PR TITLE
Reduce analysis dependencies to only the last generation sims

### DIFF
--- a/runscripts/fw_queue.py
+++ b/runscripts/fw_queue.py
@@ -596,7 +596,8 @@ for i in VARIANTS_TO_RUN:
 					raise ValueError("k ({}) < 0".format(k))
 
 				wf_fws.append(fw_this_variant_this_gen_this_sim)
-				if RUN_AGGREGATE_ANALYSIS:
+				# Only add the last generation as dependencies for multiple sim analysis tasks
+				if RUN_AGGREGATE_ANALYSIS and k == N_GENS - 1:
 					wf_links[fw_this_variant_this_gen_this_sim].append(fw_this_variant_this_seed_this_analysis)
 					wf_links[fw_this_variant_this_gen_this_sim].append(fw_this_variant_cohort_analysis)
 					wf_links[fw_this_variant_this_gen_this_sim].append(fw_variant_analysis)


### PR DESCRIPTION
This fixes part of the problem in #202.  It will reduce dependencies for multigen, cohort and variant analysis firetasks down to the last generation sims so that fireworks doesn't need to update as many firetasks when earlier generation sims complete.