### PR TITLE
install requires numpy before running requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,9 +42,6 @@
 ## Then install all the other packages listed here:
 #   CVXOPT_BUILD_GLPK=1 pip install -r requirements.txt --no-binary cvxopt
 #   pyenv rehash
-#
-# (If an older version of pip or python gives an error that numpy isn't
-# installed, install numpy then retry installing requirements.txt.)
 
 appnope==0.1.0
 astroid==1.6.3


### PR DESCRIPTION
Going through the documented process in `requirements.txt` to install the whole cell model locally, I encountered an error requiring numpy to be installed before I was able to complete the rest of the installation. I have added the instructions at the point where the package was required.