### PR TITLE
Create analysis plot templates

### DIFF
--- a/models/ecoli/analysis/cohort/template.py
+++ b/models/ecoli/analysis/cohort/template.py
@@ -27,8 +27,10 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 
 		filepath.makedirs(plotOutDir)
 
-		sim_data = cPickle.load(open(simDataFile, 'rb'))
-		validation_data = cPickle.load(open(validationDataFile, 'rb'))
+		with open(simDataFile, 'rb') as f:
+			sim_data = cPickle.load(f)
+		with open(validationDataFile, 'rb') as f:
+			validation_data = cPickle.load(f)
 
 		ap = AnalysisPaths(variantDir, cohort_plot=True)
 

--- a/models/ecoli/analysis/multigen/template.py
+++ b/models/ecoli/analysis/multigen/template.py
@@ -27,8 +27,10 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		filepath.makedirs(plotOutDir)
 
-		sim_data = cPickle.load(open(simDataFile, 'rb'))
-		validation_data = cPickle.load(open(validationDataFile, 'rb'))
+		with open(simDataFile, 'rb') as f:
+			sim_data = cPickle.load(f)
+		with open(validationDataFile, 'rb') as f:
+			validation_data = cPickle.load(f)
 
 		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
 

--- a/models/ecoli/analysis/single/template.py
+++ b/models/ecoli/analysis/single/template.py
@@ -26,8 +26,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		filepath.makedirs(plotOutDir)
 
-		sim_data = cPickle.load(open(simDataFile, 'rb'))
-		validation_data = cPickle.load(open(validationDataFile, 'rb'))
+		with open(simDataFile, 'rb') as f:
+			sim_data = cPickle.load(f)
+		with open(validationDataFile, 'rb') as f:
+			validation_data = cPickle.load(f)
 
 		# Listeners used
 		main_reader = TableReader(os.path.join(simOutDir, 'Main'))

--- a/models/ecoli/analysis/variant/template.py
+++ b/models/ecoli/analysis/variant/template.py
@@ -27,13 +27,15 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 
 		filepath.makedirs(plotOutDir)
 
-		validation_data = cPickle.load(open(validationDataFile, 'rb'))
+		with open(validationDataFile, 'rb') as f:
+			validation_data = cPickle.load(f)
 
 		ap = AnalysisPaths(inputDir, variant_plot=True)
 		variants = ap.get_variants()
 
 		for variant in variants:
-			sim_data = cPickle.load(open(ap.get_variant_kb(variant)))
+			with open(ap.get_variant_kb(variant), 'rb') as f:
+				sim_data = cPickle.load(f)
 
 			for sim_dir in ap.get_cells(variant=[variant]):
 				simOutDir = os.path.join(sim_dir, "simOut")


### PR DESCRIPTION
I was creating a new analysis plot and realized we don't have a good way to get going other than copying another existing analysis plot and stripping out what we don't need.  I figured creating a template would be best especially with the changes that were recently made to analysis plots.  These are pretty bare bones but a few things like validation data and reading time are optional although I thought they are still good to include.  This should help standardize our analysis plots, limit extra imports and limit searching around for a good plot to start from.  I think this location is good because then you can just save as in the current directory when creating a new plot but open to a better spot.  Also we could add additional plot features like figsize, xlabel, title, etc that get used a lot.