### PR TITLE
Refactor main loop to allow simulation to be run for incremental amounts of time

### DIFF
--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -196,23 +196,22 @@ class Simulation(object):
 		and then clean up.
 		"""
 
-		self.run_incremental(self._lengthSec + self.initialTime() - self.time())
+		self.run_incremental(self._lengthSec + self.initialTime())
 		self.finalize()
 
-	def run_incremental(self, run_for):
+	def run_incremental(self, run_until):
 		"""
 		Run the simulation for a given amount of time.
 
 		Args:
-		    run_for (float): interval of time to run the simulation for. 
+		    run_until (float): absolute time to run the simulation until. 
 		"""
-
-		run_until = run_for + self.time()
 
 		# Simulate
 		while self.time() < run_until and not self._isDead:
 			if self._cellCycleComplete:
 				self.finalize()
+				break
 
 			self._simulationStep += 1
 
@@ -228,7 +227,7 @@ class Simulation(object):
 		shuts down all loggers
 		"""
 
-		if not self.finalized:
+		if not self._finalized:
 			# Run post-simulation hooks
 			for hook in self.hooks.itervalues():
 				hook.finalize(self)
@@ -240,7 +239,7 @@ class Simulation(object):
 			for logger in self.loggers.itervalues():
 				logger.finalize(self)
 
-			self.finalized = True
+			self._finalized = True
 
 	# Calculate temporal evolution
 	def _evolveState(self):


### PR DESCRIPTION
In order to allow an external process to run the simulation in increments instead of all at once, an optional `time_to_run` parameter has been added to the `run` method in `wholecell/sim/simulation.py`. If present, the simulation will use that instead of the `lengthSec` parameter supplied at initialization to determine how long to run.

In addition, as the `run` method can now be called several times, it was necessary to move some initialization code out of it and place it in the `_initialize` method, and also to move some clean up code out of the `run` method into a new method `finalize`, which will have to be called after the simulation is complete.

I found only two places in the code the `run` method is actually called, and in both added the now necessary calls to `finalize`, which was being assumed to occur before. 

I have validated these changes do not affect the running of the simulation in my local environment, but this has not yet been tested on Sherlock. I do not expect the results to be different, but as I am still unfamiliar with the total codebase there may be some surprises I am not aware of.

This PR is ready to be merged if the reviewers agree.