### PR TITLE
convert variant indices to int

### DIFF
--- a/runscripts/manual/runSim.py
+++ b/runscripts/manual/runSim.py
@@ -47,7 +47,7 @@ class RunSimulation(scriptBase.ScriptBase):
 
 		if args.variant:
 			variant_type = args.variant[0]
-			variants_to_run = range(args.variant[1], args.variant[2] + 1)
+			variants_to_run = range(int(args.variant[1]), int(args.variant[2]) + 1)
 		else:
 			variant_type = 'wildtype'
 			variants_to_run = [0]


### PR DESCRIPTION
Variant indices need to be converted to ints for the range function to work in runSim. 

An example command that requires this:
```python runscripts/manual/runSim.py -v nutrientTimeSeries 4 6```