### PR TITLE
patch env initialization

### DIFF
--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -166,6 +166,10 @@ class Simulation(object):
 			state.calculatePreEvolveStateMass()
 			state.calculatePostEvolveStateMass()
 
+		# Update environment state according to the current time in timeseries
+		for external_state in self.external_states.itervalues():
+			external_state.update()
+
 		# Perform initial listener update
 		for listener in self.listeners.itervalues():
 			listener.initialUpdate()

--- a/wholecell/states/environment.py
+++ b/wholecell/states/environment.py
@@ -41,10 +41,7 @@ class Environment(wholecell.states.external_state.ExternalState):
 			]
 		self.times = [t[0] for t in self.nutrients_time_series]
 
-		if hasattr(self._sim, '_timeTotal'):
-			self.update()
-		else:
-			self.nutrients = self.nutrients_time_series[0][1]
+		self.nutrients = self.nutrients_time_series[0][1]
 
 		# save the length of the longest nutrients name, for padding names in listener
 		self.nutrients_name_max_length = len(max([t[1] for t in self.nutrients_time_series], key=len))


### PR DESCRIPTION
This initializes the environment with the current state of the time series, and should avoid initializing the nth generation with the initial environment of generation 1 (as has been happening).

When the 1st generation is initialized, the simulation does not yet have the attribute ```_timeTotal```, and so ```self.update``` can not be called. Later generations will now call ```self.update()``` to get the current environment.