### PR TITLE
Remove default iteration limit assertion

### DIFF
--- a/wholecell/tests/utils/test_nf_glpk.py
+++ b/wholecell/tests/utils/test_nf_glpk.py
@@ -86,7 +86,6 @@ class Test_NetworkFlowGLPK(unittest.TestCase):
 		nf.simplex_method = SimplexMethod.DUAL
 		self.assertEqual(nf.simplex_method, SimplexMethod.DUAL)
 
-		self.assertEqual(nf.simplex_iteration_limit, 2**31 - 1)
 		limit = 1000
 		nf.simplex_iteration_limit = limit
 		self.assertEqual(nf.simplex_iteration_limit, limit)


### PR DESCRIPTION
This removes a test for the default iteration limit since it gets set to a different value in `nf_glpk`.  The test still covers the method of setting a limit so I think it's fine to remove the default.