### PR TITLE
fix agent code problems found by PyCharm

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -46,12 +46,12 @@ class Agent(object):
 	using the configured Kafka Producer.
 	"""
 
-	def __init__(self, id, kafka_config):
+	def __init__(self, agent_id, kafka_config):
 		"""
 		Initialize the Agent object with a unique id and kafka configuration.
 
 		Args:
-		    id (str): A unique identifier which distinguishes this agent from 
+		    agent_id (str): A unique identifier which distinguishes this agent from
 		        the rest of the agents in the system.
 
 		    kafka_config (dict): A dictionary containing Kafka configuration information.
@@ -65,18 +65,19 @@ class Agent(object):
 		        to represent topics for sending messages to. 
 		"""
 
-		self.id = id
+		self.id = str(agent_id)
 		self.kafka_config = kafka_config
 
 		self.producer = Producer({
 			'bootstrap.servers': self.kafka_config['host']})
 
+		self.running = False
 		self.consumer = None
 		if self.kafka_config['subscribe_topics']:
 			self.consumer = Consumer({
 				'bootstrap.servers': self.kafka_config['host'],
 				'enable.auto.commit': True,
-				'group.id': 'simulation-' + str(id),
+				'group.id': 'simulation-' + agent_id,
 				'default.topic.config': {
 					'auto.offset.reset': 'latest'}})
 
@@ -124,6 +125,9 @@ class Agent(object):
 					self.running = False
 
 			else:
+				# `raw.value()` is implemented in C with a docstring that
+				# suggests it needs a `payload` argument. Suppress the warning.
+				# noinspection PyArgumentList
 				message = json.loads(raw.value().decode('utf-8'))
 
 				if message['event'] == event.GLOBAL_SHUTDOWN:

--- a/agent/inner.py
+++ b/agent/inner.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-import json
-
 import agent.event as event
 from agent.agent import Agent
+
 
 class Inner(Agent):
 
@@ -17,7 +16,7 @@ class Inner(Agent):
 	of the following methods:
 
 	* simulation.initialize_local_environment()
-	    Perfom any setup required for tracking changes to the local environment.
+	    Perform any setup required for tracking changes to the local environment.
 
 	* simulation.set_local_environment(concentrations)
 	    Receive a set of molecule ids to track and a dictionary containing the current
@@ -41,7 +40,7 @@ class Inner(Agent):
 	communicate with the outer agent through message passing.
 	"""
 
-	def __init__(self, kafka_config, id, simulation):
+	def __init__(self, kafka_config, agent_id, simulation):
 		"""
 		Initialize the agent.
 
@@ -51,7 +50,7 @@ class Inner(Agent):
 		        `simulation_receive`: The topic the outer agent will be sending messages on.
 		        `simulation_send`: The topic the outer agent will be listening to for 
 		            updates from the inner agents.
-		    id (string): Unique identifier for this agent.
+		    agent_id (string): Unique identifier for this agent.
 		        When the agent receives messages, it will filter out and respond to only 
 		        those containing its `id`.
 		    simulation (Simulation): The actual simulation which will perform the calculations.
@@ -61,7 +60,7 @@ class Inner(Agent):
 		self.simulation.initialize_local_environment()
 		kafka_config['subscribe_topics'] = [kafka_config['simulation_receive']]
 
-		super(Inner, self).__init__(id, kafka_config)
+		super(Inner, self).__init__(agent_id, kafka_config)
 
 	def initialize(self):
 		""" Announce the existence of this inner agent to the outer agent. """

--- a/agent/stub.py
+++ b/agent/stub.py
@@ -33,13 +33,13 @@ class SimulationStub(object):
 		#     what keys are in this dict to avoid this preset state. 
 		if not self.local_set:
 			self.environment_change = {}
-			for molecule in self.concentrations.keys():
+			for molecule in self.concentrations.iterkeys():
 				self.environment_change[molecule] = 0
 			self.local_set = True
 
 	def run_incremental(self, run_until):
 		time.sleep(1)
-		for molecule in self.concentrations.keys():
+		for molecule in self.concentrations.iterkeys():
 			self.environment_change[molecule] += random.randint(1, 6)
 		self.local_time = run_until
 
@@ -71,23 +71,23 @@ class EnvironmentStub(object):
 	def time(self):
 		return self._time
 
-	def add_simulation(self, id):
+	def add_simulation(self, agent_id):
 		state = {}
-		self.simulations[id] = state
+		self.simulations[agent_id] = state
 
-	def remove_simulation(self, id):
-		return self.simulations.pop(id, {})
+	def remove_simulation(self, agent_id):
+		return self.simulations.pop(agent_id, {})
 
 	def update_concentrations(self, all_changes):
 		self._time += self.run_for
-		for id, changes in all_changes.iteritems():
+		for agent_id, changes in all_changes.iteritems():
 			for molecule, change in changes.iteritems():
 				self.concentrations[molecule] += change
 
 	def run_until(self):
 		until = {}
-		for id in self.simulations.keys():
-			until[id] = self.time() + self.run_for
+		for agent_id in self.simulations.iterkeys():
+			until[agent_id] = self.time() + self.run_for
 
 		return until
 
@@ -96,7 +96,7 @@ class EnvironmentStub(object):
 
 	def get_concentrations(self):
 		concentrations = {}
-		for id in self.simulations.keys():
-			concentrations[id] = self.concentrations
-		
+		for agent_id in self.simulations.iterkeys():
+			concentrations[agent_id] = self.concentrations
+
 		return concentrations


### PR DESCRIPTION
[PyCharm shows these warnings while editing and via the Inspect command.]

* Don't shadow the built-in function `id()` and esp. don't use the built-in function as an agent ID.
* Initialize all instance variables in the `__init__` method.
* Kafka's `Message.value()` method seems to be written in C and PyCharm infers from its docstring that it needs a `payload` arg. Suppress the missing-arg warning.
* Don't use a mutable value as a default arg.
* Remove unused local variables and unused imports.
* `iterkeys()` is nice.

TODO: `Outer` ought to reject a duplicate agent ID.
TODO: It'd be a little bit slicker if `Inner.__init__` had the same parameter order as the other agent classes, but this PR doesn't change it.

I used the README instructions as a smoke test.

Q. Should we download the Kafka servers from Confluent or stick with the Apache downloads as mentioned in the README?