### PR TITLE
Set WC_ECOLI_DIRECTORY to correct path in runscripts/fireworks/fw_queue.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ lpad reset
 To queue up a single simulation in Fireworks:
 
 ```bash
-DESC="Example run of a single simulation." python runscripts/fw_queue.py
+DESC="Example run of a single simulation." python runscripts/fireworks/fw_queue.py
 ```
 
 The `DESC` text should be more descriptive so you can readily distinguish your runs.
@@ -92,7 +92,7 @@ The `DESC` text should be more descriptive so you can readily distinguish your r
 To queue multiple simulations (in this case 4 simulations) in fireworks:
 
 ```bash
-DESC="Example run of multiple simulations." N_INIT_SIMS=4 python runscripts/fw_queue.py
+DESC="Example run of multiple simulations." N_INIT_SIMS=4 python runscripts/fireworks/fw_queue.py
 ```
 
 ### Multiple generations
@@ -100,13 +100,13 @@ DESC="Example run of multiple simulations." N_INIT_SIMS=4 python runscripts/fw_q
 To queue multiple generations (in this case 4 generations) from a single mother cell:
 
 ```bash
-DESC="Example run of multiple generations." N_GENS=4 python runscripts/fw_queue.py
+DESC="Example run of multiple generations." N_GENS=4 python runscripts/fireworks/fw_queue.py
 ```
 
 To queue multiple generations (in this case 3 generations) from multiple mother cells (in this case 2 mother cells:
 
 ```bash
-DESC="Example run of multiple generations from multiple mother cells." N_GENS=3 N_INIT_SIMS=2 python runscripts/fw_queue.py
+DESC="Example run of multiple generations from multiple mother cells." N_GENS=3 N_INIT_SIMS=2 python runscripts/fireworks/fw_queue.py
 ```
 
 ### Shifting nutrient conditions
@@ -114,7 +114,7 @@ DESC="Example run of multiple generations from multiple mother cells." N_GENS=3 
 To queue a simulation that switches between environments, use the "nutrientTimeSeries" variant, and give the range of indices (in this case from 1 to 1) specifying conditions defined in wcEcoli/reconstruction/ecoli/flat/condition/timeseries:
 
 ```bash
-DESC="Example run of nutrient shifts." VARIANT="nutrientTimeSeries" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 python runscripts/fw_queue.py
+DESC="Example run of nutrient shifts." VARIANT="nutrientTimeSeries" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 python runscripts/fireworks/fw_queue.py
 ```
 
 ### Using the cached sim data object
@@ -122,7 +122,7 @@ DESC="Example run of nutrient shifts." VARIANT="nutrientTimeSeries" FIRST_VARIAN
 To use the cached sim data object, use the CACHED_SIM_DATA environment variable:
 
 ```bash
-DESC="Example run with cached sim data." CACHED_SIM_DATA=1 python runscripts/fw_queue.py
+DESC="Example run with cached sim data." CACHED_SIM_DATA=1 python runscripts/fireworks/fw_queue.py
 ```
 
 ### Using an interactive node to run a Fireworks workflow

--- a/runscripts/fireworks/fw_queue.py
+++ b/runscripts/fireworks/fw_queue.py
@@ -7,7 +7,7 @@ a workflow (wf) for Fireworks, and submits them to the queue.
 Several environmental variables can be specified, shown below with their (type, default value).
 These are set as follows, and otherwise revert to their default value:
 
-	VARIABLE=VALUE python runscripts/fw_queue.py
+	VARIABLE=VALUE python runscripts/fireworks/fw_queue.py
 
 Set description:
 	DESC (str, ""): a description of the simulation, used to name output folder

--- a/runscripts/paper/paper_runs.sh
+++ b/runscripts/paper/paper_runs.sh
@@ -12,7 +12,7 @@ DESC="SET A 32 gens 8 seeds basal with growth noise and D period" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
 SINGLE_DAUGHTERS=1 N_GENS=32 N_INIT_SIMS=8 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 ## Set B - nutrient shift from minimal to minimal + AA
 # Used for figure 1
@@ -20,7 +20,7 @@ DESC="SET B 9 gens 8 seeds shift to plus AA without growth noise with D period" 
 VARIANT="nutrientTimeSeries" FIRST_VARIANT_INDEX=2 LAST_VARIANT_INDEX=2 \
 SINGLE_DAUGHTERS=1 N_GENS=9 N_INIT_SIMS=8 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=0 D_PERIOD_DIVISION=1 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 ## Set C - 3 growth rates from different conditions
 # Used for figure 2
@@ -29,7 +29,7 @@ VARIANT="condition" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=2 \
 SINGLE_DAUGHTERS=1 N_GENS=4 N_INIT_SIMS=256 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
 RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 ## Set D - changes to RNAP and ribosome expression
 # Used for figure 2
@@ -42,7 +42,7 @@ SINGLE_DAUGHTERS=1 N_GENS=4 N_INIT_SIMS=256 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
 DISABLE_RIBOSOME_CAPACITY_FITTING=0 DISABLE_RNAPOLY_CAPACITY_FITTING=0 \
 RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 DESC="SET D2 4 gens 256 seeds, unfit ribosome expression" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
@@ -50,7 +50,7 @@ SINGLE_DAUGHTERS=1 N_GENS=4 N_INIT_SIMS=256 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
 DISABLE_RIBOSOME_CAPACITY_FITTING=1 DISABLE_RNAPOLY_CAPACITY_FITTING=0 \
 RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 DESC="SET D3 4 gens 256 seeds, unfit rna poly expression" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
@@ -58,7 +58,7 @@ SINGLE_DAUGHTERS=1 N_GENS=4 N_INIT_SIMS=256 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
 DISABLE_RIBOSOME_CAPACITY_FITTING=0 DISABLE_RNAPOLY_CAPACITY_FITTING=1 \
 RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 DESC="SET D4 4 gens 256 seeds, unfit ribosome and rna poly expression" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
@@ -66,7 +66,7 @@ SINGLE_DAUGHTERS=1 N_GENS=4 N_INIT_SIMS=256 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
 DISABLE_RIBOSOME_CAPACITY_FITTING=1 DISABLE_RNAPOLY_CAPACITY_FITTING=1 \
 RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 ## Set E - metabolism objective weighting
 # Used for figure 3
@@ -74,7 +74,7 @@ DESC="SET E 8 gens 8 seeds 10 metabolism weighting values" \
 VARIANT="metabolism_kinetic_objective_weight" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=9 \
 SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=8 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=0 D_PERIOD_DIVISION=0 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 ## Set F - MenE expression
 # Used in supplemental figure
@@ -82,7 +82,7 @@ DESC="SET_F 8 gens 8 seeds 9 menE expression values" \
 VARIANT=meneParams FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=8 \
 SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=8 \
 MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
-python runscripts/fw_queue.py
+python runscripts/fireworks/fw_queue.py
 
 
 ## Launch the fireworks created with fw_queue.py


### PR DESCRIPTION
This fixes a bug I found in PR #287. WC_ECOLI_DIRECTORY needs to be set to a directory that is one level higher than before to correctly point to wcEcoli. 