### PR TITLE
scale constants and cell-related variables according to global params

### DIFF
--- a/environment/two_dim_lattice.py
+++ b/environment/two_dim_lattice.py
@@ -162,7 +162,9 @@ class EnvironmentSpatialLattice(object):
 			dy = length * PATCHES_PER_EDGE / EDGE_LENGTH * np.cos(theta)
 
 			plt.plot([x-dx/2, x+dx/2], [y-dy/2, y+dy/2],
-				color='slateblue', linewidth=CELL_RADIUS/EDGE_LENGTH*600, solid_capstyle='round')
+				color='salmon', linewidth=CELL_RADIUS/EDGE_LENGTH*600, solid_capstyle='round')
+			plt.plot([x-dx*9.5/20, x+dx*9.5/20], [y-dy*9.5/20, y+dy*9.5/20],
+				color='slateblue', linewidth=CELL_RADIUS/EDGE_LENGTH*450, solid_capstyle='round')
 
 		if not in_sherlock:
 			plt.pause(0.0001)


### PR DESCRIPTION
This update makes all lattice-related parameters (such as cell location, cell length)  scale according to the global parameters ```EDGE_LENGTH``` and ```PATCHS_PER_EDGE```.

A new function ```volume_to_length()``` gives cell length from cell volume, assuming constant radius.

Additional changes include: ```BINS``` name changed to ```PATCHS``` to match standard ABM terminology (thanks @lt5bf). Matplotlib live output is improved, scaling length according to lattice size, and adding rounded caps:

![figure_1-1](https://user-images.githubusercontent.com/6809431/44997770-93247d80-af65-11e8-85ef-c86c0cd1b401.png)