### PR TITLE
Providing state from simulation rather than assuming it in `Outer`

### DIFF
--- a/agent/inner.py
+++ b/agent/inner.py
@@ -67,7 +67,8 @@ class Inner(Agent):
 
 		self.send(self.kafka_config['simulation_send'], {
 			'event': event.SIMULATION_INITIALIZED,
-			'inner_id': self.agent_id})
+			'inner_id': self.agent_id,
+			'changes': self.simulation.get_environment_change()})
 
 	def finalize(self):
 		""" Trigger any clean up the simulation needs to perform before exiting. """

--- a/agent/outer.py
+++ b/agent/outer.py
@@ -28,7 +28,7 @@ class Outer(Agent):
 	* environment.time()
 	    Return the current simulation time for the environment.
 
-	* environment.add_simulation(id)
+	* environment.add_simulation(id, state)
 
 	* environment.remove_simulation(id)
 
@@ -61,15 +61,15 @@ class Outer(Agent):
 	def finalize(self):
 		print('environment shutting down')
 
-	def initialize_simulation(self, agent_id):
-		changes = {molecule: 0 for molecule in self.environment.get_molecule_ids()}
+	def initialize_simulation(self, message):
+		agent_id = message['inner_id']
 		self.simulations[agent_id] = {
 			'time': 0,
 			'message_id': -1,
 			'last_message_id': -1,
-			'changes': changes}
+			'changes': message['changes']}
 
-		self.environment.add_simulation(agent_id)
+		self.environment.add_simulation(agent_id, message['changes'])
 
 	def send_concentrations(self):
 		""" Send updated concentrations to each inner agent. """
@@ -106,8 +106,7 @@ class Outer(Agent):
 	def simulation_changes(self):
 		return {
 			agent_id: simulation['changes']
-			for agent_id, simulation in self.simulations.iteritems()
-			}
+			for agent_id, simulation in self.simulations.iteritems()}
 
 	def send_shutdown(self):
 		for agent_id, simulation in self.simulations.iteritems():
@@ -144,7 +143,7 @@ class Outer(Agent):
 		print('--> {}: {}'.format(topic, message))
 
 		if message['event'] == event.SIMULATION_INITIALIZED:
-			self.initialize_simulation(message['inner_id'])
+			self.initialize_simulation(message)
 
 		elif message['event'] == event.TRIGGER_EXECUTION:
 			self.send_concentrations()

--- a/agent/stub.py
+++ b/agent/stub.py
@@ -71,8 +71,7 @@ class EnvironmentStub(object):
 	def time(self):
 		return self._time
 
-	def add_simulation(self, agent_id):
-		state = {}
+	def add_simulation(self, agent_id, state):
 		self.simulations[agent_id] = state
 
 	def remove_simulation(self, agent_id):


### PR DESCRIPTION
This PR addresses https://github.com/CovertLab/wcEcoli/issues/313, where the `Outer` agent was assuming the shape of the state dictionary. The new paradigm is to provide the state dictionary from the `Inner` agent during initialization.