### PR TITLE
Fix #314: KeyboardInterrupt. Fix UTF-8

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -112,7 +112,7 @@ class Agent(object):
 
 		self.running = True
 		while self.running:
-			raw = self.consumer.poll()
+			raw = self.consumer.poll(timeout=1.0)  # timeout (in seconds) so ^C works
 			if raw is None:
 				continue
 			if raw.error():
@@ -147,7 +147,10 @@ class Agent(object):
 				present will throw errors.
 		"""
 
-		encoded = json.dumps(message).encode('utf-8')
+		# json.dumps(m, ensure_ascii=False) returns a str or unicode string, depending on
+		# content (always a unicode string in Python 3) w/o \u escapes. Encode that into
+		# UTF-8 bytes. print() can decode UTF-8 bytes but not \u escapes.
+		encoded = json.dumps(message, ensure_ascii=False).encode('utf-8')
 		print('<-- {} ({}): {}'.format(topic, len(encoded), encoded))
 
 		self.producer.poll(0)


### PR DESCRIPTION
* Use a `consumer.poll()` timeout so KeyboardInterrupt works on an Agent.
* Ask `json.dumps()` for UTF-8 output, otherwise it produces an ASCII str with Unicode escapes. `.encode('utf-8')` won't change that and `print()` won't decode it.

FYI: In Python 2, `json.dumps(m, ensure_ascii=False)` returns a unicode or a str string depending on content. That's broken; fixed in Python 3.

FYI: `json.loads()` always returns unicode strings.