### PR TITLE
Timing changes for newly created cells

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -180,9 +180,9 @@ class Agent(object):
 
 		if print_send:
 			print('<-- {} ({}) [{}]: {}'.format(
-				self.agent_id,
 				topic,
-				len(encoded),
+				message.get('event', 'generic'),
+				self.agent_id,
 				encoded))
 
 		self.producer.poll(0)

--- a/agent/boot.py
+++ b/agent/boot.py
@@ -212,7 +212,7 @@ class AgentCommand(object):
 		parser.add_argument(
 			'--number',
 			type=int,
-			default=3,
+			default=0,
 			help='number of cell agents to spawn in experiment')
 
 		parser.add_argument(

--- a/agent/inner.py
+++ b/agent/inner.py
@@ -213,7 +213,7 @@ class Inner(Agent):
 		"""
 
 		if message.get('inner_id', message.get('agent_id')) == self.agent_id:
-			print('--> {}: {}'.format(topic, message))
+			print('--> {} ({}) [{}]: {}'.format(topic, message['event'], self.agent_id, message))
 
 			if message['event'] == event.ENVIRONMENT_SYNCHRONIZE:
 				self.simulation.synchronize_state(message['state'])

--- a/agent/shepherd.py
+++ b/agent/shepherd.py
@@ -168,7 +168,7 @@ class AgentShepherd(Agent):
 		#     message of the given type.
 		# if message['agent_id'] == self.agent_id:
 
-		print('--> {}: {}'.format(topic, message))
+		print('--> {} ({}) [{}]: {}'.format(topic, message['event'], self.agent_id, message))
 
 		if message['event'] == event.ADD_AGENT:
 			self.add_agent(

--- a/environment_models/boot.py
+++ b/environment_models/boot.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-import errno
 import os
+import time
 import uuid
+import errno
 import argparse
 
 import agent.event as event

--- a/environment_models/lattice.py
+++ b/environment_models/lattice.py
@@ -274,9 +274,11 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
 			self.locations[agent_id] = np.hstack((location, orientation))
 
 	def simulation_parameters(self, agent_id):
-		time = self._time
-		if agent_id in self.simulations:
-			time = max(time, self.simulations[agent_id]['time'])
+		latest = max([
+			simulation['time']
+			for agent_id, simulation
+			in self.simulations.iteritems()])
+		time = max(self._time, latest)
 		return {'time': time}
 
 	def simulation_state(self, agent_id):
@@ -292,7 +294,7 @@ class EnvironmentSpatialLattice(EnvironmentSimulation):
 			[sin, cos]])
 
 	def daughter_location(self, location, orientation, length, index):
-		offset = np.array([length * 0.5, 0])
+		offset = np.array([length * 0.75, 0])
 		rotation = self.rotation_matrix(-orientation + (index * np.pi))
 		translation = (offset * rotation).A1
 		return (location + translation)


### PR DESCRIPTION
While recording the video demo for the agent system I found a timing issue with newly created cells progressing for slightly different amounts of time than preexisting cells. The basic gist of the solution is to take the `math.ceil` of the point to which each simulation reached in order to compare their progress without precision errors.

In the process I made some other small modifications to how the locations for daughter cells are generated from the parent cell and added the event from the message into the logging for message passing to make the interactions more clear for debugging purposes.