### PR TITLE
Clean up RNA degradation process

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/rna_decay.py
+++ b/reconstruction/ecoli/dataclasses/process/rna_decay.py
@@ -21,11 +21,6 @@ class RnaDecay(object):
 		self._buildRnaDecayData(raw_data, sim_data)
 
 	def _buildRnaDecayData(self, raw_data, sim_data):
-		self.mrna_index = 2
-		self.rrna_index = 3
-		self.trna_index = 4
-		self.rtrna_index = 5
-
 		self.endoRnaseIds = [x["endoRnase"].encode("utf-8") for x in raw_data.endoRnases]
 		self.kcats = (1 / units.s) * np.array([x["kcat"].asNumber(1 / units.s) for x in raw_data.endoRnases])
 		self.StatsFit = {
@@ -55,40 +50,6 @@ class RnaDecay(object):
 		# store convergence of non-linear Km's (G(km))
 		self.KmConvergence = []
 
-
-		self.TargetEndoRNasesFullMRNA = np.zeros(len(self.endoRnaseIds))
-		self.TargetEndoRNasesFullTRNA = np.zeros(len(self.endoRnaseIds))
-		self.TargetEndoRNasesFullRRNA = np.zeros(len(self.endoRnaseIds))
-
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("EG10856-MONOMER[p]")] = self.mrna_index
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("EG10857-MONOMER[c]")] = self.mrna_index
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("G7175-MONOMER[c]")] = 0
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("EG10859-MONOMER[i]")] = self.mrna_index
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("EG11299-MONOMER[c]")] = self.mrna_index
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("EG10860-MONOMER[c]")] = self.mrna_index
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("EG10861-MONOMER[c]")] = self.mrna_index
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("G7365-MONOMER[c]")] = self.mrna_index
-		self.TargetEndoRNasesFullMRNA[self.endoRnaseIds.index("EG10862-MONOMER[c]")] = self.mrna_index
-
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("EG10856-MONOMER[p]")] = self.trna_index
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("EG10857-MONOMER[c]")] = 0
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("G7175-MONOMER[c]")] = 1
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("EG10859-MONOMER[i]")] = self.trna_index
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("EG11299-MONOMER[c]")] = 0
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("EG10860-MONOMER[c]")] = self.trna_index
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("EG10861-MONOMER[c]")] = self.trna_index
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("G7365-MONOMER[c]")] = self.trna_index
-		self.TargetEndoRNasesFullTRNA[self.endoRnaseIds.index("EG10862-MONOMER[c]")] = self.trna_index
-
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("EG10856-MONOMER[p]")] = self.rrna_index
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("EG10857-MONOMER[c]")] = self.rtrna_index
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("G7175-MONOMER[c]")] = 0
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("EG10859-MONOMER[i]")] = self.rrna_index
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("EG11299-MONOMER[c]")] = self.rtrna_index
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("EG10860-MONOMER[c]")] = self.rrna_index
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("EG10861-MONOMER[c]")] = self.rrna_index
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("G7365-MONOMER[c]")] = self.rrna_index
-		self.TargetEndoRNasesFullRRNA[self.endoRnaseIds.index("EG10862-MONOMER[c]")] = self.rrna_index
 
 	def kmLossFunction(self, vMax, rnaConc, kDeg, isEndoRnase, alpha):
 		'''


### PR DESCRIPTION
This PR fixes #270. I performed a general cleanup of the code for the `calculateRequest()` and `evolveState()` methods of the `rna_degradation` process. During the process I realized through a 
[line profile](https://github.com/CovertLab/wcEcoli/files/2497548/line_profile_before.txt) (thanks, @tahorst!) that this particular line of code that computes a summation is consuming nearly 90% of the computation time for the entire method. 

https://github.com/CovertLab/wcEcoli/blob/b499317fb65b085637cbe2c97761756059b8250d/models/ecoli/processes/rna_degradation.py#L272

I tried changing the summation function to `np.sum` - this actually made this line run slower! It turns out that the variable that was being summed over (`fracEndoRnaseSaturated`, or `frac_endornase_saturated` in the changed version of the file) is a unitless units Unum object. Apparently `np.sum` cannot sum up these objects in a memory-optimized way, but it does so anyway without any errors or warnings.

When I first convert this variable to a numpy ndarray by stripping off units and then use `np.sum` to sum it up, this cuts down the execution time of the entire `calculateRequest()` method from roughly 30ms to 2ms (See the [new line profile](https://github.com/CovertLab/wcEcoli/files/2497562/line_profile_after.txt)), and the execution time of the entire simulation by 1-2 minutes depending on the platform. 

I think this has important implications for our use of the units tool in general - we should make sure that we are using the methods that are built into the units package (`units.sum()`, `units.dot()` etc.), not numpy operations, if we are dealing with units objects. 