### PR TITLE
Reset option name for Jenkins test on causality network

### DIFF
--- a/runscripts/jenkins/ecoli-optional-features.sh
+++ b/runscripts/jenkins/ecoli-optional-features.sh
@@ -16,7 +16,7 @@ sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 echo y | lpad reset
 
 PYTHONPATH=$PWD DESC="tRNA Charging" SINGLE_DAUGHTERS=1 N_GENS=8 TRNA_CHARGING=1 COMPRESS_OUTPUT=1 python runscripts/fireworks/fw_queue.py
-PYTHONPATH=$PWD DESC="Causality Network" SINGLE_DAUGHTERS=1 N_GENS=2 CAUSALITY_NETWORK=1 COMPRESS_OUTPUT=1 python runscripts/fireworks/fw_queue.py
+PYTHONPATH=$PWD DESC="Causality Network" SINGLE_DAUGHTERS=1 N_GENS=2 BUILD_CAUSALITY_NETWORK=1 COMPRESS_OUTPUT=1 python runscripts/fireworks/fw_queue.py
 
 PYTHONPATH=$PWD rlaunch rapidfire --nlaunches 0
 


### PR DESCRIPTION
This corrects the wrong fw_queue.py option name that was used for the testing of the causality network code in Jenkins.