### PR TITLE
Fix index error read_bulk_molecule_counts

### DIFF
--- a/wholecell/analysis/analysis_tools.py
+++ b/wholecell/analysis/analysis_tools.py
@@ -98,6 +98,8 @@ def read_bulk_molecule_counts(sim_out_dir, mol_names):
 
 	TODO: generalize to any TableReader, not just BulkMolecules, if readColumn method
 	is used for those tables.
+	TODO: change readColumn() to readColumn2D() when available so reshape doesn't need
+	to be called.
 	'''
 
 	# Convert an array to tuple to ensure correct dimensions


### PR DESCRIPTION
This fixes a small error when only one molecule was passed to this function.  Because of `.squeeze()` in `readColumn()` the `bulk_counts` array was only 1D in this case while it needs to be 2D for later indexing.