### PR TITLE
Update analysis templates

### DIFF
--- a/models/ecoli/analysis/cohort/template.py
+++ b/models/ecoli/analysis/cohort/template.py
@@ -9,13 +9,15 @@ from __future__ import absolute_import
 from __future__ import division
 
 import cPickle
+import os
+
 from matplotlib import pyplot as plt
 import numpy as np
-import os
 
 from models.ecoli.analysis import cohortAnalysisPlot
 from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import filepath
 
@@ -43,10 +45,14 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			# Load data
 			time = main_reader.readColumn('time')
 
+			names = ['ATP[c]']  # Replace with desired list of names
+			(counts,) = read_bulk_molecule_counts(simOutDir, (names,))
+
 		plt.figure()
 
 		### Create Plot ###
 
+		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
 		plt.close('all')
 

--- a/models/ecoli/analysis/multigen/template.py
+++ b/models/ecoli/analysis/multigen/template.py
@@ -9,13 +9,15 @@ from __future__ import absolute_import
 from __future__ import division
 
 import cPickle
+import os
+
 from matplotlib import pyplot as plt
 import numpy as np
-import os
 
 from models.ecoli.analysis import multigenAnalysisPlot
 from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import filepath
 
@@ -43,10 +45,14 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Load data
 			time = main_reader.readColumn('time')
 
+			names = ['ATP[c]']  # Replace with desired list of names
+			(counts,) = read_bulk_molecule_counts(simOutDir, (names,))
+
 		plt.figure()
 
 		### Create Plot ###
 
+		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
 		plt.close('all')
 

--- a/models/ecoli/analysis/single/template.py
+++ b/models/ecoli/analysis/single/template.py
@@ -9,12 +9,14 @@ from __future__ import absolute_import
 from __future__ import division
 
 import cPickle
+import os
+
 from matplotlib import pyplot as plt
 import numpy as np
-import os
 
 from models.ecoli.analysis import singleAnalysisPlot
 from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import filepath
 
@@ -35,12 +37,17 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		main_reader = TableReader(os.path.join(simOutDir, 'Main'))
 
 		# Load data
-		time = main_reader.readColumn('time')
+		initial_time = main_reader.readAttribute('initialTime')
+		time = main_reader.readColumn('time') - initial_time
+
+		names = ['ATP[c]']  # Replace with desired list of names
+		(counts,) = read_bulk_molecule_counts(simOutDir, (names,))
 
 		plt.figure()
 
 		### Create Plot ###
 
+		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
 		plt.close('all')
 

--- a/models/ecoli/analysis/variant/template.py
+++ b/models/ecoli/analysis/variant/template.py
@@ -9,13 +9,15 @@ from __future__ import absolute_import
 from __future__ import division
 
 import cPickle
+import os
+
 from matplotlib import pyplot as plt
 import numpy as np
-import os
 
 from models.ecoli.analysis import variantAnalysisPlot
 from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import filepath
 
@@ -46,12 +48,15 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 				# Load data
 				time = main_reader.readColumn('time')
 
+				names = ['ATP[c]']  # Replace with desired list of names
+				(counts,) = read_bulk_molecule_counts(simOutDir, (names,))
+
 		plt.figure()
 
 		### Create Plot ###
 
+		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
-
 		plt.close('all')
 
 


### PR DESCRIPTION
This updates the analysis template scripts with the following:
- proper import order
- example of `read_bulk_molecule_counts`
- use of `plt.tight_layout()` since it seems that this has given us some issues in a lot of our analysis scripts