### PR TITLE
Fix #377 script to diff 2 sim outputs

### DIFF
--- a/runscripts/debug/diff_simouts.py
+++ b/runscripts/debug/diff_simouts.py
@@ -189,7 +189,25 @@ def cmd_diff_simout(simout_dir1, simout_dir2):
 
 if __name__ == '__main__':
 	if len(sys.argv) == 2 and sys.argv[1] in {'-h', '--help'}:
-		print('diff_simouts <simOut1> <simOut2> -- diffs two WCM simOut directories')
+		print('''Usage:  diff_simouts <simOut1> <simOut2>
+Diff two Whole Cell Model simOut directories
+
+The output is a dict with keys like:
+
+	* 'Main/': a subdir; present if there's a message about absent subdirs or
+	  subdirs that don't contain Tables
+	* 'Main@startTime': a Table attribute
+	* 'RnaDegradationListener/DiffRelativeFirstOrderDecay': a Table column
+
+The dict values are tuples of the corresponding simOut values or special
+messages like:
+
+	* <absent subdir>: an absent subdirectory
+	* <absent column>: an absent column
+	* <absent value>: an absent attribute value
+	* Arrays are not equal (mismatch 21.6859279402%)...: A NumPy Testing
+	  message summarizing the differences between two arrays
+''')
 		sys.exit()
 
 	if len(sys.argv) < 3:


### PR DESCRIPTION
The aim is just to check if two simOut directories have identical content, e.g. after an optimization that's not supposed to change results. If the outputs don't match, this identifies which Table Columns and Attributes differ.

This ignores the Daughter1 and Daughter2 directories.

**Q1.** Should it compare the Daughter inherited state directories?

Sample output:
```
$ python runscripts/debug/diff_simouts.py out/manual/wildtype_000000/000000/generation_000000/000000/simOut/ out/experiment/wildtype_000000/000000/generation_000000/000000/simOut/
Using simOut out/manual/wildtype_000000/000000/generation_000000/000000/simOut/ to check out/experiment/wildtype_000000/000000/generation_000000/000000/simOut/

{'Table: EvaluationTime': {'Unequal Columns': ['calculateRequest_times',
                                               'calculateRequest_total',
                                               'evolveState_times',
                                               'evolveState_total',
                                               'merge_times',
                                               'merge_total',
                                               'partition_times',
                                               'partition_total',
                                               'updateQueries_times',
                                               'updateQueries_total']},
 'Table: Main': {'Unequal Attributes': [u'endTime', u'startTime']},
 'Table: RnaDegradationListener': {'Unequal Columns': ['DiffRelativeFirstOrderDecay']}}
```

**Q2.** What's up with `RnaDegradationListener/DiffRelativeFirstOrderDecay`? Is that a bug in psuedo-random number use?

**Q3.** The `UniqueMolecules` table has no columns, just a single attribute `"collectionNames"`. Is it obsolete?