### PR TITLE
Fix scriptBase elapsed time printout. Use the latest Pickle protocol for km.cPickle

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -3200,7 +3200,14 @@ def setKmCooperativeEndoRNonLinearRNAdecay(sim_data, bulkContainer):
 	km_filepath = os.path.join(fixturesDir, "km.cPickle")
 
 	if os.path.exists(km_filepath):
-		KmcountsCached = cPickle.load(open(km_filepath, "rb"))
+		with open(km_filepath, "rb") as f:
+			KmcountsCached = cPickle.load(f)
+
+		# KmcountsCached fits a set of Km values to give the expected degradation rates.
+		# It takes 1.5 - 3 minutes to recompute.
+		# R_aux calculates the difference of the degradation rate based on these
+		# Km values and the expected rate so this sum seems like a reliable test of
+		# whether the cache fits current input data.
 		if np.sum(np.abs(R_aux(KmcountsCached))) > 1e-15:
 			needToUpdate = True
 	else:
@@ -3217,7 +3224,9 @@ def setKmCooperativeEndoRNonLinearRNAdecay(sim_data, bulkContainer):
 
 		if VERBOSE: print("Running non-linear optimization")
 		KmCooperativeModel = scipy.optimize.fsolve(LossFunction, Kmcounts, fprime = LossFunctionP)
-		cPickle.dump(KmCooperativeModel, open(km_filepath, "wb"))
+
+		with open(km_filepath, "wb") as f:
+			cPickle.dump(KmCooperativeModel, f, protocol=cPickle.HIGHEST_PROTOCOL)
 	else:
 		if VERBOSE:
 			print("Not running non-linear optimization--using cached result {}".format(km_filepath))

--- a/wholecell/utils/scriptBase.py
+++ b/wholecell/utils/scriptBase.py
@@ -256,15 +256,24 @@ class ScriptBase(object):
 		if location:
 			location = ' at ' + location
 
-		print('{}: {}{}'.format(time.ctime(), self.description(), location))
+		start_wall_sec = time.time()
+		print('{}: {}{}'.format(
+			time.ctime(start_wall_sec), self.description(), location))
 		pp.pprint({'Arguments': vars(args)})
 
-		start_sec = time.clock()
+		start_process_sec = time.clock()
 		self.run(args)
-		end_sec = time.clock()
-		elapsed = datetime.timedelta(seconds = (end_sec - start_sec))
+		end_process_sec = time.clock()
+		elapsed_process = end_process_sec - start_process_sec
 
-		print("Run in {}h {}m {}s total".format(*str(elapsed).split(':')))
+		end_wall_sec = time.time()
+		elapsed_wall = end_wall_sec - start_wall_sec
+		print("{}: Elapsed time {:1.2f} sec ({}); {:1.2f} sec in process".format(
+			time.ctime(end_wall_sec),
+			elapsed_wall,
+			datetime.timedelta(seconds=elapsed_wall),
+			elapsed_process,
+			))
 
 
 class TestScript(ScriptBase):


### PR DESCRIPTION
Re: the #196 discussion:
The manual runscripts will now print both the elapsed wall-clock time and the in-process CPU time. The latter is better for comparing code changes but not when they create subprocesses.

`Mon Dec  3 16:56:55 2018: Elapsed time 559.03 sec (0:09:19.027810); 573.92 sec in process`

Time is complicated. The wall clock can go backwards for adjustments like DST, leap seconds, and network time sync, but a single process ran 15s longer than the elapsed time?

* Add @tahorst's comment on the Fitter recomputing `KmcountsCached`. See #398
* Save that `fixtures/endo_km/km.cPickle` file with the latest Pickle protocol. That shrinks it from 88087 to 36597 bytes and presumably saves I/O time.