### PR TITLE
Store getter masses in a dict

### DIFF
--- a/reconstruction/ecoli/dataclasses/getterFunctions.py
+++ b/reconstruction/ecoli/dataclasses/getterFunctions.py
@@ -25,7 +25,7 @@ class getterFunctions(object):
 	def getMass(self, ids):
 		assert isinstance(ids, (list, np.ndarray))
 		try:
-			masses = [self._all_mass[re.sub("\[[a-z]\]","", i)] for i in ids]
+			masses = [self._all_mass[self._location_tag.sub('', i)] for i in ids]
 		except KeyError:
 			raise Exception("Unrecognized id: {}".format(i))
 
@@ -48,6 +48,7 @@ class getterFunctions(object):
 
 		self._all_mass = all_mass
 		self._mass_units = units.g / units.mol
+		self._location_tag = re.compile('\[[a-z]\]')
 
 	def _buildLocations(self, raw_data, sim_data):
 		locationDict = {}


### PR DESCRIPTION
This converts masses from a stuct array to a dictionary for quick lookup.  I noticed that this function took rather long (~5 sec) when I was trying to use it to get the mass for all molecules and realized a simple change to a dictionary lookup instead of np.where would save a lot of time.  This also reduces the time for the fitter when run locally from 17:50 to 16:30.