### PR TITLE
Fix division bug when counts are 0

### DIFF
--- a/wholecell/sim/divide_cell.py
+++ b/wholecell/sim/divide_cell.py
@@ -334,6 +334,8 @@ def divideUniqueMolecules(uniqueMolecules, randomState, chromosome_division_resu
 					)
 				d1_bool[d1_indexes] = True
 				d2_bool = np.logical_not(d1_bool)
+			else:
+				continue
 
 		elif molecule_name in uniqueMolecules.division_modes['domain_index']:
 			# Divide molecules associated with chromosomes based on the index
@@ -349,6 +351,8 @@ def divideUniqueMolecules(uniqueMolecules, randomState, chromosome_division_resu
 
 				n_d1 = d1_bool.sum()
 				n_d2 = d2_bool.sum()
+			else:
+				continue
 
 		elif molecule_name in uniqueMolecules.division_modes['binomial']:
 			# Binomially divide molecules with binomial division modes.
@@ -366,6 +370,8 @@ def divideUniqueMolecules(uniqueMolecules, randomState, chromosome_division_resu
 					)
 				d1_bool[d1_indexes] = True
 				d2_bool = np.logical_not(d1_bool)
+			else:
+				continue
 
 		else:
 			raise Exception, "Division mode not specified for unique molecule %s. Unable to divide cell." % (molecule_name, )


### PR DESCRIPTION
This fixes an issue I ran into when some unique molecules have 0 counts.  It resulted in an error message like:
```
Traceback (most recent call last):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/home/users/thorst/wcEcoli/wholecell/fireworks/firetasks/simulation.py", line 46, in run_task
    sim.run()
  File "/home/users/thorst/wcEcoli/wholecell/sim/simulation.py", line 212, in run
    self.run_incremental(self._lengthSec + self.initialTime())
  File "/home/users/thorst/wcEcoli/wholecell/sim/simulation.py", line 226, in run_incremental
    self.finalize()
  File "/home/users/thorst/wcEcoli/wholecell/sim/simulation.py", line 249, in finalize
    self.daughter_paths = self._divideCellFunction()
  File "/home/users/thorst/wcEcoli/wholecell/sim/divide_cell.py", line 83, in divide_cell
    chromosome_division_results, current_nutrients, sim))
  File "/home/users/thorst/wcEcoli/wholecell/sim/divide_cell.py", line 373, in divideUniqueMolecules
    assert n_d1 + n_d2 == n_molecules
AssertionError
```
`n_molecules` was 0 so it was falling through the `> 0` statement and using `n_d1` and `n_d2` from the previous molecule, which caused the assertion to fail.  If there are no molecules, we don't need to create any new ones for the daughters so we can just continue.