### PR TITLE
Fix error in cell division with D period division set to True

### DIFF
--- a/models/ecoli/listeners/cell_division.py
+++ b/models/ecoli/listeners/cell_division.py
@@ -96,7 +96,8 @@ class CellDivision(wholecell.listeners.listener.Listener):
 		# double counting.
 		if self.d_period_division:
 			# Get all existing full chromosomes
-			full_chromosomes = self.uniqueMoleculeContainer.objectsInCollection("fullChromosome")
+			full_chromosomes = self.uniqueMoleculeContainer.objectsInCollection(
+				"fullChromosome", read_only=False)
 
 			# If there are two or more full chromosomes,
 			if len(full_chromosomes) >= 2:


### PR DESCRIPTION
This fixes a bug caused by PR #419 if the sim is run with `D_PERIOD_DIVISION` set to True. The `cell_division.py` listener needs to request a writable container to edit the attributes of full chromosomes. Thanks @eagmon !