### PR TITLE
Fix bug for cells without chromosomes

### DIFF
--- a/models/ecoli/processes/chromosome_replication.py
+++ b/models/ecoli/processes/chromosome_replication.py
@@ -82,6 +82,10 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 		# Get total count of existing oriC's
 		n_oric = self.oriCs.total_counts()[0]
 
+		# If there are no origins, return immediately
+		if n_oric == 0:
+			return
+
 		# Get current cell mass
 		cellMass = (self.readFromListener("Mass", "cellMass") * units.fg)
 


### PR DESCRIPTION
This fixes a bug found by @eagmon that occurs for cells that have not inherited a chromosome. If the number of oriC's is zero, the `calculateRequest()` method of the `chromosome_replication` process should be returned instantly without attempting to calculate the critical mass for division.