### PR TITLE
Fix bugs in metabolism nodes for Fathom tool

### DIFF
--- a/models/ecoli/analysis/causality_network/read_dynamics.py
+++ b/models/ecoli/analysis/causality_network/read_dynamics.py
@@ -87,7 +87,8 @@ class Plot(causalityNetworkAnalysis.CausalityNetworkAnalysis):
 		translated_rna_ids = sim_data.process.translation.monomerData["rnaId"]
 		indexes["TranslatedRnas"] = build_index_dict(translated_rna_ids)
 
-		metabolism_rxn_ids = sim_data.process.metabolism.reactionStoich.keys()
+		metabolism_rxn_ids = TableReader(
+			os.path.join(simOutDir, "FBAResults")).readAttribute("reactionIDs")
 		indexes["MetabolismReactions"] = build_index_dict(metabolism_rxn_ids)
 
 		complexation_rxn_ids = sim_data.process.complexation.ids_reactions


### PR DESCRIPTION
This fixes two critical bugs I found for metabolism data used in the Fathom pipeline.

1. The units of the flux dynamics data were converted from mmol/L/s to mmol/gDCW/hr.
2. The list of reaction IDs correctly ordered to match the flux data read by the listener was used, instead of the list that comes from `sim_data`. This completely threw off the dynamics shown by the tool by effectively shuffling the indexes of the reactions.