### PR TITLE
Update requirements.txt with imageio and...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,6 @@ futures==3.2.0
 gnureadline==6.3.8
 gunicorn==19.7.1
 idna==2.6
-imageio==2.5.0
 ipdb==0.11
 ipython==5.7.0  # 6.0+ are for Python 3
 ipython-genutils==0.2.0
@@ -109,7 +108,6 @@ optlang==1.4.2
 osqp==0.3.1
 packaging==17.1
 pandas==0.22.0  # pandas 0.23+ releases have backwards incompatible API changes
-Pillow==5.4.1
 path.py==11.0.1
 pathlib==1.0.1
 pathlib2==2.3.2


### PR DESCRIPTION
**Y'all will need to repeat the pip install steps here on your local machines. Do install numpy & scipy --frombinary on openblas if you haven't done that already.** I'll update wcEcoli2 and wcEcoli3 on Sherlock.

* <s>volume_exclusion.py now requires imageio, which in turn requires Pillow.</s>
* The latest pip and virtualenv require stevedore, virtualenv-clone, and virtualenvwrapper.
* We'll need typing and typing-extensions to write type hints.

(Two PyCon 2018 talks about typing report that teams really like having type hints added to the code base and that there are tools to help do this by capturing types at runtime.)