### PR TITLE
Delay adding cells in experiment until environment is ready

### DIFF
--- a/environment/control.py
+++ b/environment/control.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import time
 import uuid
 
 from agent.control import AgentControl, AgentCommand
@@ -30,6 +31,8 @@ class ShepherdControl(AgentControl):
 		print('Creating lattice agent_id {} and {} cell agents\n'.format(
 			lattice_id, num_cells))
 		self.add_agent(lattice_id, 'lattice', {})
+
+		time.sleep(10)
 
 		for index in range(num_cells):
 			self.add_cell(args['type'] or 'ecoli', {


### PR DESCRIPTION
I encountered an intermittent timing issue when starting a multi-scale experiment with 

    python -m environment.control experiment --number 2

where the cells now are booting faster than the environment, so it does not catch their declarations. A simple delay before the cells are created gives the environment a chance to boot.