### PR TITLE
Corrected reference counting in latest arrow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -150,7 +150,7 @@ simplegeneric==0.8.1
 singledispatch==3.4.0.3
 six==1.11.0
 statistics==1.0.3.5
-stochastic-arrow==0.1.7
+stochastic-arrow==0.1.8
 subprocess32==3.5.2
 swiglpk==1.4.4
 sympy==1.1.1


### PR DESCRIPTION
Looks like I missed a few references: https://github.com/CovertLab/arrow/pull/37

This should bring our daily build back under the line (I did some memory profiling this time). In other news, I second @1fish2's suggestion here: https://github.com/CovertLab/wcEcoli/issues/455 Would have been nice to catch these issues before merging. Part of that is that our PR build tests a pretty serious subset of the daily build, so there are issues we won't catch until the daily build tries to run it, at which point it is already in master. 

Not a huge deal, but I think the suggestions in https://github.com/CovertLab/wcEcoli/issues/455 would help in that we could see various metrics change, rather than just a simple pass/fail.

Thanks all! 