### PR TITLE
Update FireWorks version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ ecos==2.0.5
 enum34==1.1.6
 Equation==1.2.1
 fastcache==1.0.2
-FireWorks==1.7.6
+FireWorks==1.8.7
 Flask==1.0.2
 flask-paginate==0.5.1
 funcsigs==1.0.2


### PR DESCRIPTION
This simply updates the fireworks version in requirements.txt.  I noticed a bug where fireworks that are dependent on others and had been run (marked as `COMPLETED`) were being set as `READY` if the upstream firework they were dependent on was set to be rerun instead of being set as `WAITING`.  Looks like someone had already submitted a PR to fix this so the updated version fixes this bug.

I already updated `wcEcoli2` on Sherlock but everyone should update their local environments.