### PR TITLE
Update cellCycleLength multigen analysis

### DIFF
--- a/models/ecoli/analysis/multigen/__init__.py
+++ b/models/ecoli/analysis/multigen/__init__.py
@@ -48,6 +48,7 @@ ACTIVE = [
 TAGS = {
 	'ACTIVE': ACTIVE,   # all active analyses in this category
 	'CORE': [           # the default list to run in development
+		"cellCycleLength.py",
 		"massFractionSummary.py",
 		"massFractionToUnity.py",
 		"replication.py",

--- a/models/ecoli/analysis/multigen/cellCycleLength.py
+++ b/models/ecoli/analysis/multigen/cellCycleLength.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import
 import os
 
 import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
+import numpy as np
 
 from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
@@ -37,14 +39,17 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			simOutDir = os.path.join(simDir, "simOut")
 			time = TableReader(os.path.join(simOutDir, "Main")).readColumn("time")
 
-			cellCycleLengths.append((time[-1] - time[0]) / 60. / 60.)
+			cellCycleLengths.append((time[-1] - time[0]) / 60.)
 			generations.append(idx)
 
 		plt.scatter(generations, cellCycleLengths)
 		plt.xlabel('Generation')
-		plt.ylabel('Time (hr)')
+		plt.ylabel('Time (min)')
 		plt.title('Cell cycle lengths')
 		plt.xticks(generations)
+		y_min, y_max = plt.ylim()
+		plt.ylim([np.floor(y_min), np.ceil(y_max)])
+		plt.gca().yaxis.set_major_locator(MaxNLocator(integer=True))
 
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
 


### PR DESCRIPTION
I made a minor change to improve the readability of the cellCycleLength plot by changing the units from hours to min.  It's much easier to think about 24, 44 or 100 min doubling times instead of hour equivalents.  This plot also can readily show any major issues with a multigen sim by seeing if the cell is growing too quickly or slowly so I added it to the CORE analysis group.  If anyone has issues with this, I can drop it.

Plot goes from [this](https://github.com/CovertLab/wcEcoli/files/3049941/cellCycleLength.copy.pdf) to [this](https://github.com/CovertLab/wcEcoli/files/3049942/cellCycleLength.pdf).

