### PR TITLE
Add absolute_import

### DIFF
--- a/wholecell/states/local_environment.py
+++ b/wholecell/states/local_environment.py
@@ -18,6 +18,8 @@ External state that represents environmental molecules and conditions.
 @organization: Covert Lab, Department of Bioengineering, Stanford University
 """
 
+from __future__ import absolute_import
+
 import numpy as np
 
 import wholecell.states.external_state


### PR DESCRIPTION
I ran into the issue that Eran mentioned in his email about needing to run `make clean compile` with the recent commit.  I realized it was looking in the relative `environment.pyc` so thought we should just fix the code in case people are switching between master and different branches that might not be completely up to date.  This also is a good lesson that could come up again so maybe we want to be more diligent about adding the `__future__` imports to more files as they are updated/created.