### PR TITLE
make lattice gradients more easily configurable

### DIFF
--- a/environment/control.py
+++ b/environment/control.py
@@ -81,13 +81,23 @@ class ShepherdControl(AgentControl):
 		print('Creating lattice agent_id {} and {} cell agents\n'.format(
 			lattice_id, num_cells))
 
-		media_id = 'GLC'
-		media = {'GLC': 20.0}
+		media_id = 'MeAsp'
+		media = {'GLC': 20.0,
+				 'MeAsp': 0.1}
 
 		chemotaxis_config = {
 			'run_for' : 1.0,
 			'static_concentrations': True,
-			'gradient': {'seed': True},
+			'gradient': {
+				'seed': True,
+				'molecules': {
+					'GLC':{
+						'center': [0.5, 0.5],
+						'deviation': 10.0},
+					'MeAsp': {
+						'center': [0.25, 0.25],
+						'deviation': 10.0}
+				}},
 			'diffusion': 0.0,
 			'translation_jitter': 0.0,
 			'rotation_jitter': 0.05,


### PR DESCRIPTION
This PR allows molecular gradients in ```lattice``` to be configurable within ```experiments/control```. Previously ```GLC``` was hardcoded as the only molecular field that could have a gradient (only applied in chemotaxis experiments).  Now, we can easily specify multiple gradients:
```
'molecules': {
	'GLC':{
		'center': [0.5, 0.5],
		'deviation': 10.0},
	'MeAsp': {
		'center': [0.25, 0.25],
		'deviation': 10.0}
```