### PR TITLE
Add variant that reverses rRNA gene orientation

### DIFF
--- a/models/ecoli/listeners/rnap_data.py
+++ b/models/ecoli/listeners/rnap_data.py
@@ -60,7 +60,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 		# numbers of collisions that can occur for each type in a single
 		# timestep. Currently for +AA conditions the maximum values are around
 		# 50 and 125, respectively.
-		self.headon_collision_coordinates = np.full(100, np.nan, np.float64)
+		self.headon_collision_coordinates = np.full(250, np.nan, np.float64)
 		self.codirectional_collision_coordinates = np.full(250, np.nan, np.float64)
 
 

--- a/models/ecoli/sim/variants/__init__.py
+++ b/models/ecoli/sim/variants/__init__.py
@@ -15,6 +15,7 @@ from .all_shuffle_params import all_shuffle_params
 from .mene_params import mene_params
 from .metabolism_kinetic_objective_weight import metabolism_kinetic_objective_weight
 from .rna_deg_rate_shuffle_params import rna_deg_rate_shuffle_params
+from .rrna_orientation import rrna_orientation
 
 
 nameToFunctionMapping = {
@@ -29,6 +30,7 @@ nameToFunctionMapping = {
 	"monomer_deg_rate_shuffle_params": monomer_deg_rate_shuffle_params,
 	"timelines": timelines,
 	"rna_deg_rate_shuffle_params": rna_deg_rate_shuffle_params,
+	"rrna_orientation": rrna_orientation,
 	"tf_activity": tf_activity,
 	"transcription_initiation_shuffle_params": transcription_initiation_shuffle_params,
 	"translation_efficiencies_shuffle_params": translation_efficiencies_shuffle_params,

--- a/models/ecoli/sim/variants/rrna_orientation.py
+++ b/models/ecoli/sim/variants/rrna_orientation.py
@@ -1,0 +1,39 @@
+"""
+Variant to compare the impacts of reversing the orientation of rRNA genes.
+
+Modifies:
+	sim_data.process.transcription.rnaData["direction"]
+
+Expected variant indices:
+	0: control
+	1: reverse orientation of all rRNA genes
+"""
+import numpy as np
+from wholecell.utils import units
+
+CONTROL_OUTPUT = dict(
+	shortName = "control",
+	desc = "Control simulation"
+	)
+
+
+def rrna_orientation(sim_data, index):
+	if index == 1:
+		is_rrna = sim_data.process.transcription.rnaData["isRRna"]
+		direction = sim_data.process.transcription.rnaData["direction"]
+		coordinate = sim_data.process.transcription.rnaData[
+			"replicationCoordinate"]
+		length = sim_data.process.transcription.rnaData["length"].asNumber(units.nt)
+
+		# Reverse orientations of all rRNA genes
+		coordinate[is_rrna] = coordinate[is_rrna] + np.multiply(
+			length[is_rrna], direction[is_rrna])
+		direction[is_rrna] = ~direction[is_rrna]
+
+		return dict(
+			shortName = "rrna_reversed",
+			desc = "Simulation with all rRNA orientations reversed"
+			), sim_data
+
+	else:
+		return CONTROL_OUTPUT, sim_data


### PR DESCRIPTION
This PR adds a variant sim where the orientations of all rRNA genes are reversed, such that all RNAP-replisome collisions on these rRNA genes are head-on.

![active_rnap_coordinates](https://user-images.githubusercontent.com/32276711/56770231-40077100-6768-11e9-9ee5-24a72393773e.png)