### PR TITLE
add pause before CELL_DECLARE

### DIFF
--- a/agent/inner.py
+++ b/agent/inner.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import uuid
+import time
 
 import agent.event as event
 from agent.agent import Agent
@@ -88,6 +89,9 @@ class Inner(Agent):
 		self.outer_id = outer_id
 
 	def preinitialize(self):
+
+		time.sleep(1.0)
+
 		kafka_config = self.agent_config['kafka_config']
 		state = self.agent_config['state']
 		self.send(kafka_config['topics']['environment_receive'], {
@@ -169,6 +173,9 @@ class Inner(Agent):
 				daughter,
 				parent_id=self.agent_id,
 				outer_id=self.outer_id)
+
+			print('agent_type: ' + str(agent_type))
+			print('divide_config: ' + str(agent_config))
 
 			# Send the inherited state data as a blob instead of a file path.
 			inherited_state_path = agent_config.pop('inherited_state_path', None)


### PR DESCRIPTION
This brings back a pause before the CELL_DECLARE message is sent, which facilitates better coordination with shepherd upon division.  Without this, most simulations were failing at division. The hypothesis is that some messages were being missed.