### PR TITLE
Fix bug in splitting full chromosome indexes at cell division

### DIFF
--- a/wholecell/sim/divide_cell.py
+++ b/wholecell/sim/divide_cell.py
@@ -130,7 +130,7 @@ def chromosomeDivision(uniqueMolecules, randomState, no_child_place_holder):
 
 	index = not d1_gets_first_chromosome
 	d1_domain_index_full_chroms = domain_index_full_chroms[index::2]
-	d2_domain_index_full_chroms = domain_index_full_chroms[~index::2]
+	d2_domain_index_full_chroms = domain_index_full_chroms[not index::2]
 	d1_all_domain_indexes = get_descendent_domains(
 		d1_domain_index_full_chroms, domain_index_domains,
 		child_domains, no_child_place_holder


### PR DESCRIPTION
This fixes a bug during cell division that @eagmon identified that leads to assertion errors when the cell divides prematurely before having two chromosomes.