### PR TITLE
Raise exception for inf conc

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -2889,7 +2889,7 @@ def fitLigandConcentrations(sim_data, cellSpecs):
 
 		if negativeSignal:
 			if p_inactive == 0:
-				raise Exception('Inf ligand concentration from p_inactive = 0.'
+				raise ValueError('Inf ligand concentration from p_inactive = 0.'
 					' Check results from fitPromoterBoundProbability and Kd values.')
 			if 1 - p_active < 1e-9:
 				kdNew = kd  # Concentration of metabolite-bound TF is negligible
@@ -2902,7 +2902,7 @@ def fitLigandConcentrations(sim_data, cellSpecs):
 
 		else:
 			if p_active == 1:
-				raise Exception('Inf ligand concentration from p_active = 1.'
+				raise ValueError('Inf ligand concentration from p_active = 1.'
 					' Check results from fitPromoterBoundProbability and Kd values.')
 			if p_inactive < 1e-9:
 				kdNew = kd  # Concentration of metabolite-bound TF is negligible


### PR DESCRIPTION
I was changing some AA concentrations around and running the fitter and noticed that depending on the concentrations, we can get some strange results.  If `fitPromoterBoundProbability()` calculates a probability bound of 1 or 0 in certain cases then a calculation to update the ligand concentration will result in a divide by 0 (inf concentration).  This executes just fine but can eventually throw an error in some conditions when trying to initialize the cell.  This is currently not a problem on master but I added an exception to catch it closer to the error source in the future if things are ever updated.