### PR TITLE
`make clean` should delete the generated ODE .py files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: compile, clean, clobber
+.PHONY: compile, clean
 
 PYTHON_INCLUDE=$(shell pyenv virtualenv-prefix)/include/python2.7
 PYTHON_LIB=$(shell pyenv virtualenv-prefix)/lib
@@ -14,8 +14,4 @@ clean:
 	find . -name "*.o" -exec rm -fr {} \;
 	find . -name "*.so" -exec rm -fr {} \;
 	rm -fr build
-	rm -fr launcher_20*/
-
-clobber:
-	rm -fr out/*
-	rm -fr block_20*
+	rm -fr launcher_20* block_20*


### PR DESCRIPTION
... I think. Running Parca will regenerate those files in reconstruction/ecoli/dataclasses/process/.

Also remove a bunch of obsolete Makefile targets. (What remains are 3 scripts that aren't real Make targets.)