### PR TITLE
Fix 2CS bug

### DIFF
--- a/models/ecoli/processes/two_component_system.py
+++ b/models/ecoli/processes/two_component_system.py
@@ -72,19 +72,16 @@ class TwoComponentSystem(wholecell.processes.process.Process):
 
 		# Check if any molecules were allocated fewer counts than requested
 		if (self.molecules_required > moleculeCounts).any():
+			# Solve ODEs to a large time step using the the counts of molecules
+			# allocated to this process using the BDF solver for stable integration.
+			# The number of reactions has already been determined in calculateRequest
+			# and rates will be much lower with a fraction of total counts allocated
+			# so a much longer time scale is needed.
 
-			# Solve ODEs to next time step using the the counts of molecules
-			# allocated to this process using the LSODA solver through odeint.
-			# Note: for this setting where the counts of molecules are
-			# relatively small, the default LSODA solver used by odeint was
-			# empirically tested to be the fastest.
 			_, self.all_molecule_changes = self.moleculesToNextTimeStep(
 				moleculeCounts, self.cellVolume, self.nAvogadro,
-				self.timeStepSec()
+				10000, solver="BDF", min_time_step=self.timeStepSec()
 				)
 
-			# Increment changes in molecule counts
-			self.molecules.countsInc(self.all_molecule_changes)
-		else:
-			# Increment changes in molecule counts
-			self.molecules.countsInc(self.all_molecule_changes)
+		# Increment changes in molecule counts
+		self.molecules.countsInc(self.all_molecule_changes)

--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -433,7 +433,7 @@ class TwoComponentSystem(object):
 
 
 	def moleculesToNextTimeStep(self, moleculeCounts, cellVolume,
-			nAvogadro, timeStepSec, solver="LSODA"):
+			nAvogadro, timeStepSec, solver="LSODA", min_time_step=None):
 		"""
 		Calculates the changes in the counts of molecules in the next timestep
 		by solving an initial value ODE problem.
@@ -445,6 +445,8 @@ class TwoComponentSystem(object):
 			nAvogadro (float): Avogadro's number
 			timeStepSec (float): current length of timestep in seconds
 			solver (str): name of the ODE solver to use
+			min_time_step (int): if not None, timeStepSec will be scaled down until
+				it is below min_time_step if negative counts are encountered
 
 		Returns:
 			moleculesNeeded (1d ndarray, ints): counts of molecules that need
@@ -472,9 +474,15 @@ class TwoComponentSystem(object):
 				)
 
 		if np.any(y[-1, :] * (cellVolume * nAvogadro) <= -1):
-			raise Exception(
-				"Solution to ODE for two-component systems has negative values."
-				)
+			if min_time_step and timeStepSec > min_time_step:
+				# Call method again with a shorter time step until min_time_step is reached
+				return self.moleculesToNextTimeStep(
+					moleculeCounts, cellVolume, nAvogadro, timeStepSec/2,
+					solver=solver, min_time_step=min_time_step)
+			else:
+				raise Exception(
+					"Solution to ODE for two-component systems has negative values."
+					)
 
 		y[y < 0] = 0
 		yMolecules = y * (cellVolume * nAvogadro)


### PR DESCRIPTION
This fixes #537 by using BDF instead of LSODA for integration during `evolveState` for `two_component_system.py`.

More importantly, it fixes a separate bug that has been present in two component systems.  During `calculateRequest`, we determine the number of reactions that should occur for 2CS taking the entire state of the cell into account, which becomes the requested molecules.  If the process is not allocated everything it requests, which is common because it has a lower priority (only 36 time steps out of 2928 could use the originally calculated values), then it recalculates the reaction rates using the allocated counts.  Since these counts are a small fraction of the total counts in the cell, the rates are much lower such that no reactions were occurring in a time step.  This change extends the time scale during `evolveState` so that we get the number of reactions that were expected from `calculateRequest` limited by the allocated molecules.  From one sim with our current implementation, there were 2278 out of 2928 time steps that could have had reactions with a longer time scale.  With the new implementation, these reactions will occur right away so only 10-20 time steps will have reactions but they are reactions that would not have occurred for hundreds or thousands of time steps.

The recursive approach with shortening time step was required for one time step at the beginning of the sim that saw negative counts with a long time step.