### PR TITLE
Update load_sim_data.py

### DIFF
--- a/runscripts/debug/load_sim_data.py
+++ b/runscripts/debug/load_sim_data.py
@@ -1,10 +1,11 @@
 '''
 Script to quickly load raw_data and sim_data to interactively explore contents
 through ipdb instead of running the parameter calculator (parca).
-Shortcut names rd and sd are created for typing ease.
+Shortcut names rd and sd are created for typing ease as well as variables for
+each process object.
 
 Use:
-	python runscripts/manual/load_sim_data.py
+	python runscripts/debug/load_sim_data.py
 
 Requires:
 	cached/ directory in wcEcoli root with rawData.cPickle and simData.cPickle
@@ -12,7 +13,7 @@ Requires:
 Tip:
 Create an alias in your .bash_profile to easily run this by just typing lsd (or your
 alias of choice):
-	alias lsd="python runscripts/manual/load_sim_data.py"
+	alias lsd="python runscripts/debug/load_sim_data.py"
 '''
 
 from __future__ import absolute_import, division, print_function
@@ -35,7 +36,18 @@ sim_data_filename = constants.SERIALIZED_SIM_DATA_FILENAME
 raw_data = cPickle.load(open(os.path.join(data_dir, raw_data_filename), 'rb'))
 sim_data = cPickle.load(open(os.path.join(data_dir, sim_data_filename), 'rb'))
 
+# Shortcuts for easier access or tab complete
 rd = raw_data
 sd = sim_data
+process = sd.process
+complexation = process.complexation
+equilibrium = process.equilibrium
+metabolism = process.metabolism
+replication = process.replication
+rna_decay = process.rna_decay
+transcription = process.transcription
+transcription_regulation = process.transcription_regulation
+translation = process.translation
+two_component_system = process.two_component_system
 
 ipdb.set_trace()


### PR DESCRIPTION
Small update to the load_sim_data script.  Not sure who else uses this but I find I most often use it to explore the process classes and will end up setting something like `metabolism = sd.process.metabolism`. 
 Instead of typing that most times, I think it would be best to have it already saved for easier tab complete access.  If anyone is opposed to adding a little clutter to this script and the namespace when broken into, we can scrap the PR but I think it will be convenient for most uses.

This also fixes an old path in the comments.