### PR TITLE
make compareParca.py handle derivatives_jacobian

### DIFF
--- a/runscripts/debug/compareParca.py
+++ b/runscripts/debug/compareParca.py
@@ -11,9 +11,11 @@ from runscripts.reflect.object_tree import object_tree, diff_trees
 
 def load_fit_tree(out_subdir):
 	'''Load the parameter calculator's (Parca's) output as an object_tree.'''
+	# For convenience, optionally add the prefix 'out/'.
+	if not os.path.isabs(out_subdir) and not os.path.isdir(out_subdir):
+		out_subdir = os.path.join('out', out_subdir)
+
 	path = os.path.join(
-		os.getcwd(),
-		'out',
 		out_subdir,
 		'kb',
 		constants.SERIALIZED_SIM_DATA_FILENAME)

--- a/runscripts/reflect/object_tree.py
+++ b/runscripts/reflect/object_tree.py
@@ -50,7 +50,12 @@ def all_vars(obj):
 	"""
 	Returns a dict of all the object's instance variables stored in ordinary
 	fields and in compact slots. This expands on the built-in function `vars()`.
+	If the object implements the pickling method `__getstate__`, call that
+	instead to get its defining state.
 	"""
+	if hasattr(obj, '__getstate__'):
+		return obj.__getstate__()
+
 	attrs = getattr(obj, '__dict__', {})
 	attrs.update({key: getattr(obj, key) for key in getattr(obj, '__slots__', ())})
 	return attrs


### PR DESCRIPTION
`compareParca.py` should ignore Numba-compiled functions like `derivatives_jacobian` when comparing trees, and in fact ignore all derived state that doesn't get pickled by calling the object's `__getstate__` method.

Also make compareParca more convenient by not insisting on adding the prefix `out/`. This way you can use shell filename completion to construct arguments like `out/20190517.182722__shorter_timestamp` and `out/manual/`.