### PR TITLE
Fix TCS negative counts

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -402,7 +402,7 @@ class TwoComponentSystem(object):
 				t=[0, timeStepSec], Dfun=self.derivatives_jacobian
 				)
 
-		if np.any(y[-1, :] * (cellVolume * nAvogadro) <= -1):
+		if np.any(y[-1, :] * (cellVolume * nAvogadro) <= -1e-6):
 			if min_time_step and timeStepSec > min_time_step:
 				# Call method again with a shorter time step until min_time_step is reached
 				return self.moleculesToNextTimeStep(


### PR DESCRIPTION
This fixes the error that caused the daily build to fail for basal conditions by reducing the threshold to call negative output values closer to floating point precision levels, which I believe was the original intention.

This gets around improper logic lower in the file that sets negative values to 0 but doesn't adjust products that would have been created from these negative counts.  The sim failed in this case because the `independentMoleculesCounts` were then used to calculate how many molecules were consumed.  This happened to round up to consuming another molecule of the molecule that had just been set to 0 thus consuming an extra molecule than allocated.