### PR TITLE
Adjust TCS threshold

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -402,7 +402,7 @@ class TwoComponentSystem(object):
 				t=[0, timeStepSec], Dfun=self.derivatives_jacobian
 				)
 
-		if np.any(y[-1, :] * (cellVolume * nAvogadro) <= -1e-6):
+		if np.any(y[-1, :] * (cellVolume * nAvogadro) <= -1e-3):
 			if min_time_step and timeStepSec > min_time_step:
 				# Call method again with a shorter time step until min_time_step is reached
 				return self.moleculesToNextTimeStep(


### PR DESCRIPTION
Apparently the threshold in #558 was too aggressive for some time steps which caused jenkins build failures.  The solution to the numerical integration typically gives negative values on the order of -1e-10 but then those get converted to counts which is more like -1e-4.  @heejochoi do you mind double checking the implementation of TCS to make sure that these negative values are reasonable and it doesn't indicate an underlying issue with the equation setup or should we scale the concentrations in the problem down to the uM or nM scale instead of mM to limit the loss of precision?