### PR TITLE
Fix broken symlink

### DIFF
--- a/runscripts/fireworks/fw_queue.py
+++ b/runscripts/fireworks/fw_queue.py
@@ -1,1 +1,0 @@
-../fw_queue.py

--- a/runscripts/jenkins/ecoli-anaerobic.sh
+++ b/runscripts/jenkins/ecoli-anaerobic.sh
@@ -15,7 +15,7 @@ sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 
 echo y | lpad reset
 
-PYTHONPATH=$PWD DESC="Anaerobic." VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 SINGLE_DAUGHTERS=1 N_GENS=8 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fireworks/fw_queue.py
+PYTHONPATH=$PWD DESC="Anaerobic." VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 SINGLE_DAUGHTERS=1 N_GENS=8 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fw_queue.py
 
 while [ $(lpad get_fws -s READY -d count) -ge 1 ]; do
   PYTHONPATH=$PWD rlaunch singleshot

--- a/runscripts/jenkins/ecoli-glucose-minimal.sh
+++ b/runscripts/jenkins/ecoli-glucose-minimal.sh
@@ -15,30 +15,13 @@ sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 
 echo y | lpad reset
 
-PYTHONPATH=$PWD DESC="Daily build." SINGLE_DAUGHTERS=1 N_GENS=25 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fireworks/fw_queue.py
+PYTHONPATH=$PWD DESC="Daily build." SINGLE_DAUGHTERS=1 N_GENS=25 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fw_queue.py
 
 PYTHONPATH=$PWD rlaunch rapidfire --nlaunches 0
 
 N_FAILS=$(lpad get_fws -s FIZZLED -d count)
 
 test $N_FAILS = 0
-
-export TOP_DIR="$PWD"
-
-cd out/2*/wildtype_000000/000000/generation_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-cd out/2*/wildtype_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-cd out/2*/wildtype_000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-cd $TOP_DIR
 
 cp out/2*/kb/simData_Fit_1.cPickle.bz2 /scratch/PI/mcovert/wc_ecoli/cached/
 bunzip2 -f /scratch/PI/mcovert/wc_ecoli/cached/simData_Fit_1.cPickle.bz2

--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -17,33 +17,10 @@ sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 
 echo y | lpad reset
 
-PYTHONPATH=$PWD DESC="2 generations completion test." WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 PARALLEL_FITTER=1 COMPRESS_OUTPUT=0 python runscripts/fireworks/fw_queue.py
+PYTHONPATH=$PWD DESC="2 generations completion test." WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 PARALLEL_FITTER=1 COMPRESS_OUTPUT=0 python runscripts/fw_queue.py
 
 PYTHONPATH=$PWD rlaunch rapidfire --nlaunches 0
 
 N_FAILS=$(lpad get_fws -s FIZZLED -d count)
 
 test $N_FAILS = 0
-
-# TODO (John): These calls are disabled because the files weren't appearing
-# quickly enough, post-analysis.  Consequently the PR test build was failing
-# despite running all of the code without issue.  If and when these issues are
-# addressed, the lines can be restored.  See #316
-
-# export TOP_DIR="$PWD"
-
-# cd out/2*/wildtype_000000/000000/generation_000000/000000/plotOut/low_res_plots/
-
-# curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-# cd $TOP_DIR
-# cd out/2*/wildtype_000000/000000/plotOut/low_res_plots/
-
-# curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-# cd $TOP_DIR
-# cd out/2*/wildtype_000000/plotOut/low_res_plots/
-
-# curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-# cd $TOP_DIR
-# rm -fr out/*

--- a/runscripts/jenkins/ecoli-two-generations.sh
+++ b/runscripts/jenkins/ecoli-two-generations.sh
@@ -15,7 +15,7 @@ sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 
 echo y | lpad reset
 
-PYTHONPATH=$PWD DESC="2 generations completion test." SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fireworks/fw_queue.py
+PYTHONPATH=$PWD DESC="2 generations completion test." SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fw_queue.py
 
 PYTHONPATH=$PWD rlaunch rapidfire --nlaunches 0
 
@@ -23,29 +23,13 @@ N_FAILS=$(lpad get_fws -s FIZZLED -d count)
 
 test $N_FAILS = 0
 
-export TOP_DIR="$PWD"
-
-cd out/2*/wildtype_000000/000000/generation_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-cd out/2*/wildtype_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-cd out/2*/wildtype_000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-cd $TOP_DIR
 rm -fr out/*
 
 # Run everything with WC_ANALYZE_FAST and PARALLEL_FITTER
 
 echo y | lpad reset
 
-PYTHONPATH=$PWD DESC="2 generations completion test." WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 PARALLEL_FITTER=1 python runscripts/fireworks/fw_queue.py
+PYTHONPATH=$PWD DESC="2 generations completion test." WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 PARALLEL_FITTER=1 python runscripts/fw_queue.py
 
 PYTHONPATH=$PWD rlaunch rapidfire --nlaunches 0
 

--- a/runscripts/jenkins/ecoli-with-aa.sh
+++ b/runscripts/jenkins/ecoli-with-aa.sh
@@ -15,7 +15,7 @@ sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 
 echo y | lpad reset
 
-PYTHONPATH=$PWD DESC="With AAs." VARIANT="condition" FIRST_VARIANT_INDEX=2 LAST_VARIANT_INDEX=2 SINGLE_DAUGHTERS=1 N_GENS=8 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fireworks/fw_queue.py
+PYTHONPATH=$PWD DESC="With AAs." VARIANT="condition" FIRST_VARIANT_INDEX=2 LAST_VARIANT_INDEX=2 SINGLE_DAUGHTERS=1 N_GENS=8 MASS_DISTRIBUTION=0 COMPRESS_OUTPUT=1 python runscripts/fw_queue.py
 
 PYTHONPATH=$PWD rlaunch rapidfire --nlaunches 0
 


### PR DESCRIPTION
This removes a symlink that was creating incorrect paths on the paper branch - `out/` was being created in `runscripts/` instead of the base directory.  This will allow us to run the PR build on PR's into `release-paper` and prevent any confusion by having only one `fw_queue.py` file that uses the correct paths.  It also removes our slack token from jenkins scripts since that doesn't work any more (probably got disabled when we pushed it to the public repo) and so it's eventually removed from the public repo HEAD.