### PR TITLE
Remove slack token from scripts

### DIFF
--- a/runscripts/jenkins/ecoli-glucose-minimal.sh
+++ b/runscripts/jenkins/ecoli-glucose-minimal.sh
@@ -29,19 +29,6 @@ fi
 
 test $N_FAILS = 0
 
-export TOP_DIR="$PWD"
-
-cd out/2*/wildtype_000000/000000/generation_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-cd out/2*/wildtype_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-
 cp out/2*/kb/rawData.cPickle.bz2 /scratch/PI/mcovert/wc_ecoli/cached/
 bunzip2 -f /scratch/PI/mcovert/wc_ecoli/cached/rawData.cPickle.bz2
 chmod 444 /scratch/PI/mcovert/wc_ecoli/cached/rawData.cPickle

--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -30,16 +30,4 @@ fi
 
 test $N_FAILS = 0
 
-export TOP_DIR="$PWD"
-
-cd out/2*/wildtype_000000/000000/generation_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-cd out/2*/wildtype_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
 rm -fr out/*

--- a/runscripts/jenkins/ecoli-two-generations.sh
+++ b/runscripts/jenkins/ecoli-two-generations.sh
@@ -23,18 +23,6 @@ N_FAILS=$(lpad get_fws -s FIZZLED -d count)
 
 test $N_FAILS = 0
 
-export TOP_DIR="$PWD"
-
-cd out/2*/wildtype_000000/000000/generation_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
-cd out/2*/wildtype_000000/000000/plotOut/low_res_plots/
-
-curl -F file=@massFractionSummary.png -F channels=#jenkins -F token=xoxb-17787270916-3VkwrS6348nn9DJz8bDs6EYG https://slack.com/api/files.upload
-
-cd $TOP_DIR
 rm -fr out/*
 
 # Run everything with WC_ANALYZE_FAST and PARALLEL_PARCA


### PR DESCRIPTION
As discussed in #563, this removes the slack token, which has been revoked, from Jenkins scripts.