### PR TITLE
Add plot for RNA/protein mass ratios over different growth rates

### DIFF
--- a/models/ecoli/analysis/variant/rna_protein_ratio_comparison.py
+++ b/models/ecoli/analysis/variant/rna_protein_ratio_comparison.py
@@ -98,7 +98,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 
 		# Add linear plot proposed in Scott et al. (2010)
 		x_linear = np.linspace(0, 3, 100)
-		y_linear = 0.23*x_linear + 0.09
+		y_linear = x_linear/4.5 + 0.087
 		plt.plot(x_linear, y_linear, linewidth=2, color=color_cycle[2])
 
 		plt.xlim([0, 3])


### PR DESCRIPTION
This adds a new plot in the release-paper branch that addresses reviewer 1's comments. The plot is a comparison of the simulation's results to the data in [Scott et al., Science (2010)](https://science.sciencemag.org/content/330/6007/1099.long), where they show there's a linear relationship between _E. coli_'s growth rate and the mass ratio of RNA to protein. I sneaked this file into this branch without a PR some time ago, so you'll only see here the changes I made to add error bars to the plot. 

Here's the output plot from the script:
[rna_protein_ratio_comparison.pdf](https://github.com/CovertLab/wcEcoli/files/3267428/rna_protein_ratio_comparison.pdf)
