### PR TITLE
Add script to compile process pdfs

### DIFF
--- a/docs/processes/README.md
+++ b/docs/processes/README.md
@@ -16,12 +16,6 @@ The Processes of the *E. coli* model span several major areas of cellular physio
 
 ### Regeneration of pdf files from tex files
 
-Assuming all the dependencies have been installed, the pdf files can be compiled from the tex files by changing to the `src` directory and running the following commands
+Assuming all the dependencies have been installed (try `sudo apt install texlive-full` on linux if not), the pdf files can be compiled from the tex files with:
 
-      pdflatex PROCESS_NAME.tex
-      bibtex PROCESS_NAME.aux
-      pdflatex PROCESS_NAME.tex
-      pdflatex PROCESS_NAME.tex
-      mv PROCESS_NAME.pdf ../
-
-where `PROCESS_NAME` is replaced by the name of the process for which the `tex` file has been edited.
+      runscripts/fileManipulation/compile_process_pdf.sh docs/processes/src/<process>.tex

--- a/runscripts/fileManipulation/compile_process_pdf.sh
+++ b/runscripts/fileManipulation/compile_process_pdf.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+# Compiles process tex files from docs/processes/src to pdf
+
+# Usage:
+#   compile_process_pdfs.sh path_to_tex_file
+
+set -eu
+
+src_dir=$(dirname $1)
+file_base=$(basename $1 .tex)
+
+cd $src_dir
+
+# Compile pdf from tex with proper citation linking
+pdflatex ${file_base}.tex
+bibtex ${file_base}.aux
+pdflatex ${file_base}.tex
+pdflatex ${file_base}.tex
+
+# Move compiled pdf to parent directory
+mv ${file_base}.pdf ../
+
+# Clean intermediate files
+rm *.log *.aux *.bbl *.blg


### PR DESCRIPTION
This creates a script to make it easier to compile the process doc pdfs instead of making multiple command line calls