### PR TITLE
Cleanup cell division for release-paper

### DIFF
--- a/models/ecoli/listeners/cell_division.py
+++ b/models/ecoli/listeners/cell_division.py
@@ -95,21 +95,13 @@ class CellDivision(wholecell.listeners.listener.Listener):
 		if self.d_period_division:
 			fullChrom = self.uniqueMoleculeContainer.objectsInCollection("fullChromosome")
 			if len(fullChrom):
-				# print "grep_marker cell division check - full chromosome division times: {}".format(fullChrom.attr("division_time"))
-
 				division_times = fullChrom.attr("division_time")
 				divide_at_time = division_times.min()
 
 				if self.time() >= divide_at_time:
-					print "grep_marker cell division occurs - time: {}".format(self.time())
-					print "grep_marker cell division occurs - relative time: {}".format(self.time() - self._sim.initialTime())
-					print "grep_marker cell division occurs - divide time: {}".format(divide_at_time)
-					print "grep_marker cell division occurs - cell mass: {}".format(self.cellMass)
-
 					fullChrom.delByIndexes(np.where(division_times == divide_at_time)[0])
 
 					if not uneven_counts.any():
-					# if self.fullChromosomeView.count() > 1:
 						self._sim.cellCycleComplete()
 		else:
 			# End simulation once the mass of an average cell is
@@ -117,11 +109,4 @@ class CellDivision(wholecell.listeners.listener.Listener):
 			current_nutrients = self._external_states['Environment'].nutrients
 			if self.dryMass - self.dryMassInitial >= self.expectedDryMassIncreaseDict[current_nutrients].asNumber(units.fg) * self.divisionMassMultiplier:
 				if not uneven_counts.any():
-				# if self.fullChromosomeView.count() > 1:
 					self._sim.cellCycleComplete()
-
-
-		# if self.dryMass >= 2. * self.dryMassInitial:
-		# 	if not uneven_counts.any():
-		# 	# if self.fullChromosomeView.count() > 1:
-		# 		self._sim.cellCycleComplete()


### PR DESCRIPTION
I was running some sims on the paper branch and noticed we still had these debug print statements that look sloppy so I thought I'd clean up the file a bit for eventual release.  We won't have the grep_marker statements at the end of the sim like below any more:

```
 2644.19    417.97        1.277        1.269        1.245        1.287        2.002
grep_marker cell division occurs - time: 2645.08046875                             
grep_marker cell division occurs - relative time: 2645.08046875                    
grep_marker cell division occurs - divide time: 2644.93046875                      
grep_marker cell division occurs - cell mass: 1393.08357024                        
 2645.08    418.00        1.277        1.269        1.245        1.288        2.003
```