### PR TITLE
cherry-pick from PR #573 for the release-paper branch

### DIFF
--- a/cloud/build-containers.sh
+++ b/cloud/build-containers.sh
@@ -3,7 +3,7 @@
 #
 # ASSUMES: The current working dir is the wcEcoli/ project root.
 #
-# Add the `docker build` option `--build-arg from ABC` to name a different "FROM" image.
+# Add the `docker build` option `--build-arg from=ABC` to name a different "FROM" image.
 
 set -eu
 

--- a/cloud/docker/runtime/Dockerfile
+++ b/cloud/docker/runtime/Dockerfile
@@ -1,17 +1,17 @@
 # Container image #1: wcm-runtime.
 # This Dockerfile builds the runtime environment for the whole cell model.
 #
-# To build this image from the wcEcoli/ project root directory:
+# To build this image locally from the wcEcoli/ project root directory:
 #
 #     > docker build -f cloud/docker/runtime/Dockerfile -t wcm-runtime .
 #
-# Add option `--build-arg from ABC` to build from a different base image but
+# Add option `--build-arg from=ABC` to build from a different base image but
 # DO NOT USE an alpine base since the simulation math comes out different!
 ARG from=python:2.7.16
 FROM ${from}
 
 RUN apt-get update \
-    && apt-get install -y glpk-utils libglpk-dev glpk-doc swig python-cvxopt \
+    && apt-get install -y swig python-cvxopt \
         gfortran llvm cmake ncurses-dev libreadline7 libreadline-dev nano
 
 RUN echo "alias ls='ls --color=auto'" >> ~/.bashrc

--- a/cloud/docker/wholecell/Dockerfile
+++ b/cloud/docker/wholecell/Dockerfile
@@ -2,13 +2,13 @@
 # This Dockerfile builds a container image with the wcEcoli whole cell model
 # code, layered on the wcm-runtime container image.
 #
-# To build this image from the wcEcoli/ project root directory:
+# To build this image locally from the wcEcoli/ project root directory:
 #
 #     > docker build -f cloud/docker/wholecell/Dockerfile -t wcm-code .
 #
-# (Add option `--build-arg from ABC` to build from a different base image.)
+# (Add option `--build-arg from=ABC` to build from a different base image.)
 #
-# After building you can start up a new container from the image:
+# After building locally you can start up a new container from the image:
 #
 #     > docker run --name wholecelltest -it wcm-code
 #
@@ -22,6 +22,12 @@
 
 ARG from=wcm-runtime:latest
 FROM ${from}
+
+LABEL application="Whole Cell Model of Escherichia coli" \
+    email="allencentercovertlab@gmail.com" \
+    license="https://github.com/CovertLab/WholeCellEcoliRelease/blob/master/LICENSE.md" \
+    organization="Covert Lab at Stanford" \
+    website="https://www.covert.stanford.edu/"
 
 COPY . /wcEcoli
 WORKDIR /wcEcoli


### PR DESCRIPTION
* Just one installation of GLPK to the `wcm-runtime` image.
* Add the `LABEL` info to the `wcm-code` image.
* Fix the `--build-arg from=ABC` instruction.

[There's not really anything to review here.]