### PR TITLE
Fix tRNA distribution and adjust for growth rate

### DIFF
--- a/reconstruction/ecoli/dataclasses/growthRateDependentParameters.py
+++ b/reconstruction/ecoli/dataclasses/growthRateDependentParameters.py
@@ -334,17 +334,15 @@ class Mass(object):
 
 		self._trna_ids = [x['rna id'] for x in raw_data.trnaData.trna_ratio_to_16SrRNA_0p4]
 
-	def getTrnaDistribution(self):
-		return self._getTrnaAbundanceAtGrowthRate(self._doubling_time)
-
-	def _getTrnaAbundanceAtGrowthRate(self, doubling_time):
+	def getTrnaDistribution(self, doubling_time):
 		assert type(doubling_time) == unum.Unum
 		assert type(doubling_time.asNumber()) == float
 		growth_rate = 1 / doubling_time
 		growth_rate = growth_rate.asNumber(1/units.h)
 
-		from scipy.interpolate import interp1d
-		trna_abundance_interpolation_functions = [interp1d(self._trna_growth_rates.asNumber(1/units.h), self._trna_ratio_to_16SrRNA_by_growth_rate[:,i]) for i in range(self._trna_ratio_to_16SrRNA_by_growth_rate.shape[1])]
+		trna_abundance_interpolation_functions = [
+			interpolate.interp1d(self._trna_growth_rates.asNumber(1/units.h), self._trna_ratio_to_16SrRNA_by_growth_rate[:,i])
+			for i in range(self._trna_ratio_to_16SrRNA_by_growth_rate.shape[1])]
 
 		abundance = np.zeros(len(self._trna_ids), dtype = [('id','a50'),('molar_ratio_to_16SrRNA', np.float64)])
 		abundance['id'] = self._trna_ids

--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -985,7 +985,6 @@ def setInitialRnaExpression(sim_data, expression, doubling_time):
 	ids_rRNA23S = sim_data.process.transcription.rnaData["id"][sim_data.process.transcription.rnaData["isRRna23S"]] # 23S rRNA
 	ids_rRNA16S = sim_data.process.transcription.rnaData["id"][sim_data.process.transcription.rnaData["isRRna16S"]] # 16S rRNA
 	ids_rRNA5S = sim_data.process.transcription.rnaData["id"][sim_data.process.transcription.rnaData["isRRna5S"]] # 5s rRNA
-	ids_tRNA = sim_data.process.transcription.rnaData["id"][sim_data.process.transcription.rnaData["isTRna"]] # tRNAs
 	ids_mRNA = sim_data.process.transcription.rnaData["id"][sim_data.process.transcription.rnaData["isMRna"]] # mRNAs
 
 	avgCellFractionMass = sim_data.mass.getFractionMass(doubling_time)
@@ -1062,7 +1061,9 @@ def setInitialRnaExpression(sim_data, expression, doubling_time):
 	distribution_rRNA16S = normalize(n_avg_copy_rRNA16S)
 	distribution_rRNA5S = normalize(n_avg_copy_rRNA5S)
 
-	distribution_tRNA = normalize(sim_data.mass.getTrnaDistribution()['molar_ratio_to_16SrRNA'])
+	trna_distribution = sim_data.mass.getTrnaDistribution(doubling_time)
+	ids_tRNA = trna_distribution['id']
+	distribution_tRNA = normalize(trna_distribution['molar_ratio_to_16SrRNA'])
 	distribution_mRNA = normalize(expression[sim_data.process.transcription.rnaData['isMRna']])
 
 	# Construct bulk container


### PR DESCRIPTION
This fixes an issue where tRNA distributions were being calculated for ids that didn't match up with the expression that was being updated.  The order of `sim_data.process.transcription.rnaData["id"][sim_data.process.transcription.rnaData["isTRna"]]` does not match the order of `sim_data.mass.getTrnaDistribution()['id']` so expression for tRNA was not matching the data we had.

The tRNA data is growth rate dependent so this also adjusts the fraction depending on the expected doubling time instead of using a default doubling time for all conditions.

This didn't have a noticeable impact on sims but I expect it will improve growth control implementation.