### PR TITLE
Finalize sim even on exceptions

### DIFF
--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -219,15 +219,18 @@ class Simulation(CellSimulation):
 		and then clean up.
 		"""
 
-		self.run_incremental(self._lengthSec + self.initialTime())
-		self.finalize()
+		try:
+			self.run_incremental(self._lengthSec + self.initialTime())
+			self.cellCycleComplete()
+		finally:
+			self.finalize()
 
 	def run_incremental(self, run_until):
 		"""
 		Run the simulation for a given amount of time.
 
 		Args:
-		    run_until (float): absolute time to run the simulation until. 
+		    run_until (float): absolute time to run the simulation until.
 		"""
 
 		# Simulate
@@ -246,8 +249,8 @@ class Simulation(CellSimulation):
 		"""
 		Clean up any details once the simulation has finished.
 		Specifically, this calls `finalize` in all hooks,
-		invokes the simulation's `_divideCellFunction` and then
-		shuts down all loggers
+		invokes the simulation's `_divideCellFunction` if the
+		cell cycle has completed and then shuts down all loggers.
 		"""
 
 		if not self._finalized:
@@ -256,7 +259,8 @@ class Simulation(CellSimulation):
 				hook.finalize(self)
 
 			# Divide mother into daughter cells
-			self.daughter_paths = self._divideCellFunction()
+			if self._cellCycleComplete:
+				self.daughter_paths = self._divideCellFunction()
 
 			# Finish logging
 			for logger in self.loggers.itervalues():


### PR DESCRIPTION
This places the simulation in a try-finally block so that even if the sim exits due to error or interrupt, `TableWriter` objects can finish writing their data.  Currently, data is not written to disk until a block size has been reached so `finalize()` is needed to write the remaining data.  This is useful if you want to plot data from a failed sim.  Otherwise you might run into incomplete data or an error like:

```
Traceback (most recent call last):                                                 
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/analysisBase.py", line 120, in run_task                 
    mod.Plot.main(*args)                                                           
  File "/home/travis/wcEcoli/models/ecoli/analysis/analysisPlot.py", line 124, in main
    validationDataFile, metadata)                                                                         
  File "/home/travis/wcEcoli/models/ecoli/analysis/analysisPlot.py", line 114, in plot                                                                              
    validationDataFile, metadata)                               
  File "/home/travis/wcEcoli/models/ecoli/analysis/multigen/charging_molecules.py", line 146, in do_plot
    time = main_reader.readColumn('time') / 3600                                   
  File "/home/travis/wcEcoli/wholecell/io/tablereader.py", line 244, in readColumn
    return self.readColumn2D(name, indices).squeeze()
  File "/home/travis/wcEcoli/wholecell/io/tablereader.py", line 207, in readColumn2D
    last_entries = decomp(entry_blocks.pop())
IndexError: pop from empty list
```

I also had to make a small adjustment to the finalize method so that we don't divide the cell after an error ends the sim early.