### PR TITLE
Use measured protein deg rates

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/translation.py
+++ b/reconstruction/ecoli/dataclasses/process/translation.py
@@ -71,8 +71,9 @@ class Translation(object):
 
 		# Calculate degradation rates based on N-rule
 		# TODO: citation
-		fastRate = (np.log(2) / (2*units.min)).asUnit(1 / units.s)
-		slowRate = (np.log(2) / (10*60*units.min)).asUnit(1 / units.s)
+		deg_rate_units = 1 / units.s
+		fastRate = (np.log(2) / (2*units.min)).asNumber(deg_rate_units)
+		slowRate = (np.log(2) / (10*60*units.min)).asNumber(deg_rate_units)
 
 		fastAAs = ["R", "K", "F", "L", "W", "Y"]
 		slowAAs = ["H", "I", "D", "E", "N", "Q", "C", "A", "S", "T", "G", "V", "M"]
@@ -95,12 +96,20 @@ class Translation(object):
 		ribosomalProteins.extend([x[:-3] for x in sim_data.moleculeGroups.s30_proteins])
 		ribosomalProteins.extend([x[:-3] for x in sim_data.moleculeGroups.s50_proteins])
 
+		# Get degradation rates from measured protein half lives
+		measured_deg_rates = {
+			p['id']: (np.log(2) / p['half life']).asNumber(deg_rate_units)
+			for p in raw_data.protein_half_lives
+			}
+
 		degRate = np.zeros(len(raw_data.proteins))
 		for i,m in enumerate(raw_data.proteins):
-			if m['id'] not in ribosomalProteins:
-				degRate[i] = NruleDegRate[m['seq'][0]].asNumber()
+			if m['id'] in measured_deg_rates:
+				degRate[i] = measured_deg_rates[m['id']]
+			elif m['id'] not in ribosomalProteins:
+				degRate[i] = NruleDegRate[m['seq'][0]]
 			else:
-				degRate[i] = slowRate.asNumber()
+				degRate[i] = slowRate
 
 		monomerData = np.zeros(
 			size,
@@ -126,7 +135,7 @@ class Translation(object):
 		field_units = {
 			'id'		:	None,
 			'rnaId'		:	None,
-			'degRate'	:	1 / units.s,
+			'degRate'	:	deg_rate_units,
 			'length'	:	units.aa,
 			'aaCounts'	:	units.aa,
 			'mw'		:	units.g / units.mol,

--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -41,13 +41,11 @@ TRANSLATION_EFFICIENCIES_ADJUSTMENTS = {
 RNA_EXPRESSION_ADJUSTMENTS = {
 	"EG11493_RNA[c]": 10,  # pabC, aminodeoxychorismate lyase
 	"EG12438_RNA[c]": 10,  # menH, 2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate synthetase
-	"EG10139_RNA[c]": 10,  # cdsA, CDP-diglyceride synthetase
 	"EG12298_RNA[c]": 10,  # yibQ, Predicted polysaccharide deacetylase; This RNA is fit for the anaerobic condition viability
 	"EG11672_RNA[c]": 10,  # atoB, acetyl-CoA acetyltransferase; This RNA is fit for the anaerobic condition viability
 	}
 RNA_DEG_RATES_ADJUSTMENTS = {
 	"EG11493_RNA[c]": 2,  # pabC, aminodeoxychorismate lyase
-	"EG10139_RNA[c]": 2,  # cdsA, CDP-diglyceride synthetase
 	}
 PROTEIN_DEG_RATES_ADJUSTMENTS = {
 	"EG12298-MONOMER[p]": 0.1, # yibQ, Predicted polysaccharide deacetylase; This protein is fit for the anaerobic condition

--- a/reconstruction/ecoli/flat/protein_half_lives.tsv
+++ b/reconstruction/ecoli/flat/protein_half_lives.tsv
@@ -1,0 +1,9 @@
+# Measured half lives, other proteins follow N-end rule in code
+"id"	"half life (units.h)"	"comments"
+"DCUR-MONOMER"	1.8	"DcuR"
+"DETHIOBIOTIN-SYN-MONOMER"	5.4	"BioD"
+"EG10863-MONOMER"	0.6	"Rph"
+"CARBPSYN-SMALL"	14.1	"CarA"
+"EG10743-MONOMER"	16.2	"Pnp"
+"GLUTCYSLIG-MONOMER"	39.7	"GshA"
+"CDPDIGLYSYN-MONOMER"	10.0	"CdsA, unable to measure exactly but measured as longer than expected 2 min from N-end rule so default to 10 hr from N-end rule"

--- a/reconstruction/ecoli/knowledge_base_raw.py
+++ b/reconstruction/ecoli/knowledge_base_raw.py
@@ -42,6 +42,7 @@ LIST_OF_DICT_FILENAMES = (
 	"polymerized.tsv",
 	"previousBiomassFluxes.tsv",
 	"promoters.tsv",
+	"protein_half_lives.tsv",
 	"proteinComplexes.tsv",
 	"proteins.tsv",
 	"reactions.tsv",


### PR DESCRIPTION
This adds a flat file with the protein half lives measured for our paper and sets the deg rate for these based on the half life.  As was mentioned at our meeting, it was not possible to determine an exact half life for CdsA because of the increasing intensity so we are defaulting to 10 hr instead of 2 min.  I also removed the previous tweaks we had for CdsA because the new half life takes care of the issues we had with no counts.

This is currently for the `release-paper` branch but will get moved over to `master` as well.  Once the new options are merged in, I will also be able to add an option to turn this off for comparison purposes in the paper.