### PR TITLE
Interpret month as base-10

### DIFF
--- a/runscripts/jenkins/purge.sh
+++ b/runscripts/jenkins/purge.sh
@@ -39,7 +39,7 @@ fi
 DIR="/scratch/PI/mcovert/wc_ecoli/$DIR_TO_PURGE"
 
 # Only deletes files from one month which is selected by MONTHS_AGO_TO_PURGE months prior to today
-MONTH=$(($(date +%m) - $MONTHS_AGO_TO_PURGE))
+MONTH=$((10#$(date +%m) - $MONTHS_AGO_TO_PURGE))
 YEAR=$(date +%Y)
 while [ $MONTH -lt 1 ]; do
 	MONTH=$(($MONTH + 12))


### PR DESCRIPTION
Fun tidbit, bash will interpret 08 (or any value with a leading zero) as an octal number so the daily build was failing since 08 is not a valid octal number.  This forces interpretation of the month to be base-10 since `date` doesn't have an option to return the month without a leading 0 so that when it is 08 or 09, the purge script won't fail.