### PR TITLE
Ensure ribosome elongation rates never fall to zero

### DIFF
--- a/models/ecoli/processes/polypeptide_initiation.py
+++ b/models/ecoli/processes/polypeptide_initiation.py
@@ -77,7 +77,7 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 			self.variable_elongation)
 
 		# ensure rates are never zero
-		self.elongation_rates = np.fmax(elongation_rates, 1)
+		self.elongation_rates = np.fmax(self.elongation_rates, 1)
 
 	def evolveState(self):
 		# Calculate number of ribosomes that could potentially be initalized based on


### PR DESCRIPTION
Based on a recent gcloud workflow run, sometimes the stochastic rounding for elongation rates in `polypeptide_elongation.py` produced zero values if the time step was short (which it is for the first five time steps), leading to nans and ensuing chaos. 

This PR enforces the minimum elongation rate to be 1, avoiding dividing by zero and ensuring the simulation will continue to run past the first few steps in the cases where this occurred.