### PR TITLE
Pass in elongation option

### DIFF
--- a/wholecell/utils/random.py
+++ b/wholecell/utils/random.py
@@ -86,8 +86,14 @@ def make_elongation_rates(
 		time_step,
 		flat_elongation=False):
 
-	rates = make_elongation_rates_flat(size, base, amplified, ceiling)
-	rates = stochasticRound(random, rates * time_step)
+	if flat_elongation:
+		base = stochasticRound(random, base * time_step)
+
+	rates = make_elongation_rates_flat(size, base, amplified, ceiling, flat_elongation)
+
+	if not flat_elongation:
+		rates = stochasticRound(random, rates * time_step)
+
 	return np.array(rates, dtype=np.int64)
 
 def randomlySelectRows(randomState, mat, prob):


### PR DESCRIPTION
@tahorst pointed out that in the paper branch the elongation option was not making it all the way to the function that needed it. Also, if elongation is flat we want to use the same rate everywhere, so do the stochasticRound before generating the elongation rates vector. 