### PR TITLE
Add average to cellCycleLength

### DIFF
--- a/models/ecoli/analysis/multigen/cellCycleLength.py
+++ b/models/ecoli/analysis/multigen/cellCycleLength.py
@@ -42,10 +42,13 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			cellCycleLengths.append((time[-1] - time[0]) / 60.)
 			generations.append(idx)
 
+		ave_length = np.mean(cellCycleLengths)
+
 		plt.scatter(generations, cellCycleLengths)
 		plt.xlabel('Generation')
 		plt.ylabel('Time (min)')
-		plt.title('Cell cycle lengths')
+		plt.title('Cell cycle lengths\nAverage: {:.1f} min'.format(ave_length))
+		plt.axhline(ave_length, color='k', linestyle='--', linewidth=1)
 		plt.xticks(generations)
 		y_min, y_max = plt.ylim()
 		plt.ylim([np.floor(y_min), np.ceil(y_max)])


### PR DESCRIPTION
Simple update to a plot to add a dashed line at the average cell length and add the average value to the title for easier comparison.

Before:
![old_cellCycleLength](https://user-images.githubusercontent.com/18123227/63196952-614be000-c02b-11e9-8ff6-717199b288f1.png)

After:
![cellCycleLength](https://user-images.githubusercontent.com/18123227/63196961-6577fd80-c02b-11e9-831c-9d93d09f4fc8.png)
