### PR TITLE
Fix option check

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -33,7 +33,7 @@ class Transcription(object):
 
 		# Load rna half lives
 		rna_half_life_file = "raw_data.rnas"
-		if options['alternate_rna_half_life'] != None:
+		if options['alternate_rna_half_life']:
 			rna_half_life_file += "_alternate_half_lives_without_kas"
 		rnaDegRates = np.log(2) / np.array([rna['halfLife'] for rna in eval(rna_half_life_file)])  # seconds
 		rnaLens = np.array([len(rna['seq']) for rna in raw_data.rnas])


### PR DESCRIPTION
This should fix the issue seen in the subgenerational expression plot (#644).  The option was bool so checking against None always evaluated to True and the alternate half lives so we were getting more RNA expression and degradation.

Checking after 2 gens shows ~57% of genes expressed in both gens which is in line with what was seen before the problem merge vs >70% after 2 gens after the merge so I'd expect a similar plot as before once we simulate 32 gens.