### PR TITLE
Fix analysis plots

### DIFF
--- a/models/ecoli/analysis/multigen/biosynthesisProductionDynamics.py
+++ b/models/ecoli/analysis/multigen/biosynthesisProductionDynamics.py
@@ -146,20 +146,20 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			for tfIdx, tf in enumerate(tfs):
 				monomerId = tfToMonomerId[tf]
 				monomerIdx = bulkMoleculeIds.index(monomerId)
-				monomerCounts = bulkMoleculeCounts[:, monomerIdx].reshape(-1)
+				monomerCounts = bulkMoleculeCounts[:, monomerIdx].copy()
 				if tf in tfToComplexId:
 					complexId = tfToComplexId[tf]
 					complexIdx = bulkMoleculeIds.index(complexId)
-					complexCounts = bulkMoleculeCounts[:, complexIdx].reshape(-1)
+					complexCounts = bulkMoleculeCounts[:, complexIdx].copy()
 
 					monomerCounts += (tfToComplexStoich[tf] * complexCounts)
 
 				rnaId = tfToRNAId[tf]
 				rnaIdx = bulkMoleculeIds.index(rnaId)
-				rnaCounts = bulkMoleculeCounts[:, rnaIdx].reshape(-1)
+				rnaCounts = bulkMoleculeCounts[:, rnaIdx].copy()
 
 				synthProbIdx = rnaSynthProbIds.index(rnaId)
-				synthProb = synthProbs[:, synthProbIdx].reshape(-1)
+				synthProb = synthProbs[:, synthProbIdx].copy()
 
 				# Compute moving averages
 				width = 100

--- a/models/ecoli/analysis/multigen/carRegulation.py
+++ b/models/ecoli/analysis/multigen/carRegulation.py
@@ -71,11 +71,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Load data from bulk molecules
 			bulkMoleculesReader = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 			bulkMoleculeIds = bulkMoleculesReader.readAttribute("objectNames")
+			bulkMoleculeCounts = bulkMoleculesReader.readColumn("counts")
 
 			# Get the concentration of intracellular arg
 			argId = ["ARG[c]"]
 			argIndex = np.array([bulkMoleculeIds.index(x) for x in argId])
-			argCounts = bulkMoleculesReader.readColumn("counts")[:, argIndex].reshape(-1)
+			argCounts = bulkMoleculeCounts[:, argIndex].reshape(-1)
 			argMols = 1. / nAvogadro * argCounts
 			volume = cellMass / cellDensity
 			argConcentration = argMols * 1. / volume
@@ -83,36 +84,36 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Get the amount of active argR (that is promoter bound)
 			argRActiveId = ["CPLX0-228[c]"]
 			argRActiveIndex = np.array([bulkMoleculeIds.index(x) for x in argRActiveId])
-			argRActiveCounts = bulkMoleculesReader.readColumn("counts")[:, argRActiveIndex].reshape(-1)
+			argRActiveCounts = bulkMoleculeCounts[:, argRActiveIndex].reshape(-1)
 
 			# Get the amount of inactive argR
 			argRInactiveId = ["PC00005[c]"]
 			argRInactiveIndex = np.array([bulkMoleculeIds.index(x) for x in argRInactiveId])
-			argRInactiveCounts = bulkMoleculesReader.readColumn("counts")[:, argRInactiveIndex].reshape(-1)
+			argRInactiveCounts = bulkMoleculeCounts[:, argRInactiveIndex].reshape(-1)
 
 			# Get the amount of monomeric argR
 			argRMonomerId = ["PD00194[c]"]
 			argRMonomerIndex = np.array([bulkMoleculeIds.index(x) for x in argRMonomerId])
-			argRMonomerCounts = bulkMoleculesReader.readColumn("counts")[:, argRMonomerIndex].reshape(-1)
+			argRMonomerCounts = bulkMoleculeCounts[:, argRMonomerIndex].reshape(-1)
 
 			# Get the promoter-bound status for all regulated genes
 			tfBoundIndex = np.array([bulkMoleculeIds.index(x) for x in tfBoundIds])
-			tfBoundCounts = bulkMoleculesReader.readColumn("counts")[:, tfBoundIndex]
+			tfBoundCounts = bulkMoleculeCounts[:, tfBoundIndex]
 
 			# Get the amount of monomeric carA
 			carAProteinId = ["CARBPSYN-SMALL[c]"]
 			carAProteinIndex = np.array([bulkMoleculeIds.index(x) for x in carAProteinId])
-			carAProteinCounts = bulkMoleculesReader.readColumn("counts")[:, carAProteinIndex].reshape(-1)
+			carAProteinCounts = bulkMoleculeCounts[:, carAProteinIndex].reshape(-1)
 
 			# Get the amount of complexed carA
 			carAComplexId = ["CARBPSYN-CPLX[c]"]
 			carAComplexIndex = np.array([bulkMoleculeIds.index(x) for x in carAComplexId])
-			carAComplexCounts = bulkMoleculesReader.readColumn("counts")[:, carAComplexIndex].reshape(-1)
+			carAComplexCounts = bulkMoleculeCounts[:, carAComplexIndex].reshape(-1)
 
 			# Get the amount of carA mRNA
 			carARnaId = ["EG10134_RNA[c]"]
 			carARnaIndex = np.array([bulkMoleculeIds.index(x) for x in carARnaId])
-			carARnaCounts = bulkMoleculesReader.readColumn("counts")[:, carARnaIndex].reshape(-1)
+			carARnaCounts = bulkMoleculeCounts[:, carARnaIndex].reshape(-1)
 
 			bulkMoleculesReader.close()
 

--- a/models/ecoli/analysis/multigen/growthAffectingPolymerases.py
+++ b/models/ecoli/analysis/multigen/growthAffectingPolymerases.py
@@ -79,9 +79,10 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Get free counts
 			bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 			moleculeIds = bulkMolecules.readAttribute("objectNames")
+			bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 			rnapId = "APORNAP-CPLX[c]"
 			rnapIndex = moleculeIds.index(rnapId)
-			rnapCountsBulk = bulkMolecules.readColumn("counts")[:, rnapIndex]
+			rnapCountsBulk = bulkMoleculeCounts[:, rnapIndex]
 			bulkMolecules.close()
 
 			# Get active counts
@@ -134,15 +135,15 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 			# Get counts of 30S and 50S mRNA, rProteins, rRNA, and full complex counts
 			initialTime = TableReader(os.path.join(simOutDir, "Main")).readAttribute("initialTime")
-			freeProteinCounts30S = bulkMolecules.readColumn("counts")[:, proteinIndexes30S]
-			rnaCounts30S = bulkMolecules.readColumn("counts")[:, rnaIndexes30S]
-			freeRRnaCounts30S = bulkMolecules.readColumn("counts")[:, rRnaIndexes30S]
-			complexCounts30S = bulkMolecules.readColumn("counts")[:, complexIndexes30S]
+			freeProteinCounts30S = bulkMoleculeCounts[:, proteinIndexes30S]
+			rnaCounts30S = bulkMoleculeCounts[:, rnaIndexes30S]
+			freeRRnaCounts30S = bulkMoleculeCounts[:, rRnaIndexes30S]
+			complexCounts30S = bulkMoleculeCounts[:, complexIndexes30S]
 
-			freeProteinCounts50S = bulkMolecules.readColumn("counts")[:, proteinIndexes50S]
-			rnaCounts50S = bulkMolecules.readColumn("counts")[:, rnaIndexes50S]
-			freeRRnaCounts50S = bulkMolecules.readColumn("counts")[:, rRnaIndexes50S]
-			complexCounts50S = bulkMolecules.readColumn("counts")[:, complexIndexes50S]
+			freeProteinCounts50S = bulkMoleculeCounts[:, proteinIndexes50S]
+			rnaCounts50S = bulkMoleculeCounts[:, rnaIndexes50S]
+			freeRRnaCounts50S = bulkMoleculeCounts[:, rRnaIndexes50S]
+			complexCounts50S = bulkMoleculeCounts[:, complexIndexes50S]
 
 			bulkMolecules.close()
 

--- a/models/ecoli/analysis/multigen/ribosomeProduction.py
+++ b/models/ecoli/analysis/multigen/ribosomeProduction.py
@@ -85,14 +85,15 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 			bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 			moleculeIds = bulkMolecules.readAttribute("objectNames")
+			bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 
 			idx_16s = np.array([moleculeIds.index(comp) for comp in ids_16s], np.int)
 			idx_23s = np.array([moleculeIds.index(comp) for comp in ids_23s], np.int)
 			idx_5s = np.array([moleculeIds.index(comp) for comp in ids_5s], np.int)
 
-			rrn16s_count_bulk = bulkMolecules.readColumn("counts")[:, idx_16s].sum(axis=1)
-			rrn23s_count_bulk = bulkMolecules.readColumn("counts")[:, idx_23s].sum(axis=1)
-			rrn5s_count_bulk = bulkMolecules.readColumn("counts")[:, idx_5s].sum(axis=1)
+			rrn16s_count_bulk = bulkMoleculeCounts[:, idx_16s].sum(axis=1)
+			rrn23s_count_bulk = bulkMoleculeCounts[:, idx_23s].sum(axis=1)
+			rrn5s_count_bulk = bulkMoleculeCounts[:, idx_5s].sum(axis=1)
 
 			uniqueMoleculeCounts = TableReader(os.path.join(simOutDir, "UniqueMoleculeCounts"))
 

--- a/models/ecoli/analysis/multigen/rnaVsProteinPerCell.py
+++ b/models/ecoli/analysis/multigen/rnaVsProteinPerCell.py
@@ -108,11 +108,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 				# Account for bulk molecules
 				bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
+				bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 				moleculeIds = bulkMolecules.readAttribute("objectNames")
 				proteinIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in ids_protein], np.int)
-				proteinCountsBulk = bulkMolecules.readColumn("counts")[:, proteinIndexes]
+				proteinCountsBulk = bulkMoleculeCounts[:, proteinIndexes]
 				rnaIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in rnaIds], np.int)
-				avgRnaCounts = bulkMolecules.readColumn("counts")[:, rnaIndexes].mean(axis = 0)
+				avgRnaCounts = bulkMoleculeCounts[:, rnaIndexes].mean(axis = 0)
 				bulkMolecules.close()
 				if i == 0:
 					# Skip first few time steps for 1st generation (becaused complexes have not yet formed during these steps)

--- a/models/ecoli/analysis/multigen/trpRegulation.py
+++ b/models/ecoli/analysis/multigen/trpRegulation.py
@@ -71,11 +71,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Load data from bulk molecules
 			bulkMoleculesReader = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 			bulkMoleculeIds = bulkMoleculesReader.readAttribute("objectNames")
+			bulkMoleculeCounts = bulkMoleculesReader.readColumn("counts")
 
 			# Get the concentration of intracellular trp
 			trpId = ["TRP[c]"]
 			trpIndex = np.array([bulkMoleculeIds.index(x) for x in trpId])
-			trpCounts = bulkMoleculesReader.readColumn("counts")[:, trpIndex].reshape(-1)
+			trpCounts = bulkMoleculeCounts[:, trpIndex].reshape(-1)
 			trpMols = 1. / nAvogadro * trpCounts
 			volume = cellMass / cellDensity
 			trpConcentration = trpMols * 1. / volume
@@ -83,36 +84,36 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Get the amount of active trpR (that isn't promoter bound)
 			trpRActiveId = ["CPLX-125[c]"]
 			trpRActiveIndex = np.array([bulkMoleculeIds.index(x) for x in trpRActiveId])
-			trpRActiveCounts = bulkMoleculesReader.readColumn("counts")[:, trpRActiveIndex].reshape(-1)
+			trpRActiveCounts = bulkMoleculeCounts[:, trpRActiveIndex].reshape(-1)
 
 			# Get the amount of inactive trpR
 			trpRInactiveId = ["PC00007[c]"]
 			trpRInactiveIndex = np.array([bulkMoleculeIds.index(x) for x in trpRInactiveId])
-			trpRInactiveCounts = bulkMoleculesReader.readColumn("counts")[:, trpRInactiveIndex].reshape(-1)
+			trpRInactiveCounts = bulkMoleculeCounts[:, trpRInactiveIndex].reshape(-1)
 
 			# Get the amount of monomeric trpR
 			trpRMonomerId = ["PD00423[c]"]
 			trpRMonomerIndex = np.array([bulkMoleculeIds.index(x) for x in trpRMonomerId])
-			trpRMonomerCounts = bulkMoleculesReader.readColumn("counts")[:, trpRMonomerIndex].reshape(-1)
+			trpRMonomerCounts = bulkMoleculeCounts[:, trpRMonomerIndex].reshape(-1)
 
 			# Get the promoter-bound status for all regulated genes
 			tfBoundIndex = np.array([bulkMoleculeIds.index(x) for x in tfBoundIds])
-			tfBoundCounts = bulkMoleculesReader.readColumn("counts")[:, tfBoundIndex]
+			tfBoundCounts = bulkMoleculeCounts[:, tfBoundIndex]
 
 			# Get the amount of monomeric trpA
 			trpAProteinId = ["TRYPSYN-APROTEIN[c]"]
 			trpAProteinIndex = np.array([bulkMoleculeIds.index(x) for x in trpAProteinId])
-			trpAProteinCounts = bulkMoleculesReader.readColumn("counts")[:, trpAProteinIndex].reshape(-1)
+			trpAProteinCounts = bulkMoleculeCounts[:, trpAProteinIndex].reshape(-1)
 
 			# Get the amount of complexed trpA
 			trpABComplexId = ["TRYPSYN[c]"]
 			trpABComplexIndex = np.array([bulkMoleculeIds.index(x) for x in trpABComplexId])
-			trpABComplexCounts = bulkMoleculesReader.readColumn("counts")[:, trpABComplexIndex].reshape(-1)
+			trpABComplexCounts = bulkMoleculeCounts[:, trpABComplexIndex].reshape(-1)
 
 			# Get the amount of trpA mRNA
 			trpARnaId = ["EG11024_RNA[c]"]
 			trpARnaIndex = np.array([bulkMoleculeIds.index(x) for x in trpARnaId])
-			trpARnaCounts = bulkMoleculesReader.readColumn("counts")[:, trpARnaIndex].reshape(-1)
+			trpARnaCounts = bulkMoleculeCounts[:, trpARnaIndex].reshape(-1)
 
 			bulkMoleculesReader.close()
 

--- a/models/ecoli/analysis/multigen/tyrRegulation.py
+++ b/models/ecoli/analysis/multigen/tyrRegulation.py
@@ -65,10 +65,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Load data from bulk molecules
 			bulkMoleculesReader = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 			bulkMoleculeIds = bulkMoleculesReader.readAttribute("objectNames")
+			bulkMoleculeCounts = bulkMoleculesReader.readColumn("counts")
+
 			# Get the concentration of intracellular phe
 			pheId = ["PHE[c]"]
 			pheIndex = np.array([bulkMoleculeIds.index(x) for x in pheId])
-			pheCounts = bulkMoleculesReader.readColumn("counts")[:, pheIndex].reshape(-1)
+			pheCounts = bulkMoleculeCounts[:, pheIndex].reshape(-1)
 			pheMols = 1. / nAvogadro * pheCounts
 			volume = cellMass / cellDensity
 			pheConcentration = pheMols * 1. / volume
@@ -76,26 +78,26 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Get the amount of active tyrR (that isn't promoter bound)
 			tyrRActiveId = ["MONOMER0-162[c]"]
 			tyrRActiveIndex = np.array([bulkMoleculeIds.index(x) for x in tyrRActiveId])
-			tyrRActiveCounts = bulkMoleculesReader.readColumn("counts")[:, tyrRActiveIndex].reshape(-1)
+			tyrRActiveCounts = bulkMoleculeCounts[:, tyrRActiveIndex].reshape(-1)
 
 			# Get the amount of inactive tyrR
 			tyrRInactiveId = ["PD00413[c]"]
 			tyrRInactiveIndex = np.array([bulkMoleculeIds.index(x) for x in tyrRInactiveId])
-			tyrRInactiveCounts = bulkMoleculesReader.readColumn("counts")[:, tyrRInactiveIndex].reshape(-1)
+			tyrRInactiveCounts = bulkMoleculeCounts[:, tyrRInactiveIndex].reshape(-1)
 
 			# Get the promoter-bound status of the tyrA gene
 			tyrATfBoundId = ["EG11039_RNA__MONOMER0-162"]
 			tyrATfBoundIndex = np.array([bulkMoleculeIds.index(x) for x in tyrATfBoundId])
-			tyrATfBoundCounts = bulkMoleculesReader.readColumn("counts")[:, tyrATfBoundIndex].reshape(-1)
+			tyrATfBoundCounts = bulkMoleculeCounts[:, tyrATfBoundIndex].reshape(-1)
 
 			# Get the amount of monomeric tyrA
 			tyrAProteinId = ["CHORISMUTPREPHENDEHYDROG-MONOMER[c]"]
 			tyrAProteinIndex = np.array([bulkMoleculeIds.index(x) for x in tyrAProteinId])
-			tyrAProteinCounts = bulkMoleculesReader.readColumn("counts")[:, tyrAProteinIndex].reshape(-1)
+			tyrAProteinCounts = bulkMoleculeCounts[:, tyrAProteinIndex].reshape(-1)
 
 			tyrAComplexId = ["CHORISMUTPREPHENDEHYDROG-CPLX[c]"]
 			tyrAComplexIndex = np.array([bulkMoleculeIds.index(x) for x in tyrAComplexId])
-			tyrAComplexCounts = bulkMoleculesReader.readColumn("counts")[:, tyrAComplexIndex].reshape(-1)
+			tyrAComplexCounts = bulkMoleculeCounts[:, tyrAComplexIndex].reshape(-1)
 
 			bulkMoleculesReader.close()
 

--- a/models/ecoli/analysis/single/mrnaVsProteinCounts.py
+++ b/models/ecoli/analysis/single/mrnaVsProteinCounts.py
@@ -40,16 +40,17 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		proteinIds = sim_data.process.translation.monomerData["id"]
 
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
+		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
 
 		rnaIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in rnaIds], np.int)
 
-		rnaCountsBulk = bulkMolecules.readColumn("counts")[:, rnaIndexes]
+		rnaCountsBulk = bulkMoleculeCounts[:, rnaIndexes]
 
 		proteinIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in proteinIds], np.int)
 
-		proteinCountsBulk = bulkMolecules.readColumn("counts")[:, proteinIndexes]
+		proteinCountsBulk = bulkMoleculeCounts[:, proteinIndexes]
 
 		bulkMolecules.close()
 

--- a/models/ecoli/analysis/single/mrnasVsProteinSingle.py
+++ b/models/ecoli/analysis/single/mrnasVsProteinSingle.py
@@ -47,16 +47,17 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		proteinIds = sim_data.process.translation.monomerData["id"]
 
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
+		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
 
 		rnaIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in rnaIds], np.int)
 
-		rnaCountsBulk = bulkMolecules.readColumn("counts")[:, rnaIndexes]
+		rnaCountsBulk = bulkMoleculeCounts[:, rnaIndexes]
 
 		proteinIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in proteinIds], np.int)
 
-		proteinCountsBulk = bulkMolecules.readColumn("counts")[:, proteinIndexes]
+		proteinCountsBulk = bulkMoleculeCounts[:, proteinIndexes]
 
 		initialTime = TableReader(os.path.join(simOutDir, "Main")).readAttribute("initialTime")
 		time = TableReader(os.path.join(simOutDir, "Main")).readColumn("time") - initialTime

--- a/models/ecoli/analysis/single/polymeraseTimeLag.py
+++ b/models/ecoli/analysis/single/polymeraseTimeLag.py
@@ -77,6 +77,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Load count data for s30 proteins, rRNA, and final 30S complex
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
+		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 
 		# Get indexes
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
@@ -84,8 +85,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		rnaIndexes = np.array([moleculeIds.index(comp) for comp in rnaIds])
 
 		# Load data
-		ribosomeSubunitCounts = bulkMolecules.readColumn("counts")[:, ribosomeSubunitIndexes]
-		rnaCounts = bulkMolecules.readColumn("counts")[:, rnaIndexes]
+		ribosomeSubunitCounts = bulkMoleculeCounts[:, ribosomeSubunitIndexes]
+		rnaCounts = bulkMoleculeCounts[:, rnaIndexes]
 
 		bulkMolecules.close()
 

--- a/models/ecoli/analysis/single/ribosome30SCounts.py
+++ b/models/ecoli/analysis/single/ribosome30SCounts.py
@@ -41,6 +41,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Load count data for s30 proteins, rRNA, and final 30S complex
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
+		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
+
 		# Get indexes
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
 		proteinIndexes = np.array([moleculeIds.index(protein) for protein in proteinIds], np.int)
@@ -51,10 +53,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Load data
 		initialTime = TableReader(os.path.join(simOutDir, "Main")).readAttribute("initialTime")
 		time = TableReader(os.path.join(simOutDir, "Main")).readColumn("time") - initialTime
-		freeProteinCounts = bulkMolecules.readColumn("counts")[:, proteinIndexes]
-		rnaCounts = bulkMolecules.readColumn("counts")[:, rnaIndexes]
-		freeRRnaCounts = bulkMolecules.readColumn("counts")[:, rRnaIndexes]
-		complexCounts = bulkMolecules.readColumn("counts")[:, complexIndexes]
+		freeProteinCounts = bulkMoleculeCounts[:, proteinIndexes]
+		rnaCounts = bulkMoleculeCounts[:, rnaIndexes]
+		freeRRnaCounts = bulkMoleculeCounts[:, rRnaIndexes]
+		complexCounts = bulkMoleculeCounts[:, complexIndexes]
 
 		bulkMolecules.close()
 

--- a/models/ecoli/analysis/single/ribosome50SCounts.py
+++ b/models/ecoli/analysis/single/ribosome50SCounts.py
@@ -43,6 +43,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Load count data for s30 proteins, rRNA, and final 30S complex
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
+		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
+
 		# Get indexes
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
 		proteinIndexes = np.array([moleculeIds.index(protein) for protein in proteinIds], np.int)
@@ -53,10 +55,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Load data
 		initialTime = TableReader(os.path.join(simOutDir, "Main")).readAttribute("initialTime")
 		time = TableReader(os.path.join(simOutDir, "Main")).readColumn("time") - initialTime
-		freeProteinCounts = bulkMolecules.readColumn("counts")[:, proteinIndexes]
-		rnaCounts = bulkMolecules.readColumn("counts")[:, rnaIndexes]
-		freeRRnaCounts = bulkMolecules.readColumn("counts")[:, rRnaIndexes]
-		complexCounts = bulkMolecules.readColumn("counts")[:, complexIndexes]
+		freeProteinCounts = bulkMoleculeCounts[:, proteinIndexes]
+		rnaCounts = bulkMoleculeCounts[:, rnaIndexes]
+		freeRRnaCounts = bulkMoleculeCounts[:, rRnaIndexes]
+		complexCounts = bulkMoleculeCounts[:, complexIndexes]
 
 		bulkMolecules.close()
 

--- a/models/ecoli/analysis/single/rnaDegradationCounts.py
+++ b/models/ecoli/analysis/single/rnaDegradationCounts.py
@@ -62,6 +62,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Load count data for s30 proteins, rRNA, and final 30S complex
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
+		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 
 		# Get indexes
 		proteinIndexes = np.array([moleculeIds.index(protein) for protein in RnaseIds], np.int)
@@ -71,10 +72,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Load data
 		initialTime = TableReader(os.path.join(simOutDir, "Main")).readAttribute("initialTime")
 		time = TableReader(os.path.join(simOutDir, "Main")).readColumn("time") - initialTime
-		RnaseCounts = bulkMolecules.readColumn("counts")[:, proteinIndexes]
+		RnaseCounts = bulkMoleculeCounts[:, proteinIndexes]
 
-		exoRnaseCounts = bulkMolecules.readColumn("counts")[:, exoproteinIndexes]
-		endoRnaseCounts = bulkMolecules.readColumn("counts")[:, endoproteinIndexes]
+		exoRnaseCounts = bulkMoleculeCounts[:, exoproteinIndexes]
+		endoRnaseCounts = bulkMoleculeCounts[:, endoproteinIndexes]
 		bulkMolecules.close()
 
 		rnaDegradationListenerFile = TableReader(os.path.join(simOutDir, "RnaDegradationListener"))
@@ -117,7 +118,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
 		NTP_IDS = ['ATP[c]', 'CTP[c]', 'GTP[c]', 'UTP[c]']
 		ntpIndexes = np.array([moleculeIds.index(ntpId) for ntpId in NTP_IDS], np.int)
-		ntpCounts = bulkMolecules.readColumn("counts")[:, ntpIndexes]
+		ntpCounts = bulkMoleculeCounts[:, ntpIndexes]
 		bulkMolecules.close()
 
 

--- a/models/ecoli/analysis/single/rnapCounts.py
+++ b/models/ecoli/analysis/single/rnapCounts.py
@@ -27,15 +27,16 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			os.mkdir(plotOutDir)
 
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
+		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 
 		moleculeIds = bulkMolecules.readAttribute("objectNames")
 		rnapId = "APORNAP-CPLX[c]"
 		rnapIndex = moleculeIds.index(rnapId)
-		rnapCountsBulk = bulkMolecules.readColumn("counts")[:, rnapIndex]
+		rnapCountsBulk = bulkMoleculeCounts[:, rnapIndex]
 
 		RNAP_RNA_IDS = ["EG10893_RNA[c]", "EG10894_RNA[c]", "EG10895_RNA[c]", "EG10896_RNA[c]"]
 		rnapRnaIndexes = np.array([moleculeIds.index(rnapRnaId) for rnapRnaId in RNAP_RNA_IDS], np.int)
-		rnapRnaCounts = bulkMolecules.readColumn("counts")[:, rnapRnaIndexes]
+		rnapRnaCounts = bulkMoleculeCounts[:, rnapRnaIndexes]
 
 		bulkMolecules.close()
 

--- a/models/ecoli/analysis/single/trpRegulation.py
+++ b/models/ecoli/analysis/single/trpRegulation.py
@@ -52,11 +52,12 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Load data from bulk molecules
 		bulkMoleculesReader = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 		bulkMoleculeIds = bulkMoleculesReader.readAttribute("objectNames")
+		bulkMoleculeCounts = bulkMoleculesReader.readColumn("counts")
 
 		# Get the concentration of intracellular trp
 		trpId = ["TRP[c]"]
 		trpIndex = np.array([bulkMoleculeIds.index(x) for x in trpId])
-		trpCounts = bulkMoleculesReader.readColumn("counts")[:, trpIndex].reshape(-1)
+		trpCounts = bulkMoleculeCounts[:, trpIndex].reshape(-1)
 		trpMols = 1. / nAvogadro * trpCounts
 		volume = cellMass / cellDensity
 		trpConcentration = trpMols * 1. / volume
@@ -64,32 +65,32 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Get the amount of active trpR (that isn't promoter bound)
 		trpRActiveId = ["CPLX-125[c]"]
 		trpRActiveIndex = np.array([bulkMoleculeIds.index(x) for x in trpRActiveId])
-		trpRActiveCounts = bulkMoleculesReader.readColumn("counts")[:, trpRActiveIndex].reshape(-1)
+		trpRActiveCounts = bulkMoleculeCounts[:, trpRActiveIndex].reshape(-1)
 
 		# Get the amount of inactive trpR
 		trpRInactiveId = ["PC00007[c]"]
 		trpRInactiveIndex = np.array([bulkMoleculeIds.index(x) for x in trpRInactiveId])
-		trpRInactiveCounts = bulkMoleculesReader.readColumn("counts")[:, trpRInactiveIndex].reshape(-1)
+		trpRInactiveCounts = bulkMoleculeCounts[:, trpRInactiveIndex].reshape(-1)
 
 		# Get the amount of monomeric trpR
 		trpRMonomerId = ["PD00423[c]"]
 		trpRMonomerIndex = np.array([bulkMoleculeIds.index(x) for x in trpRMonomerId])
-		trpRMonomerCounts = bulkMoleculesReader.readColumn("counts")[:, trpRMonomerIndex].reshape(-1)
+		trpRMonomerCounts = bulkMoleculeCounts[:, trpRMonomerIndex].reshape(-1)
 
 		# Get the promoter-bound status for all regulated genes
 		tfBoundIds = [target + "__CPLX-125" for target in sim_data.tfToFC["CPLX-125"].keys()]
 		tfBoundIndex = np.array([bulkMoleculeIds.index(x) for x in tfBoundIds])
-		tfBoundCounts = bulkMoleculesReader.readColumn("counts")[:, tfBoundIndex]
+		tfBoundCounts = bulkMoleculeCounts[:, tfBoundIndex]
 
 		# Get the amount of monomeric trpA
 		trpAProteinId = ["TRYPSYN-APROTEIN[c]"]
 		trpAProteinIndex = np.array([bulkMoleculeIds.index(x) for x in trpAProteinId])
-		trpAProteinCounts = bulkMoleculesReader.readColumn("counts")[:, trpAProteinIndex].reshape(-1)
+		trpAProteinCounts = bulkMoleculeCounts[:, trpAProteinIndex].reshape(-1)
 
 		# Get the amount of complexed trpA
 		trpABComplexId = ["TRYPSYN[c]"]
 		trpABComplexIndex = np.array([bulkMoleculeIds.index(x) for x in trpABComplexId])
-		trpABComplexCounts = bulkMoleculesReader.readColumn("counts")[:, trpABComplexIndex].reshape(-1)
+		trpABComplexCounts = bulkMoleculeCounts[:, trpABComplexIndex].reshape(-1)
 
 		bulkMoleculesReader.close()
 

--- a/models/ecoli/analysis/single/tyrRegulation.py
+++ b/models/ecoli/analysis/single/tyrRegulation.py
@@ -52,10 +52,12 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Load data from bulk molecules
 		bulkMoleculesReader = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 		bulkMoleculeIds = bulkMoleculesReader.readAttribute("objectNames")
+		bulkMoleculeCounts = bulkMoleculesReader.readColumn("counts")
+
 		# Get the concentration of intracellular phe
 		pheId = ["PHE[c]"]
 		pheIndex = np.array([bulkMoleculeIds.index(x) for x in pheId])
-		pheCounts = bulkMoleculesReader.readColumn("counts")[:, pheIndex].reshape(-1)
+		pheCounts = bulkMoleculeCounts[:, pheIndex].reshape(-1)
 		pheMols = 1. / nAvogadro * pheCounts
 		volume = cellMass / cellDensity
 		pheConcentration = pheMols * 1. / volume
@@ -63,26 +65,26 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Get the amount of active tyrR (that isn't promoter bound)
 		tyrRActiveId = ["MONOMER0-162[c]"]
 		tyrRActiveIndex = np.array([bulkMoleculeIds.index(x) for x in tyrRActiveId])
-		tyrRActiveCounts = bulkMoleculesReader.readColumn("counts")[:, tyrRActiveIndex].reshape(-1)
+		tyrRActiveCounts = bulkMoleculeCounts[:, tyrRActiveIndex].reshape(-1)
 
 		# Get the amount of inactive tyrR
 		tyrRInactiveId = ["PD00413[c]"]
 		tyrRInactiveIndex = np.array([bulkMoleculeIds.index(x) for x in tyrRInactiveId])
-		tyrRInactiveCounts = bulkMoleculesReader.readColumn("counts")[:, tyrRInactiveIndex].reshape(-1)
+		tyrRInactiveCounts = bulkMoleculeCounts[:, tyrRInactiveIndex].reshape(-1)
 
 		# Get the promoter-bound status of the tyrA gene
 		tyrATfBoundId = ["EG11039_RNA__MONOMER0-162"]
 		tyrATfBoundIndex = np.array([bulkMoleculeIds.index(x) for x in tyrATfBoundId])
-		tyrATfBoundCounts = bulkMoleculesReader.readColumn("counts")[:, tyrATfBoundIndex].reshape(-1)
+		tyrATfBoundCounts = bulkMoleculeCounts[:, tyrATfBoundIndex].reshape(-1)
 
 		# Get the amount of monomeric tyrA
 		tyrAProteinId = ["CHORISMUTPREPHENDEHYDROG-MONOMER[c]"]
 		tyrAProteinIndex = np.array([bulkMoleculeIds.index(x) for x in tyrAProteinId])
-		tyrAProteinCounts = bulkMoleculesReader.readColumn("counts")[:, tyrAProteinIndex].reshape(-1)
+		tyrAProteinCounts = bulkMoleculeCounts[:, tyrAProteinIndex].reshape(-1)
 
 		tyrAComplexId = ["CHORISMUTPREPHENDEHYDROG-CPLX[c]"]
 		tyrAComplexIndex = np.array([bulkMoleculeIds.index(x) for x in tyrAComplexId])
-		tyrAComplexCounts = bulkMoleculesReader.readColumn("counts")[:, tyrAComplexIndex].reshape(-1)
+		tyrAComplexCounts = bulkMoleculeCounts[:, tyrAComplexIndex].reshape(-1)
 
 		bulkMoleculesReader.close()
 

--- a/models/ecoli/analysis/variant/meneSensitivity.py
+++ b/models/ecoli/analysis/variant/meneSensitivity.py
@@ -75,10 +75,12 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 						# Get molecule counts
 						bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 						moleculeIds = bulkMolecules.readAttribute("objectNames")
+						bulkMoleculeCounts = bulkMolecules.readColumn("counts")
+
 						meneIndex = moleculeIds.index(enzymeId)
-						meneCounts = bulkMolecules.readColumn("counts")[:, meneIndex]
+						meneCounts = bulkMoleculeCounts[:, meneIndex]
 						endProductIndices = [moleculeIds.index(x) for x in endProductIds]
-						endProductCounts = bulkMolecules.readColumn("counts")[:, endProductIndices]
+						endProductCounts = bulkMoleculeCounts[:, endProductIndices]
 						bulkMolecules.close()
 
 						# Compute time with zero counts of tetramer (MENE-CPLX)


### PR DESCRIPTION
This pulls the fixes from #276 back to `release-paper`.  After running Set A for the paper, the multigen analysis got killed on biosynthesisProductionDynamics.  This should prevent that without bumping up the number of cpus and also improve analysis speed for other plots with the large sims we are running.