### PR TITLE
Round independent molecules conservatively in TCS

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -417,13 +417,8 @@ class TwoComponentSystem(object):
 		yMolecules = y * (cellVolume * nAvogadro)
 		dYMolecules = yMolecules[-1, :] - yMolecules[0, :]
 
-		independentMoleculesCounts = dYMolecules[self.independent_molecule_indexes]
-
-		# Round conservatively
-		independentMoleculesCounts[independentMoleculesCounts < 0] = np.ceil(
-			independentMoleculesCounts[independentMoleculesCounts < 0])
-		independentMoleculesCounts[independentMoleculesCounts > 0] = np.floor(
-			independentMoleculesCounts[independentMoleculesCounts > 0])
+		# Isolate independent molecules and round conservatively via trunc
+		independentMoleculesCounts = np.trunc(dYMolecules[self.independent_molecule_indexes])
 
 		# To ensure that we have non-negative counts of phosphate, we must
 		# have the following (which can be seen from the dependency matrix)


### PR DESCRIPTION
- Replaces rounding method (np.round) with a conservative rounding strategy to avoid negative counts of molecules
- Addresses -1 ATP issue described in #641 