### PR TITLE
Correct activation probabilities for transcription and translation

### DIFF
--- a/models/ecoli/processes/polypeptide_initiation.py
+++ b/models/ecoli/processes/polypeptide_initiation.py
@@ -73,7 +73,7 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 		self.elongation_rates = self.make_elongation_rates(
 			self.randomState,
 			self.ribosomeElongationRate,
-			self.timeStepSec(),
+			1,  # want elongation rate, not lengths adjusted for time step
 			self.variable_elongation)
 
 		# ensure rates are never zero
@@ -148,7 +148,7 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 		# averageTranslationTimeStepCounts: Average number of timesteps required to translate a protein, weighted by initiation probabilities
 		# expectedTerminationRate: Average number of terminations in one timestep for one protein
 		allTranslationTimes = 1. / ribosomeElongationRates * proteinLengths
-		allTranslationTimestepCounts = np.ceil(allTranslationTimes / (timeStepSec * 1.0))
+		allTranslationTimestepCounts = np.ceil(allTranslationTimes / timeStepSec)
 		averageTranslationTimestepCounts = np.dot(allTranslationTimestepCounts, proteinInitProb)
 		expectedTerminationRate = 1.0 / averageTranslationTimestepCounts
 
@@ -156,7 +156,7 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 		# allFractionTimeInactive: Vector of probabilities an "active" ribosome will in effect be "inactive" because it has terminated during a timestep
 		# averageFractionTimeInactive: Average probability of an "active" ribosome being in effect "inactive", weighted by initiation probabilities
 		# effectiveFracActiveRnap: New higher "goal" for fraction of active ribosomes, considering that the "effective" fraction is lower than what the listener sees
-		allFractionTimeInactive = 1 - allTranslationTimes / (timeStepSec * 1.0) / allTranslationTimestepCounts
+		allFractionTimeInactive = 1 - allTranslationTimes / timeStepSec / allTranslationTimestepCounts
 		averageFractionTimeInactive = np.dot(allFractionTimeInactive, proteinInitProb)
 		effectiveFracActiveRibosome = fracActiveRibosome * 1 / (1 - averageFractionTimeInactive)
 

--- a/models/ecoli/processes/transcript_initiation.py
+++ b/models/ecoli/processes/transcript_initiation.py
@@ -172,7 +172,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 		self.elongation_rates = self.make_elongation_rates(
 			self.randomState,
 			self.rnaPolymeraseElongationRate.asNumber(units.nt / units.s),
-			self.timeStepSec(),
+			1,  # want elongation rate, not lengths adjusted for time step
 			self.variable_elongation)
 
 
@@ -180,7 +180,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 		# Get attributes of promoters
 		TU_index, coordinates_promoters, domain_index_promoters, bound_TF = self.promoters.attrs(
 			"TU_index", "coordinates", "domain_index", "bound_TF")
-		
+
 		# Construct matrix that maps promoters to transcription units
 		n_promoters = len(TU_index)
 		TU_to_promoter = scipy.sparse.csr_matrix(


### PR DESCRIPTION
This fixes #645.  Looking at the first 4 gens of a sim with the fix, the doubling time doesn't quite reach what it was before but is still a minute faster for each generation when compared to after the problem merge (see comparison plots for 16 gens in #645).  The small remaining difference might just be changes to the polymerize function.

![cellCycleLength](https://user-images.githubusercontent.com/18123227/63629624-ffa9e980-c5c7-11e9-9e19-80d1655a03ed.png)

This issue highlights a discrepancy in nomenclature for `make_elongation_rates`.  A rate would be per time but this function multiplies by the time step so it is more accurately `make_elongation_lengths`.  There are many instances of this throughout the codebase that we might want to consider renaming to prevent future mistakes.

Luckily, this feature didn't make it back to the paper branch so we don't need to change it there or rerun those sims.

Also cleaned up some `*1.0` instances that must have been in place from before the future division import.