### PR TITLE
Properly handle cells with no chromosomes

### DIFF
--- a/models/ecoli/processes/chromosome_replication.py
+++ b/models/ecoli/processes/chromosome_replication.py
@@ -159,13 +159,13 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 		n_active_replisomes = self.active_replisomes.total_counts()[0]
 		n_oriC = self.oriCs.total_counts()[0]
 
-		# Get attributes of existing chromosome domains
-		domain_index_existing_domain, child_domains = self.chromosome_domains.attrs(
-			'domain_index', 'child_domains')
-
 		# If there are no origins, return immediately
 		if n_oriC == 0:
 			return
+
+		# Get attributes of existing chromosome domains
+		domain_index_existing_domain, child_domains = self.chromosome_domains.attrs(
+			'domain_index', 'child_domains')
 
 		# Get number of available replisome subunits
 		n_replisome_trimers = self.replisome_trimers.counts()

--- a/models/ecoli/processes/tf_binding.py
+++ b/models/ecoli/processes/tf_binding.py
@@ -96,6 +96,10 @@ class TfBinding(wholecell.processes.process.Process):
 
 
 	def evolveState(self):
+		# If there are no promoters, return immediately
+		if self.promoters.total_counts() == 0:
+			return
+
 		# Get attributes of all promoters
 		TU_index, coordinates_promoters, domain_index_promoters, bound_TF = self.promoters.attrs(
 			"TU_index", "coordinates", "domain_index", "bound_TF")

--- a/models/ecoli/processes/transcript_initiation.py
+++ b/models/ecoli/processes/transcript_initiation.py
@@ -111,13 +111,13 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 		# Get all inactive RNA polymerases
 		self.inactiveRnaPolys.requestAll()
 
-		# Get attributes of promoters
-		TU_index, bound_TF = self.promoters.attrs("TU_index", "bound_TF")
-
 		# Read current environment
 		current_media_id = self._external_states['Environment'].current_media_id
 
 		if self.full_chromosomes.total_counts()[0] > 0:
+			# Get attributes of promoters
+			TU_index, bound_TF = self.promoters.attrs("TU_index", "bound_TF")
+
 			# Calculate probabilities of the RNAP binding to each promoter
 			self.promoter_init_probs = (self.basal_prob[TU_index] +
 				np.multiply(self.delta_prob_matrix[TU_index, :], bound_TF).sum(axis=1))
@@ -165,7 +165,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 
 		# If there are no chromosomes in the cell, set all probs to zero
 		else:
-			self.promoter_init_probs = np.zeros(len(TU_index))
+			self.promoter_init_probs = np.zeros(self.promoters.total_counts())
 
 		self.fracActiveRnap = self.fracActiveRnapDict[current_media_id]
 		self.rnaPolymeraseElongationRate = self.rnaPolymeraseElongationRateDict[current_media_id]
@@ -177,12 +177,18 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 
 
 	def evolveState(self):
+		# no synthesis if no chromosome
+		if self.full_chromosomes.total_counts()[0] == 0:
+			self.writeToListener(
+				"RnaSynthProb", "rnaSynthProb", np.zeros(self.n_TUs))
+			return
+
 		# Get attributes of promoters
 		TU_index, coordinates_promoters, domain_index_promoters, bound_TF = self.promoters.attrs(
 			"TU_index", "coordinates", "domain_index", "bound_TF")
 		
 		# Construct matrix that maps promoters to transcription units
-		n_promoters = len(TU_index)
+		n_promoters = self.promoters.total_counts()
 		TU_to_promoter = scipy.sparse.csr_matrix(
 			(np.ones(n_promoters), (TU_index, np.arange(n_promoters))),
 			shape = (self.n_TUs, n_promoters))
@@ -199,10 +205,6 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 				np.arange(self.n_TUs),
 				TU_synth_probs[self.shuffleIdxs],
 				TU_index)
-
-		# no synthesis if no chromosome
-		if self.full_chromosomes.total_counts()[0] == 0:
-			return
 
 		# Calculate RNA polymerases to activate based on probabilities
 		self.activationProb = self._calculateActivationProb(


### PR DESCRIPTION
This partially addresses #659. Our anaerobic daily builds have been failing because generation 5 failed to divide its chromosome within the 3hr limit, and the resulting daughter cell did not have a chromosome, causing issues with some processes that assume that there's at least one chromosome in the cell. This pr should stop the builds from failing, but generation 5 being unable to grow properly seems to be coming from different problem.