### PR TITLE
Fix analyses that fail with zero chromosomes

### DIFF
--- a/models/ecoli/analysis/single/mRnaHalfLives.py
+++ b/models/ecoli/analysis/single/mRnaHalfLives.py
@@ -118,6 +118,9 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 					expectedDegR.append(expectedDegradationRate[i])
 					predictedDegR.append(rnaDegradationRate3[i])
 
+		if len(expectedDegR) == 0:
+			print("Skipping analysis - no RNAs synthesized during this generation")
+			return
 
 		plt.figure(figsize = (8.5, 11))
 		maxLine = 1.1 * max(max(expectedDegR), max(predictedDegR))

--- a/models/ecoli/analysis/single/replication.py
+++ b/models/ecoli/analysis/single/replication.py
@@ -64,8 +64,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			"uniqueMoleculeCounts")[:, full_chromosome_index]
 
 		# Count critical initiation mass equivalents
-		# criticalInitiationMass[0] = criticalInitiationMass[1]
-		criticalMassEquivalents = totalMass / criticalInitiationMass
+		if np.all(criticalInitiationMass > 0):
+			criticalMassEquivalents = totalMass / criticalInitiationMass
+		else:  # Cell does not have any chromosomes
+			criticalMassEquivalents = np.zeros_like(totalMass)
 
 		# Plot stuff
 		plt.figure(figsize = (8.5, 11))


### PR DESCRIPTION
This also partially addresses #659 by fixing single analyses scripts that fail for cells without chromosomes.