### PR TITLE
Add runscripts to get sims & figures for figure S2

### DIFF
--- a/runscripts/paper/paper_figures.sh
+++ b/runscripts/paper/paper_figures.sh
@@ -6,70 +6,67 @@
 ## Figure 1
 #Bottom Simulations Left to Right, Top to bottom:
  python models/ecoli/analysis/multigen/growth_dynamics_grid.py \
- /scratch/PI/mcovert/wc_ecoli/paper/SET_B/20180822.181305.660233__SET_B_9_gens_8_seeds_shift_to_plus_AA_without_growth_noise_with_D_period/ \
+ /scratch/PI/mcovert/wc_ecoli/paper/SET_B/20190825.220728__SET_B_9_gens_8_seeds_shift_to_plus_AA_without_growth_noise_with_D_period/ \
  --variant_index 2 --seed 7
 
 
 ## Figure 2
 # Panel a
 python models/ecoli/analysis/cohort/doubling_times_histogram_all.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_D/20180815.085246.549352__SET_D1_4_gens_256_seeds/
+/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20190821.000038__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/
 
 python models/ecoli/analysis/cohort/doubling_times_histogram_all.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_D/20180815.181420.368837__SET_D2_4_gens_256_seeds,_unfit_ribosome_expression/
+/scratch/PI/mcovert/wc_ecoli/paper/SET_D/20190822.092543__SET_D2_4_gens_256_seeds,_unfit_ribosome_expression/
 
 python models/ecoli/analysis/cohort/doubling_times_histogram_all.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_D/20180815.235510.655007__SET_D3_4_gens_256_seeds,_unfit_rna_poly_expression/
+/scratch/PI/mcovert/wc_ecoli/paper/SET_D/20190822.230154__SET_D3_4_gens_256_seeds,_unfit_rna_poly_expression/
 
 python models/ecoli/analysis/cohort/doubling_times_histogram_all.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_D/20180817.001302.336012__SET_D4_4_gens_256_seeds,_unfit_ribosome_and_rna_poly_expression/
+/scratch/PI/mcovert/wc_ecoli/paper/SET_D/20190824.144321__SET_D5_4_gens_256_seeds,_unfit_ribosome_and_rna_poly_expression/
 
 # Panel b
 python models/ecoli/analysis/cohort/doubling_times_histogram_all.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20180810.094634.563490__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20190821.000038__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/ \
 --variant_index 1
 
 python models/ecoli/analysis/cohort/doubling_times_histogram_all.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20180810.094634.563490__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20190821.000038__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/ \
 --variant_index 2
 
 # Panel c
 python models/ecoli/analysis/variant/growth_condition_comparison_validation.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20180810.094634.563490__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/
+/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20190821.000038__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/
 
-# Panel d
-python models/ecoli/analysis/variant/adder_sizer.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20180810.094634.563490__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/
 
 
 ## Figure 3
 # panel A and D
 python models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/
 
 # panel B
 python models/ecoli/analysis/single/massFractionSummary.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 3 --generation 0 --seed 0
 
 # panel C
 python models/ecoli/analysis/single/massFractionSummary.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 6 --generation 0 --seed 0
 
 # panel E
 python models/ecoli/analysis/cohort/kinetics_flux_comparison.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 0
 
 # panel F
 python models/ecoli/analysis/cohort/kinetics_flux_comparison.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 3
 
 # panel G
 python models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 3
 
 
@@ -107,61 +104,71 @@ python models/ecoli/analysis/multigen/pabx_limitations.py \
 
 ## Supplemental figure 1
 python models/ecoli/analysis/multigen/growth_dynamics_panel.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_B/20180822.181305.660233__SET_B_9_gens_8_seeds_shift_to_plus_AA_without_growth_noise_with_D_period/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_B/20190825.220728__SET_B_9_gens_8_seeds_shift_to_plus_AA_without_growth_noise_with_D_period/ \
 --variant_index 2 --seed 7
 
 python models/ecoli/analysis/multigen/environmental_shift_fluxes.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_B/20180822.181305.660233__SET_B_9_gens_8_seeds_shift_to_plus_AA_without_growth_noise_with_D_period/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_B/20190825.220728__SET_B_9_gens_8_seeds_shift_to_plus_AA_without_growth_noise_with_D_period/ \
 --seed 7
 
 
 ## Supplemental figure 2
-# Made by script for panel d, Figure 2
+python models/ecoli/analysis/variant/adder_sizer.py \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20190821.000038__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/
+
+python models/ecoli/analysis/variant/rna_protein_ratio_comparison.py \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20190821.000038__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/
+
+python models/ecoli/analysis/variant/rna_protein_ratio_comparison.py \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_L/20190828.123526__SET_L_4_gens_256_seeds_3_conditions_unfit_ribosome_and_rna_poly_expression/
+
+python models/ecoli/analysis/variant/adder_sizer_comparison.py \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_C/20190821.000038__SET_C_4_gens_256_seeds_3_conditions_with_growth_noise_and_D_period/
 
 
 ## Supplemental figure 3
 # panel A
 python models/ecoli/analysis/single/massFractionSummary.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 0 --generation 0 --seed 0
 
 python models/ecoli/analysis/cohort/kinetics_flux_comparison.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 0
 
 python models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 0
 
 # panel B
 python models/ecoli/analysis/single/massFractionSummary.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 3 --generation 0 --seed 0
 
 python models/ecoli/analysis/cohort/kinetics_flux_comparison.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 3
 
 python models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 3
 
 # panel C
 python models/ecoli/analysis/single/massFractionSummary.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 6 --generation 0 --seed 0
 
 python models/ecoli/analysis/cohort/kinetics_flux_comparison.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 6
 
 python models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/ \
 --variant_index 6
 
 # panels D, E and F
 python models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py \
-/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20180813.102120.814493__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/
+/scratch/PI/mcovert/wc_ecoli/paper/SET_E/20190826.093027__SET_E_8_gens_8_seeds_10_metabolism_weighting_values/
 
 
 ## Supplemental figure 4

--- a/runscripts/paper/paper_runs.sh
+++ b/runscripts/paper/paper_runs.sh
@@ -222,6 +222,17 @@ DISABLE_RIBOSOME_CAPACITY_FITTING=1 DISABLE_RNAPOLY_CAPACITY_FITTING=1 \
 ALTERNATE_RIBOSOME_ACTIVITY=1 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fw_queue.py
 
+## Set L - comparison of RNA/protein ratios with Scott et al. before changes
+# to RNAP and ribosome expression
+# Used for Figure S2
+# SET D5 is used for condition 0 (basal)
+DESC="SET L 4 gens 256 seeds 3 conditions unfit ribosome and rna poly expression" \
+VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=2 \
+SINGLE_DAUGHTERS=1 N_GENS=4 N_INIT_SIMS=256 \
+MASS_DISTRIBUTION=1 GROWTH_RATE_NOISE=1 D_PERIOD_DIVISION=1 \
+DISABLE_RIBOSOME_CAPACITY_FITTING=1 DISABLE_RNAPOLY_CAPACITY_FITTING=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fw_queue.py
 
 ## Launch the fireworks created with fw_queue.py
 # Uncomment one method - rlaunch is interactive, qlaunch is distributed


### PR DESCRIPTION
This PR adds a new set of simulations and a few plots to the paper runscripts that are needed for supplementary figure S2. This also updates the paths for the existing figure runscripts to our most recently run sims.