### PR TITLE
[release-paper] Reformat adder-sizer plot, remove histogram

### DIFF
--- a/models/ecoli/analysis/variant/adder_sizer.py
+++ b/models/ecoli/analysis/variant/adder_sizer.py
@@ -44,7 +44,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		plt.style.use('seaborn-deep')
 		color_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color']
 
-		title_list = [r"Glucose minimal, $\tau = $44 min", r"Glucose minimal anaerobic, $\tau = $100 min", r"Glucose minimal + 20 amino acids, $\tau = $22 min"]
+		title_list = [r"Glucose minimal, $\tau = $44 min", r"Glucose minimal anaerobic, $\tau = $100 min", r"Glucose minimal + 20 amino acids, $\tau = $25 min"]
 
 		for varIdx in ap.get_variants():
 

--- a/models/ecoli/analysis/variant/doubling_time_histogram.py
+++ b/models/ecoli/analysis/variant/doubling_time_histogram.py
@@ -34,7 +34,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		fig.set_figwidth(15)
 		fig.set_figheight(5)
 
-		doublingTimeVariants = [44, 100, 22]
+		doublingTimeVariants = [44, 100, 25]
 
 		for varIdx in range(ap.n_variant):
 


### PR DESCRIPTION
This PR adds some formatting changes to the adder-sizer plot, and removes the obsolete histograms of initial and added masses. The new plots look something like this:
![adder_sizer0_stripped](https://user-images.githubusercontent.com/32276711/64202804-dbab9b00-ce46-11e9-94cf-8418bde5f81f.png)
