### PR TITLE
fix import_constraint_threshold

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/metabolism.py
+++ b/reconstruction/ecoli/dataclasses/process/metabolism.py
@@ -34,8 +34,8 @@ reverseReactionString = "{} (reverse)"
 
 # threshold (units.mmol / units.L) separates concentrations that are import constrained with
 # max flux = 0 from unconstrained molecules.
-# TODO (Eran) remove this once a transport kinetics process is operating
-IMPORT_CONSTRAINT_THRESHOLD =  0.01
+IMPORT_CONSTRAINT_THRESHOLD =  1e-5
+
 
 class Metabolism(object):
 	""" Metabolism """
@@ -793,7 +793,9 @@ class Boundary(object):
 
 		#remove molecules with low concentration
 		exchange_molecules = {self.env_to_exchange_map[mol]: conc for mol, conc in molecules.iteritems()}
-		nonzero_molecules = {molecule_id:concentration for molecule_id, concentration in exchange_molecules.items() if concentration >= 0.00001}
+		nonzero_molecules = {molecule_id:concentration
+							 for molecule_id, concentration in exchange_molecules.items()
+							 if concentration >= self.import_constraint_threshold}
 
 		for molecule_id, concentration in nonzero_molecules.iteritems():
 

--- a/wholecell/states/local_environment.py
+++ b/wholecell/states/local_environment.py
@@ -193,10 +193,5 @@ class EnvironmentView(EnvironmentViewBase):
 
 
 	def countsInc(self, molecule_ids, counts):
-		# self._state._environment_deltas = counts
-
 		self._state.accumulate_deltas(molecule_ids, counts)
-		#TODO (Eran) save deltas for external environment dict(zip(molecule_ids, counts))
-		#TODO (Eran) deltas size varies because of changing importExchange.  This will need to be fixed for a listener to save these
-
 		return


### PR DESCRIPTION
This fixes a long-standing mistake with no functional consequences. ```import_constraint_threshold``` is now set to 1e-5, and is used to determine ```nonzero_molecules``` in metabolism's ```Boundary```. A hardcoded 1e-5 was previously being used to get ```nonzero_molecules``` instead of using ```import_constraint_threshold```.