### PR TITLE
Avoid code duplication of RNAP demand calcuations

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -1632,10 +1632,11 @@ def setMrnaDegRateConstrainedByRNAPDemand(sim_data, bulkContainer, doubling_time
 
 	# Estimate active RNAP demand and supply
 	rnap_demand_per_transcript = getActiveRNAPDemand(sim_data, bulkContainer, doubling_time, avgCellDryMassInit, Km, rna_deg_rate, options)
+
 	n_active_rnap_demand = units.sum(rnap_demand_per_transcript).asNumber()
 	unitless_rnap_demand = np.array([
-		demand.asNumber()
-		for demand in rnap_demand_per_transcript.asNumber()])
+		demand.asNumber(units.s / units.nt)
+		for demand in rnap_demand_per_transcript.asNumber(units.nt / units.s)])
 
 	n_active_rnap_supply = min(bulkContainer.counts(rnap_ids) / rnap_stoich) * rnap_activity
 


### PR DESCRIPTION
This PR provides an alternate solution to https://github.com/CovertLab/wcEcoli/pull/694 that avoids duplicating all the RNAP demand calculations. 