### PR TITLE
[Python 3] Cython-coded stochastic-arrow 0.2.0

### DIFF
--- a/models/ecoli/tests/test_arrow.py
+++ b/models/ecoli/tests/test_arrow.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from pprint import pprint
+import unittest
+
+from arrow import StochasticSystem
+
+
+class TestArrow(unittest.TestCase):
+	"""Test linkage to the stochastic-arrow library."""
+
+	def test_arrow(self):
+		stoichiometric_matrix = np.array([
+			[1, 1, -1, 0],
+			[-2, 0, 0, 1],
+			[-1, -1, 1, 0]], np.int64)
+
+		rates = np.array([3, 1, 1]) * 0.01
+
+		arrow = StochasticSystem(stoichiometric_matrix, rates)
+		result = arrow.evolve(1.0, np.array([50, 20, 30, 40], np.int64))
+		pprint(result)
+
+		self.assertEqual(stoichiometric_matrix.shape[0], arrow.obsidian.reactions_count())
+		self.assertEqual(stoichiometric_matrix.shape[1], arrow.obsidian.substrates_count())
+
+		self.assertEqual(13, result['steps'])
+		self.assertEqual(13, len(result['events']))
+		self.assertEqual(2, result['events'][0])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -149,7 +149,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 statistics==1.0.3.5
 stevedore==1.30.1
-stochastic-arrow==0.1.8
+stochastic-arrow==0.2.0
 subprocess32==3.5.2
 swiglpk==1.4.4
 sympy==1.1.1


### PR DESCRIPTION
To get to Python 3, we need all the pips need to be ready. Python's C API seems to change in every Python release (https://docs.python.org/3/whatsnew/changelog.html, https://docs.python.org/2.7/whatsnew/2.7.html#build-and-c-api-changes), so I rewrote stochastic-arrow's Python-to-C glue in Cython. Let the Cython compiler deal with it.

The stochastic-arrow source code got 1/3 or 1/4 the size and much easier to work on. The outputs are the same and the speed is the same within measurement noise. Only its glue code changed.

Cython 0.29's docs explain more of its semantics than 0.28. The rules are complicated because they combine Python semantics with C semantics and their interactions.

I put some tips on a wiki page, https://github.com/CovertLab/wcEcoli/wiki/Cython-tips