### PR TITLE
[release-paper] Make small change to Figure 4E

### DIFF
--- a/models/ecoli/analysis/multigen/functionalUnits.py
+++ b/models/ecoli/analysis/multigen/functionalUnits.py
@@ -166,7 +166,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		subgenMonomerIdToComplexIds = {}
 		for complexId in subgenComplexIds:
 			subunitIds = sim_data.process.complexation.getMonomers(complexId)["subunitIds"]
-			isEssential = np.any([x in essentialGenes_monomers for x in subunitIds])
+			isEssential = np.all([x in essentialGenes_monomers for x in subunitIds])
 
 			if isEssential:
 				complexIndex = proteinIds.index(complexId)


### PR DESCRIPTION
This [hopefully the last] PR makes a small change to Figure 4E by labeling a protein complex as being essential only if all of its subunits come from essential genes. This was needed to make the number of essential subunits we have in this Figure match with the number of proteins in Table S4 (they are now both at 18). I will update the figures and legends accordingly in the next few minutes. 