### PR TITLE
security update to pip Werkzeug==0.15.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -166,7 +166,7 @@ virtualenv>=16.4.1
 virtualenv-clone>=0.5.1
 virtualenvwrapper>=4.8.4
 wcwidth==0.1.7
-Werkzeug==0.14.1
+Werkzeug==0.15.3
 wrapt==1.10.11
 xlrd==1.1.0
 zipp==0.6.0


### PR DESCRIPTION
Git security checkers keep reminding us that Werkzeug==0.14.1 has security holes.

AFIK, the security holes would only affect a Fireworks monitor webpage on the open internet. Fireworks uses Flask which uses Werkzeug.

I updated `pyenv wcEcoli2` and (`pyenv wcEcoli3`) on Sherlock. I'll merge this after the CI build. No real need to your local pyenvs for this except to quiet tool warnings.