### PR TITLE
Revert "[release-paper] Make small change to Figure 4E"

### DIFF
--- a/models/ecoli/analysis/multigen/functionalUnits.py
+++ b/models/ecoli/analysis/multigen/functionalUnits.py
@@ -166,7 +166,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		subgenMonomerIdToComplexIds = {}
 		for complexId in subgenComplexIds:
 			subunitIds = sim_data.process.complexation.getMonomers(complexId)["subunitIds"]
-			isEssential = np.all([x in essentialGenes_monomers for x in subunitIds])
+			isEssential = np.any([x in essentialGenes_monomers for x in subunitIds])
 
 			if isEssential:
 				complexIndex = proteinIds.index(complexId)


### PR DESCRIPTION
After discussing with @tahorst, it seems more reasonable to consider protein complexes composed of essential and nonessential subunits as being essential, since many complexation reactions just physically glue together different functional units without adding any new functionality. I will roll back the changes I made to the figures and text as well.