### PR TITLE
[release-paper] Only consider subgenerational subunits to determine essentiality

### DIFF
--- a/models/ecoli/analysis/multigen/functionalUnits.py
+++ b/models/ecoli/analysis/multigen/functionalUnits.py
@@ -166,7 +166,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		subgenMonomerIdToComplexIds = {}
 		for complexId in subgenComplexIds:
 			subunitIds = sim_data.process.complexation.getMonomers(complexId)["subunitIds"]
-			isEssential = np.any([x in essentialGenes_monomers for x in subunitIds])
+			isEssential = np.any([(x in essentialGenes_monomers) and (x in subgenMonomerIds) for x in subunitIds])
 
 			if isEssential:
 				complexIndex = proteinIds.index(complexId)


### PR DESCRIPTION
This PR adds one more minor fix to the functional units plot in Figure 4E. The essentiality of the complex is now only determined by the essentiality of subgenerationally expressed monomers inside the complex.