### PR TITLE
Use more precise Avogadro's number

### DIFF
--- a/reconstruction/ecoli/dataclasses/constants.py
+++ b/reconstruction/ecoli/dataclasses/constants.py
@@ -8,6 +8,11 @@ SimulationData constants
 
 from __future__ import division
 
+import scipy.constants
+
+from wholecell.utils import units
+
+
 class Constants(object):
 	""" Constants """
 
@@ -15,8 +20,7 @@ class Constants(object):
 		self._buildConstants(raw_data, sim_data)
 
 	def _buildConstants(self, raw_data, sim_data):
-		constants = raw_data.constants
-		self.__dict__.update(constants)
+		self.nAvogadro = scipy.constants.Avogadro / units.mol
 
 		parameters = raw_data.parameters
 		self.__dict__.update(parameters)

--- a/reconstruction/ecoli/dataclasses/growthRateDependentParameters.py
+++ b/reconstruction/ecoli/dataclasses/growthRateDependentParameters.py
@@ -306,7 +306,7 @@ class Mass(object):
 			raw_data.genome_sequence.count('T') + raw_data.genome_sequence.count('A')
 		])
 
-		dntMasses = (sim_data.getter.getMass(sim_data.moleculeGroups.polymerizedDNT_IDs) / raw_data.constants['nAvogadro']).asUnit(units.g)
+		dntMasses = (sim_data.getter.getMass(sim_data.moleculeGroups.polymerizedDNT_IDs) / sim_data.constants.nAvogadro).asUnit(units.g)
 		chromMass = units.dot(dntCounts, dntMasses)
 		return chromMass
 

--- a/reconstruction/ecoli/dataclasses/process/replication.py
+++ b/reconstruction/ecoli/dataclasses/process/replication.py
@@ -108,7 +108,7 @@ class Replication(object):
 		self.replicationMonomerWeights = (
 			(sim_data.getter.getMass(sim_data.moleculeGroups.dNtpIds)
 			- sim_data.getter.getMass(["PPI[c]"]))
-			/ raw_data.constants['nAvogadro']
+			/ sim_data.constants.nAvogadro
 		)
 
 

--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -114,7 +114,7 @@ class Transcription(object):
 		# Load sequence data
 		sequences = [rna['seq'] for rna in raw_data.rnas]
 		maxSequenceLength = max(len(sequence) for sequence in sequences)
-		
+
 		# Load IDs of protein monomers
 		monomerIds = [rna['monomerId'] for rna in raw_data.rnas]
 
@@ -287,11 +287,11 @@ class Transcription(object):
 				sim_data.getter.getMass(sim_data.moleculeGroups.ntpIds)
 				- sim_data.getter.getMass(["PPI[c]"])
 				)
-			/ raw_data.constants['nAvogadro']
+			/ sim_data.constants.nAvogadro
 			).asNumber(units.fg)
 
 		self.transcriptionEndWeight = ((sim_data.getter.getMass(["PPI[c]"])
-            / raw_data.constants['nAvogadro']).asNumber(units.fg))
+            / sim_data.constants.nAvogadro).asNumber(units.fg))
 
 	def _build_charged_trna(self, raw_data, sim_data):
 		'''

--- a/reconstruction/ecoli/dataclasses/process/translation.py
+++ b/reconstruction/ecoli/dataclasses/process/translation.py
@@ -174,10 +174,10 @@ class Translation(object):
 				sim_data.getter.getMass(aaIDs)
 				- sim_data.getter.getMass(["WATER[c]"])
 				)
-			/ raw_data.constants['nAvogadro']
+			/ sim_data.constants.nAvogadro
 			).asNumber(units.fg)
 
-		self.translationEndWeight = (sim_data.getter.getMass(["WATER[c]"]) / raw_data.constants['nAvogadro']).asNumber(units.fg)
+		self.translationEndWeight = (sim_data.getter.getMass(["WATER[c]"]) / sim_data.constants.nAvogadro).asNumber(units.fg)
 
 	def _buildTranslationEfficiency(self, raw_data, sim_data):
 		monomerIds = [x["id"].encode("utf-8") + "[" + sim_data.getter.getLocation([x["id"]])[0][0] + "]" for x in raw_data.proteins]

--- a/reconstruction/ecoli/flat/constants.tsv
+++ b/reconstruction/ecoli/flat/constants.tsv
@@ -1,2 +1,0 @@
-name	value	units
-nAvogadro	6.02E+23	1 / units.mol

--- a/reconstruction/ecoli/knowledge_base_raw.py
+++ b/reconstruction/ecoli/knowledge_base_raw.py
@@ -90,7 +90,6 @@ LIST_OF_DICT_FILENAMES = (
 	)
 SEQUENCE_FILE = 'sequence.fasta'
 LIST_OF_PARAMETER_FILENAMES = ("parameters.tsv", "mass_parameters.tsv")
-CONSTANTS_FILENAME = "constants.tsv"
 
 class DataStore(object):
 	def __init__(self):
@@ -106,7 +105,6 @@ class KnowledgeBaseEcoli(object):
 
 		for filename in LIST_OF_PARAMETER_FILENAMES:
 			self._load_parameters(os.path.join(FLAT_DIR, filename))
-		self._load_parameters(os.path.join(FLAT_DIR, CONSTANTS_FILENAME))
 
 		self.genome_sequence = self._load_sequence(os.path.join(FLAT_DIR, SEQUENCE_FILE))
 


### PR DESCRIPTION
This updates the value for Avogadro's number that we use in sims to be more precise.  Previously it was defined in a flat file as `6.02e23` but now we use the exact value from scipy: `6.022140857e+23`.  This shouldn't make a big difference in sims but it seems strange to lose so much precision on a physical constant that is used so often in the model especially when most of our molar masses are given with 6 significant figures.