### PR TITLE
Fix TF listener count bug

### DIFF
--- a/models/ecoli/processes/tf_binding.py
+++ b/models/ecoli/processes/tf_binding.py
@@ -178,12 +178,12 @@ class TfBinding(wholecell.processes.process.Process):
 			n_to_bind = int(stochasticRound(
 				self.randomState, n_available_promoters*pPromoterBound))
 
+			bound_locs = np.zeros(n_available_promoters, dtype=np.bool)
 			if n_to_bind > 0:
 				# Determine randomly which DNA targets to bind based on which of
 				# the following is more limiting:
 				# number of promoter sites to bind, or number of active
 				# transcription factors
-				bound_locs = np.zeros(n_available_promoters, dtype=np.bool)
 				bound_locs[
 					self.randomState.choice(
 						n_available_promoters,


### PR DESCRIPTION
This fixes a minor listener bug - don't think it has any simulation impact.  In the case where `n_to_bind` is 0, the number of `nActualBound` calculated below is for the previous TF's `bound_locs` array.