### PR TITLE
adjust workflow names for usability

### DIFF
--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -172,17 +172,19 @@ There are many ways to download the outputs from your workflow:
 
 * **Simplest for individual files:** Open the [Google Cloud
 Storage — Browser](https://console.cloud.google.com/storage/browser?project=allen-discovery-center-mcovert),
-browse into the [sisyphus storage bucket](https://console.cloud.google.com/storage/browser/sisyphus?project=allen-discovery-center-mcovert)
-bucket, find your workflow files, and click on individual files to download them.
-* **Most convenient:** Use [gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse) to mount the storage
-bucket `sisyphus` to your local file system
-(or use the `--only-dir data/$USER` option to mount just its `data/$USER/` subdirectory) and access
+browse into your Google Cloud Storage bucket ("sisyphus-crick" or whatever)
+find your workflow files, and click on individual files to download them.
+* **Most convenient:** Use [gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse) to mount your
+storage bucket to your local file system (or use the `--only-dir data/$USER` option
+to mount just a subdirectory of it) and access
 the files like local files.
+  * Example:  
+    `cd ~/dev/gcs/ && mkdir sisyphus-crick && gcsfuse sisyphus-crick sisyphus-crick`
   * gcsfuse reads and writes whole files to Cloud Storage on demand. It's convenient but
   it has higher latency than an NFS server.
   * Google Cloud Storage (GCS) is not a regular file system and gcsfuse can't totally hide that.
   E.g. GCS doesn't have directories, just file paths that may contain slashes and some that end
-  with a slash. See the notes in
+  with a slash. GCS reads and writes whole files. See the notes in
   [semantics.md](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md)
   for details.
   * (For workflows run before 2019-08-18: You need to use gcsfuse's `--implicit-dirs` option since

--- a/runscripts/cloud/util/workflow_cli.py
+++ b/runscripts/cloud/util/workflow_cli.py
@@ -70,7 +70,7 @@ class WorkflowCLI(scriptBase.ScriptBase):
 		basename = type(self).__name__
 		owner_id = os.environ['USER']
 		timestamp = fp.timestamp()
-		name = '{}_{}_{}'.format(basename, owner_id, timestamp)
+		name = '{}_{}_{}'.format(owner_id, basename, timestamp)
 		self.storage_prefix = posixpath.join(
 			Workflow.storage_root(args.storage_root), basename, timestamp, '')
 		self.wf = Workflow(name)

--- a/runscripts/cloud/wcm.py
+++ b/runscripts/cloud/wcm.py
@@ -29,7 +29,7 @@ class WcmWorkflow(Workflow):
 	def __init__(self, owner_id, timestamp, verbose_logging=True,
 			description='', cli_storage_root=None):
 		# type: (str, str, bool, str, Optional[str]) -> None
-		name = 'WCM_{}_{}'.format(owner_id, timestamp)
+		name = '{}_WCM_{}'.format(owner_id, timestamp)
 		super(WcmWorkflow, self).__init__(name, verbose_logging=verbose_logging)
 
 		self.owner_id = owner_id


### PR DESCRIPTION
Rename the workflows e.g.
from: `WCM_jerry_20191107.010721` and `Demo_jerry_20191107.010721`
to: `jerry_WCM_20191107.010721` and `jerry_Demo_20191107.010721`
so a sorted list will be more usable in the future web UI.

Also improve the how-to-access-workflow-outputs instructions. Include an example `gcsfuse` command line.