### PR TITLE
Remove raw_data load during simulation

### DIFF
--- a/reconstruction/ecoli/dataclasses/state/external_state.py
+++ b/reconstruction/ecoli/dataclasses/state/external_state.py
@@ -17,7 +17,6 @@ Initializes the environment using conditions and time series from raw_data.
 
 from __future__ import absolute_import, division, print_function
 
-from wholecell.utils import units
 from reconstruction.ecoli.dataclasses.state.environment import Environment
 from wholecell.utils.make_media import Media
 
@@ -29,22 +28,21 @@ class ExternalState(object):
 		self.environment = Environment(raw_data, sim_data)
 
 		# make media object
-		make_media = Media()
+		self.make_media = Media(raw_data)
 
 		# create a dictionary with all saved timelines
 		self.environment.saved_timelines = {}
 		for row in raw_data.condition.timelines_def:
 			timeline_id = row["timeline"]
 			timeline_str = row["events"]
-			new_timeline = make_media.make_timeline(timeline_str)
+			new_timeline = self.make_media.make_timeline(timeline_str)
 			self.environment.saved_timelines[timeline_id] = new_timeline
 
 		# set default current_timeline_id to None, this can be overwritten by the timelines variant
 		self.environment.current_timeline_id = None
 
 		# make a dictionary with all media conditions specified by media_recipes
-		make_media = Media()
-		self.environment.saved_media = make_media.make_saved_media()
+		self.environment.saved_media = self.make_media.make_saved_media()
 
 		# make mapping from external molecule to exchange molecule
 		self.environment.env_to_exchange_map = {

--- a/wholecell/states/local_environment.py
+++ b/wholecell/states/local_environment.py
@@ -28,7 +28,6 @@ import wholecell.views.view
 from wholecell.utils import units
 from wholecell.containers.bulk_objects_container import BulkObjectsContainer
 
-from wholecell.utils.make_media import Media
 
 COUNTS_UNITS = units.mmol
 VOLUME_UNITS = units.L
@@ -64,7 +63,7 @@ class LocalEnvironment(wholecell.states.external_state.ExternalState):
 		self._nAvogadro = sim_data.constants.nAvogadro
 
 		# make media object
-		make_media = Media()
+		make_media = sim_data.external_state.make_media
 
 		# if current_timeline_id is specified by a variant in sim_data, look it up in saved_timelines.
 		# else, construct the timeline given to initialize

--- a/wholecell/utils/make_media.py
+++ b/wholecell/utils/make_media.py
@@ -4,7 +4,7 @@ Functions for making media
 # Example use of make_media
 
 ### Create media object
-> media_obj = Media()
+> media_obj = Media(raw_data)
 
 ### Retrieve stock media
 > base_media = media_obj.stock_media['M9_GLC']
@@ -38,8 +38,6 @@ from __future__ import absolute_import, division, print_function
 
 from wholecell.utils import units
 
-# Raw data class
-from reconstruction.ecoli.knowledge_base_raw import KnowledgeBaseEcoli
 
 INF = float("inf")
 NEG_INF = float("-inf")
@@ -67,10 +65,7 @@ class Media(object):
 	ingredients at weights.
 	'''
 
-	def __init__(self):
-
-		raw_data = KnowledgeBaseEcoli()
-
+	def __init__(self, raw_data):
 		# get dicts from knowledge base
 		self.environment_molecules_fw = self._get_environment_molecules_fw(raw_data)
 		self.stock_media = self._get_stock_media(raw_data)


### PR DESCRIPTION
I ran into the following error when running simulations after checking out a different branch:

```
Traceback (most recent call last):
  File "/home/travis/.pyenv/versions/2.7.16/envs/wcEcoli2/lib/python2.7/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/simulationDaughter.py", line 52, in run_task
    sim = EcoliDaughterSimulation(**options)
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 131, in __init__
    sim_data = self._simData
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 155, in _initialize

  File "/home/travis/wcEcoli/wholecell/states/local_environment.py", line 67, in initialize
    make_media = Media()
  File "/home/travis/wcEcoli/wholecell/utils/make_media.py", line 72, in __init__
    raw_data = KnowledgeBaseEcoli()
  File "/home/travis/wcEcoli/reconstruction/ecoli/knowledge_base_raw.py", line 106, in __init__
    for filename in LIST_OF_PARAMETER_FILENAMES:
  File "/home/travis/wcEcoli/reconstruction/ecoli/knowledge_base_raw.py", line 122, in _load_tsv
    ifilter(lambda x: x.lstrip()[0] != "#", csvfile), # Strip comments
IOError: [Errno 2] No such file or directory: '/home/travis/wcEcoli/reconstruction/ecoli/flat/ppgpp_fc.tsv'
```

The issue is that for every simulation, `Media()` will load the raw flat files again.  This goes against the paradigm of the whole-cell model where raw data is loaded once, used to create `sim_data` once, and then all simulations use the saved `sim_data` (potentially with variant modifications).  This could easily create some hard to track down bugs that would mostly be silent.

This creates only one `make_media` object from previously loaded `raw_data` and stores it in `sim_data` for use during simulations so that a new object doesn't need to be created each time.