### PR TITLE
fix #740 Missing CI scripts

### DIFF
--- a/runscripts/jenkins/ecoli-performance-test.sh
+++ b/runscripts/jenkins/ecoli-performance-test.sh
@@ -1,0 +1,10 @@
+module load wcEcoli/sherlock2
+pyenv local wcEcoli2
+
+make clean
+make compile
+
+set -e
+
+# Running it this way prints all timing measurements:
+python -m wholecell.tests.utils.test_library_performance

--- a/runscripts/jenkins/ecoli-small.sh
+++ b/runscripts/jenkins/ecoli-small.sh
@@ -1,0 +1,10 @@
+set -e
+
+module load wcEcoli/sherlock2
+pyenv local wcEcoli2
+
+make clean
+make compile
+
+PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=wholecell --cov-report xml \
+    --junitxml=unittests.xml


### PR DESCRIPTION
Restore `runscripts/jenkins/ecoli-performance-test.sh` and `runscripts/jenkins/ecoli-small.sh`, updating them to use pytest, so the Jenkins builds can complete.