### PR TITLE
Fix list unit bug

### DIFF
--- a/reconstruction/spreadsheets.py
+++ b/reconstruction/spreadsheets.py
@@ -57,7 +57,11 @@ class JsonReader(csv.DictReader):
 			try:
 				attribute = re.search('(.*?) \(', key).group(1)
 				value_units =  eval(re.search('\((.*?)\)',key).group(1))
-				attributeDict[attribute] = value * value_units
+				# Units do not work with lists so need to convert to ndarray
+				if isinstance(value, list):
+					attributeDict[attribute] = value_units * np.array(value)
+				else:
+					attributeDict[attribute] = value_units * value
 			except AttributeError:
 				attributeDict[key] = value
 		return attributeDict

--- a/wholecell/utils/make_media.py
+++ b/wholecell/utils/make_media.py
@@ -119,8 +119,6 @@ class Media(object):
 			recipe["added media"] = row.get("added media", None)
 			recipe["ingredients"] = row.get("ingredients", None)
 
-			# TODO -- with units placed on Infinity, it makes entries return TypeError: can't multiply sequence by non-int of type 'float'
-			# TODO -- This still works for making media, but you can't read the recipes
 			recipe["base media volume"] = row.get("base media volume", 0 * units.L)
 			recipe["added media volume"] = row.get("added media volume", 0 * units.L)
 			recipe["ingredients weight"] = row.get("ingredients weight", None)


### PR DESCRIPTION
This fixes an issue that was preventing comparison of two `sim_data` objects with the following trace:

```
Traceback (most recent call last):                                                                                                                                                                                                                                       
  File "runscripts/debug/compareParca.py", line 44, in <module>                                                                                                                                                                                                          
    diffs = diff_trees(once, twice)                                                                                                                                                                                                                                      
  File "/home/travis/wcEcoli/runscripts/reflect/object_tree.py", line 160, in diff_trees                                                                                                                                                                                 
    subdiff = diff_trees(a.get(key, na), b.get(key, nb))                                                                                                                                                                                                                 
  File "/home/travis/wcEcoli/runscripts/reflect/object_tree.py", line 160, in diff_trees                                                                                                                                                                                 
    subdiff = diff_trees(a.get(key, na), b.get(key, nb))                                                                                                                                                                                                                 
  File "/home/travis/wcEcoli/runscripts/reflect/object_tree.py", line 160, in diff_trees                                                                                                                                                                                 
    subdiff = diff_trees(a.get(key, na), b.get(key, nb))                                                                                                                                                                                                                 
  File "/home/travis/wcEcoli/runscripts/reflect/object_tree.py", line 160, in diff_trees                                                                                                                                                                                 
    subdiff = diff_trees(a.get(key, na), b.get(key, nb))                                                                                                                                                                                                                 
  File "/home/travis/wcEcoli/runscripts/reflect/object_tree.py", line 160, in diff_trees                                                                                                                                                                                 
    subdiff = diff_trees(a.get(key, na), b.get(key, nb))                                                                                                                                                                                                                 
  File "/home/travis/wcEcoli/runscripts/reflect/object_tree.py", line 147, in diff_trees                                                                                                                                                                                 
    return diff_trees(a0.asNumber(), b0.asNumber())                                                                                                                                                                                                                      
  File "/home/travis/.pyenv/versions/wcEcoli2/lib/python2.7/site-packages/unum/__init__.py", line 388, in asNumber                                                                                                                                                       
    return self.copy(True)._value                                                                                                                                                                                                                                        
  File "/home/travis/.pyenv/versions/wcEcoli2/lib/python2.7/site-packages/unum/__init__.py", line 170, in copy                                                                                                                                                           
    result.normalize()                                                                                                                                                                                                                                                   
  File "/home/travis/.pyenv/versions/wcEcoli2/lib/python2.7/site-packages/unum/__init__.py", line 230, in normalize                                                                                                                                                      
    s = subst_unum.replaced(u, conv_unum)                                                                                                                                                                                                                                
  File "/home/travis/.pyenv/versions/wcEcoli2/lib/python2.7/site-packages/unum/__init__.py", line 192, in replaced                                                                                                                                                       
    res = self.copy() * conv_unum ** self._unit[u]                                                                                                                                                                                                                       
  File "/home/travis/.pyenv/versions/wcEcoli2/lib/python2.7/site-packages/unum/__init__.py", line 308, in __mul__                                                                                                                                                        
    return Unum(unit, self._value * other._value)                                                                                                                                                                                                                        
TypeError: can't multiply sequence by non-int of type 'float'
```

The `media_recipes.tsv` file was the only file that was trying to multiply units by lists so this won't affect any other file loads but allows for future use of empty lists and units in flat files without raising the `TypeError`.

@eagmon, can you want to make sure the list -> ndarray doesn't affect your media calculations at all?