### PR TITLE
Fix improper initialization for timelines variants not starting in basal

### DIFF
--- a/models/ecoli/sim/variants/timelines.py
+++ b/models/ecoli/sim/variants/timelines.py
@@ -9,15 +9,18 @@ Expected variant indices (dependent on sorted order from reconstruction/ecoli/fl
 	0-26
 """
 
+from __future__ import absolute_import, division, print_function
+
+
 def timelines(sim_data, index):
-	timelines = sim_data.external_state.environment.saved_timelines
-	timeline_ids = sorted(timelines)
+	saved_timelines = sim_data.external_state.environment.saved_timelines
+	timeline_ids = sorted(saved_timelines)
 	current_timeline_id = timeline_ids[index]
 	sim_data.external_state.environment.current_timeline_id = current_timeline_id
 
 	# Get possible condition from starting nutrients for proper initialization
 	# Not guaranteed to map to any condition or could map to multiple conditions
-	nutrients = timelines[current_timeline_id][0][1]
+	nutrients = saved_timelines[current_timeline_id][0][1]
 	conditions = [cond for cond in sim_data.conditionActiveTfs
 		if sim_data.conditions[cond]['nutrients'] == nutrients]
 	if len(conditions) == 1:


### PR DESCRIPTION
This updates the timelines variant so that cells are properly initialized.  `sim_data.condition` needs to be set for proper initialization so all cells were being initialized in basal condition even if the starting nutrients at time 0 were different.  For nutrients that we don't have a proper condition mapping, the cell will be initialized like it is in basal conditions but a warning will be printed.  Alternatively, we could raise an exception since I don't know how well those other timelines would be simulated at this point.