### PR TITLE
(prototye) compartmentalized ODE model of Min system

### DIFF
--- a/prototypes/spatiality/min_system/min_system_compartment_ode.py
+++ b/prototypes/spatiality/min_system/min_system_compartment_ode.py
@@ -413,12 +413,13 @@ class MinODEMaster():
 
         return
 
-l_0 = 4 # unit: um
-n = 6 # number of compartments in the beginning
-min_ode_master = MinODEMaster(n, l_0)
-if CHANGE_SIZE:
-    dl_dt = 6 / 2400
-else:
-    dl_dt = 0
-t_max = 500
-sol = min_ode_master.min_master(dl_dt, t_max)
+if __name__ == "__main__":
+    l_0 = 4 # unit: um
+    n = 6 # number of compartments in the beginning
+    min_ode_master = MinODEMaster(n, l_0)
+    if CHANGE_SIZE:
+        dl_dt = 6 / 2400
+    else:
+        dl_dt = 0
+    t_max = 500
+    sol = min_ode_master.min_master(dl_dt, t_max)


### PR DESCRIPTION
This PR add the functions that can produce the compartmentalized ODE model of Min system. The effect of size change and nucleoid exclusion can be enabled or disabled.

The results look like this:
(1) CHANGE_SIZE = False; NUCLEOID = False
[min_ode.pdf](https://github.com/CovertLab/wcEcoli/files/3970729/min_ode.pdf)

(2) CHANGE_SIZE = True; NUCLEOID = False
[min_ode.pdf](https://github.com/CovertLab/wcEcoli/files/3970764/min_ode.pdf)

(3) CHANGE_SIZE = False; NUCLEOID = True
[min_ode.pdf](https://github.com/CovertLab/wcEcoli/files/3970728/min_ode.pdf)

(4) CHANGE_SIZE = True; NUCLEOID = True
[min_ode.pdf](https://github.com/CovertLab/wcEcoli/files/3970741/min_ode.pdf)
