### PR TITLE
Add faulthandler pip and enable for firetasks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,7 @@ ecos==2.0.5
 enum34==1.1.6
 Equation==1.2.1
 fastcache==1.0.2
+faulthandler==3.1
 FireWorks==1.8.7
 Flask==1.0.2
 flask-paginate==0.5.1

--- a/wholecell/fireworks/firetasks/__init__.py
+++ b/wholecell/fireworks/firetasks/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+# Enable segmentation and other fault handling for tracebacks
+import faulthandler; faulthandler.enable()
+
 from .initRawData import InitRawDataTask
 from .fitSimData import FitSimDataTask
 from .variantSimData import VariantSimDataTask


### PR DESCRIPTION
As discussed today and in #764, this adds the pip for faulthandler to handle seg faults and other system signals.  I did a rough test of sim time for a generation with it enabled and there was no significant difference in computation time so it shouldn't add overhead but will give us some additional information if things go wrong.  It is already part of `wcEcoli2` pyenv in Sherlock.