### PR TITLE
Fix bug in tcs solver call function

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -414,7 +414,7 @@ class TwoComponentSystem(object):
 				# Try with different solver for better stability
 				print('Warning: switching to LSODA method in TCS')
 				return self.moleculesToNextTimeStep(
-					moleculeCounts, cellVolume, nAvogadro, timeStepSec,
+					moleculeCounts, cellVolume, nAvogadro, timeStepSec, random_state,
 					solver='LSODA', min_time_step=min_time_step)
 			else:
 				raise Exception(


### PR DESCRIPTION
Added call for required input argument for tcs solver. Without this argument, some gene_knockout variants fail to run (error: not enough input arguments).