### PR TITLE
Speed up single analysis

### DIFF
--- a/models/ecoli/analysis/single/aaCounts.py
+++ b/models/ecoli/analysis/single/aaCounts.py
@@ -15,7 +15,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from wholecell.io.tablereader import TableReader
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 
@@ -28,21 +28,14 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		if not os.path.exists(plotOutDir):
 			os.mkdir(plotOutDir)
 
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-
-		moleculeIds = bulkMolecules.readAttribute("objectNames")
-
 		sim_data = cPickle.load(open(simDataFile))
 
 		aaIDs = sim_data.moleculeGroups.aaIDs
-		aaIndexes = np.array([moleculeIds.index(aaId) for aaId in aaIDs], np.int)
-		aaCounts = bulkMolecules.readColumn("counts")[:, aaIndexes]
+		(aaCounts,) = read_bulk_molecule_counts(simOutDir, (aaIDs,))
 
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))
 		initialTime = main_reader.readAttribute("initialTime")
 		time = main_reader.readColumn("time") - initialTime
-
-		bulkMolecules.close()
 
 		plt.figure(figsize = (8.5, 11))
 

--- a/models/ecoli/analysis/single/active_rnap_coordinates.py
+++ b/models/ecoli/analysis/single/active_rnap_coordinates.py
@@ -152,7 +152,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		plt.tight_layout()
 
-		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
+		exportFigure(plt, plotOutDir, plotOutFileName, metadata, extension='.pdf')
 		plt.close('all')
 
 

--- a/models/ecoli/analysis/single/concentrationDeviation.py
+++ b/models/ecoli/analysis/single/concentrationDeviation.py
@@ -17,7 +17,7 @@ import cPickle
 
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 COLOR_CHOICES = np.array([
@@ -59,9 +59,6 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		time = main_reader.readColumn("time") - initialTime
 
 		# Calculate concentration data
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-		bulkMoleculeIds = bulkMolecules.readAttribute("objectNames")
-
 		mass = TableReader(os.path.join(simOutDir, "Mass"))
 		cellMass = units.fg * mass.readColumn("cellMass")
 
@@ -72,13 +69,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		concentrationSetpoints = concentrationSetpoints[sortedConcentrationIndex]
 
 		poolIds = np.array(concIds)[sortedConcentrationIndex]
-		poolIndexes = np.array([bulkMoleculeIds.index(x) for x in poolIds])
-		poolCounts = bulkMolecules.readColumn("counts")[:, poolIndexes]
+		(poolCounts,) = read_bulk_molecule_counts(simOutDir, (poolIds,))
 		poolMols = 1/nAvogadro * poolCounts
 		volume = cellMass / cellDensity
 		poolConcentrations = poolMols * 1/volume[:,np.newaxis]
-
-		bulkMolecules.close()
 
 		# Compare
 		common_units = units.mmol / units.L

--- a/models/ecoli/analysis/single/dntpCounts.py
+++ b/models/ecoli/analysis/single/dntpCounts.py
@@ -15,7 +15,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from wholecell.io.tablereader import TableReader
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 
@@ -30,19 +30,11 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile))
 
 		dntpIDs = sim_data.moleculeGroups.dNtpIds
-
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-
-		moleculeIds = bulkMolecules.readAttribute("objectNames")
-
-		dntpIndexes = np.array([moleculeIds.index(dntpId) for dntpId in dntpIDs], np.int)
-		dntpCounts = bulkMolecules.readColumn("counts")[:, dntpIndexes]
+		(dntpCounts,) = read_bulk_molecule_counts(simOutDir, (dntpIDs,))
 
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))
 		initialTime = main_reader.readAttribute("initialTime")
 		time = main_reader.readColumn("time") - initialTime
-
-		bulkMolecules.close()
 
 		plt.figure(figsize = (8.5, 8.5))
 

--- a/models/ecoli/analysis/single/equilibriumComparison.py
+++ b/models/ecoli/analysis/single/equilibriumComparison.py
@@ -49,7 +49,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Calculate concentration data
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-		bulkMoleculeIds = bulkMolecules.readAttribute("objectNames")
+		bulkMoleculeIdx = {name: i for i, name in enumerate(bulkMolecules.readAttribute("objectNames"))}
 		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
 
 		mass = TableReader(os.path.join(simOutDir, "Mass"))
@@ -68,13 +68,13 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 			reactantIds = [moleculeNames[x] for x in np.where(stoichMatrix[:, idx] < 0)[0]]
 			reactantCoeffs = np.abs(stoichMatrix[stoichMatrix[:, idx] < 0, idx])
-			reactantIdxs = np.array([bulkMoleculeIds.index(x) for x in reactantIds], dtype = np.int64)
+			reactantIdxs = np.array([bulkMoleculeIdx[x] for x in reactantIds], dtype = np.int64)
 			reactantCounts = bulkMoleculeCounts[:, reactantIdxs]
 			reactantConcentrations = reactantCounts / (cellVolume[:, np.newaxis] * nAvogadro)
 
 			productIds = [moleculeNames[x] for x in np.where(stoichMatrix[:, idx] > 0)[0]]
 			productCoeffs = np.abs(stoichMatrix[stoichMatrix[:, idx] > 0, idx])
-			productIdxs = np.array([bulkMoleculeIds.index(x) for x in productIds], dtype = np.int64)
+			productIdxs = np.array([bulkMoleculeIdx[x] for x in productIds], dtype = np.int64)
 			productCounts = bulkMoleculeCounts[:, productIdxs]
 			productConcentrations = productCounts / (cellVolume[:, np.newaxis] * nAvogadro)
 

--- a/models/ecoli/analysis/single/expression_rna_01_low.py
+++ b/models/ecoli/analysis/single/expression_rna_01_low.py
@@ -41,7 +41,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))
 		mRNA_counts = mRNA_counts_reader.readColumn('mRNA_counts')
-		all_mRNA_ids = mRNA_counts_reader.readAttribute('mRNA_ids')
+		all_mRNA_idx = {rna: i for i, rna in enumerate(mRNA_counts_reader.readAttribute('mRNA_ids'))}
 
 		rnaIds = [
 			"G7355_RNA[c]", "EG11783_RNA[c]", "G7742_RNA[c]", "G6253_RNA[c]", "EG10632_RNA[c]",
@@ -60,7 +60,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			"ushA - UDP-sugar hydrolase / 5'-ribonucleotidase / 5'-deoxyribonucleotidase",
 		]
 
-		rnaIndexes = np.array([all_mRNA_ids.index(x) for x in rnaIds], np.int)
+		rnaIndexes = np.array([all_mRNA_idx[x] for x in rnaIds], np.int)
 		rnaCounts = mRNA_counts[:, rnaIndexes]
 
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))

--- a/models/ecoli/analysis/single/expression_rna_02_med.py
+++ b/models/ecoli/analysis/single/expression_rna_02_med.py
@@ -41,7 +41,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))
 		mRNA_counts = mRNA_counts_reader.readColumn('mRNA_counts')
-		all_mRNA_ids = mRNA_counts_reader.readAttribute('mRNA_ids')
+		all_mRNA_idx = {rna: i for i, rna in enumerate(mRNA_counts_reader.readAttribute('mRNA_ids'))}
 
 		rnaIds = [
 			"EG10789_RNA[c]", "EG11556_RNA[c]", "EG12095_RNA[c]", "G1_RNA[c]", "G360_RNA[c]",
@@ -60,7 +60,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			"livJ - Branched chain amino acid ABC transporter - periplasmic binding protein",
 		]
 
-		rnaIndexes = np.array([all_mRNA_ids.index(x) for x in rnaIds], np.int)
+		rnaIndexes = np.array([all_mRNA_idx[x] for x in rnaIds], np.int)
 		rnaCounts = mRNA_counts[:, rnaIndexes]
 
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))

--- a/models/ecoli/analysis/single/expression_rna_03_high.py
+++ b/models/ecoli/analysis/single/expression_rna_03_high.py
@@ -39,7 +39,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))
 		mRNA_counts = mRNA_counts_reader.readColumn('mRNA_counts')
-		all_mRNA_ids = mRNA_counts_reader.readAttribute('mRNA_ids')
+		all_mRNA_idx = {rna: i for i, rna in enumerate(mRNA_counts_reader.readAttribute('mRNA_ids'))}
 
 		rnaIds = [
 			"EG10367_RNA[c]", "EG11036_RNA[c]", "EG50002_RNA[c]", "EG10671_RNA[c]", "EG50003_RNA[c]",
@@ -58,7 +58,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			"lpp - Murein lipoprotein",
 		]
 
-		rnaIndexes = np.array([all_mRNA_ids.index(x) for x in rnaIds], np.int)
+		rnaIndexes = np.array([all_mRNA_idx[x] for x in rnaIds], np.int)
 		rnaCounts = mRNA_counts[:, rnaIndexes]
 
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))

--- a/models/ecoli/analysis/single/mass_fractions_voronoi.py
+++ b/models/ecoli/analysis/single/mass_fractions_voronoi.py
@@ -36,7 +36,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		unique_molecule_counts = TableReader(os.path.join(simOutDir, "UniqueMoleculeCounts"))
 		bulk_molecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
 		bulk_molecule_counts = bulk_molecules.readColumn("counts")
-		bulk_molecule_ids = bulk_molecules.readAttribute("objectNames")
+		bulk_molecule_idx = {name: i for i, name in enumerate(bulk_molecules.readAttribute("objectNames"))}
 		nAvogadro = sim_data.constants.nAvogadro
 
 		# Get the stoichiometry matrix of 50s & 30s subunits
@@ -48,9 +48,9 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			ribosome_30s_subunits["subunitStoich"]))
 
 		# Count 50s & 30s subunits
-		complex_indexes = bulk_molecule_ids.index(sim_data.moleculeIds.s50_fullComplex)
+		complex_indexes = bulk_molecule_idx[sim_data.moleculeIds.s50_fullComplex]
 		complex_50s_counts = bulk_molecule_counts[:, complex_indexes]
-		complex_indexes = bulk_molecule_ids.index(sim_data.moleculeIds.s30_fullComplex)
+		complex_indexes = bulk_molecule_idx[sim_data.moleculeIds.s30_fullComplex]
 		complex_30s_counts = bulk_molecule_counts[:, complex_indexes]
 
 		n_50s_subunits = np.outer(complex_50s_counts, ribosome_50s_subunits["subunitStoich"])
@@ -69,7 +69,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			# Count free rRNAs
 			rRna_ids = getattr(sim_data.moleculeGroups, str(rRna_id))
 			rRna_indexes = np.array(
-				[bulk_molecule_ids.index(rRna) for rRna in rRna_ids])
+				[bulk_molecule_idx[rRna] for rRna in rRna_ids])
 			free_rRna_counts = bulk_molecule_counts[:, rRna_indexes]
 
 			# Include the rRNAs already in active ribosomes & ribosome subunits
@@ -91,7 +91,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# lipids and polyamines
 		def find_mass_molecule_group(group_id):
 			temp_ids = getattr(sim_data.moleculeGroups, str(group_id))
-			temp_indexes = np.array([bulk_molecule_ids.index(temp) for temp in temp_ids])
+			temp_indexes = np.array([bulk_molecule_idx[temp] for temp in temp_ids])
 			temp_counts = bulk_molecule_counts[:, temp_indexes]
 			temp_mw = sim_data.getter.getMass(temp_ids)
 			return (units.dot(temp_counts, temp_mw)/nAvogadro).asNumber(units.fg)
@@ -102,7 +102,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# LPS, murein, and glycogen
 		def find_mass_single_molecule(molecule_id):
 			temp_id = getattr(sim_data.moleculeIds, str(molecule_id))
-			temp_index = bulk_molecule_ids.index(temp_id)
+			temp_index = bulk_molecule_idx[temp_id]
 			temp_counts = bulk_molecule_counts[:, temp_index]
 			temp_mw = sim_data.getter.getMass([temp_id])
 			return (units.multiply(temp_counts, temp_mw)/nAvogadro).asNumber(units.fg)

--- a/models/ecoli/analysis/single/mrnaVsProteinCounts.py
+++ b/models/ecoli/analysis/single/mrnaVsProteinCounts.py
@@ -16,7 +16,7 @@ from matplotlib import pyplot as plt
 import cPickle
 
 from wholecell.io.tablereader import TableReader
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 
@@ -39,19 +39,14 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		proteinIds = sim_data.process.translation.monomerData["id"]
 		rnaIds = sim_data.process.translation.monomerData["rnaId"]
 
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
-		moleculeIds = bulkMolecules.readAttribute("objectNames")
-
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))
 		mRNA_counts = mRNA_counts_reader.readColumn('mRNA_counts')
-		all_mRNA_ids = mRNA_counts_reader.readAttribute('mRNA_ids')
+		all_mRNA_idx = {rna: i for i, rna in enumerate(mRNA_counts_reader.readAttribute('mRNA_ids'))}
 
-		rnaIndexes = np.array([all_mRNA_ids.index(moleculeId) for moleculeId in rnaIds], np.int)
+		rnaIndexes = np.array([all_mRNA_idx[moleculeId] for moleculeId in rnaIds], np.int)
 		rnaCountsBulk = mRNA_counts[:, rnaIndexes]
 
-		proteinIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in proteinIds], np.int)
-		proteinCountsBulk = bulkMoleculeCounts[:, proteinIndexes]
+		(proteinCountsBulk,) = read_bulk_molecule_counts(simOutDir, (proteinIds,))
 
 		relativeMRnaCounts = rnaCountsBulk[-1, :]
 		relativeProteinCounts = proteinCountsBulk[-1, :]

--- a/models/ecoli/analysis/single/ntpCounts.py
+++ b/models/ecoli/analysis/single/ntpCounts.py
@@ -13,7 +13,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from wholecell.io.tablereader import TableReader
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 
@@ -25,14 +25,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		if not os.path.exists(plotOutDir):
 			os.mkdir(plotOutDir)
 
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-
-		moleculeIds = bulkMolecules.readAttribute("objectNames")
-
-		NTP_IDS = ['ATP[c]', 'CTP[c]', 'GTP[c]', 'UTP[c]']
-		ntpIndexes = np.array([moleculeIds.index(ntpId) for ntpId in NTP_IDS], np.int)
-
-		ntpCounts = bulkMolecules.readColumn("counts")[:, ntpIndexes]
+		ntp_ids = ['ATP[c]', 'CTP[c]', 'GTP[c]', 'UTP[c]']
+		(ntpCounts,) = read_bulk_molecule_counts(simOutDir, (ntp_ids,))
 
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))
 		initialTime = main_reader.readAttribute("initialTime")
@@ -47,7 +41,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			plt.plot(time / 60., ntpCounts[:, idx], linewidth = 2)
 			plt.xlabel("Time (min)")
 			plt.ylabel("Counts")
-			plt.title(NTP_IDS[idx])
+			plt.title(ntp_ids[idx])
 
 		plt.subplots_adjust(hspace = 0.5)
 

--- a/models/ecoli/analysis/single/replisome_counts.py
+++ b/models/ecoli/analysis/single/replisome_counts.py
@@ -16,7 +16,7 @@ from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
 
 from wholecell.io.tablereader import TableReader
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 
@@ -37,9 +37,6 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			)
 		replication_reader = TableReader(
 			os.path.join(simOutDir, "ReplicationData")
-			)
-		bulk_molecules_reader = TableReader(
-			os.path.join(simOutDir, "BulkMolecules")
 			)
 		main_reader = TableReader(
 			os.path.join(simOutDir, "Main")
@@ -70,11 +67,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			)
 
 		# Load counts of replisome subunits
-		moleculeIds = bulk_molecules_reader.readAttribute("objectNames")
-		replisome_subunit_idx = np.array([moleculeIds.index(x)
-			for x in replisome_subunit_ids])
-		replisome_subunit_counts = bulk_molecules_reader.readColumn(
-			"counts")[:, replisome_subunit_idx]
+		(replisome_subunit_counts,) = read_bulk_molecule_counts(simOutDir, (replisome_subunit_ids,))
 
 		# Load time data
 		initialTime = main_reader.readAttribute("initialTime")

--- a/models/ecoli/analysis/single/ribosome30SCounts.py
+++ b/models/ecoli/analysis/single/ribosome30SCounts.py
@@ -15,7 +15,7 @@ import cPickle
 
 from wholecell.io.tablereader import TableReader
 from wholecell.utils.sparkline import sparklineAxis, setAxisMaxMinY
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 FONT = {
@@ -38,30 +38,20 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		rRnaIds = sim_data.moleculeGroups.s30_16sRRNA
 		complexIds = [sim_data.moleculeIds.s30_fullComplex]
 
-		# Load count data for s30 proteins, rRNA, and final 30S complex
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
-
 		# Load count data for mRNAs
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))
 		mRNA_counts = mRNA_counts_reader.readColumn('mRNA_counts')
-		all_mRNA_ids = mRNA_counts_reader.readAttribute('mRNA_ids')
-
-		# Get indexes
-		moleculeIds = bulkMolecules.readAttribute("objectNames")
-		proteinIndexes = np.array([moleculeIds.index(protein) for protein in proteinIds], np.int)
-		rnaIndexes = np.array([all_mRNA_ids.index(rna) for rna in rnaIds], np.int)
-		rRnaIndexes = np.array([moleculeIds.index(rRna) for rRna in rRnaIds], np.int)
-		complexIndexes = np.array([moleculeIds.index(comp) for comp in complexIds], np.int)
+		all_mRNA_idx = {rna: i for i, rna in enumerate(mRNA_counts_reader.readAttribute('mRNA_ids'))}
+		rnaIndexes = np.array([all_mRNA_idx[rna] for rna in rnaIds], np.int)
+		rnaCounts = mRNA_counts[:, rnaIndexes]
+		(freeProteinCounts, freeRRnaCounts, complexCounts) = read_bulk_molecule_counts(
+			simOutDir, (proteinIds, rRnaIds, complexIds))
+		complexCounts = complexCounts.reshape(-1, 1)
 
 		# Load data
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))
 		initialTime = main_reader.readAttribute("initialTime")
 		time = main_reader.readColumn("time") - initialTime
-		freeProteinCounts = bulkMoleculeCounts[:, proteinIndexes]
-		rnaCounts = mRNA_counts[:, rnaIndexes]
-		freeRRnaCounts = bulkMoleculeCounts[:, rRnaIndexes]
-		complexCounts = bulkMoleculeCounts[:, complexIndexes]
 
 		uniqueMoleculeCounts = TableReader(os.path.join(simOutDir, "UniqueMoleculeCounts"))
 

--- a/models/ecoli/analysis/single/ribosomeCounts.py
+++ b/models/ecoli/analysis/single/ribosomeCounts.py
@@ -26,14 +26,6 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		if not os.path.exists(plotOutDir):
 			os.mkdir(plotOutDir)
 
-		# bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-		#
-		# moleculeIds = bulkMolecules.readAttribute("objectNames")
-		#
-		# RIBOSOME_RNA_IDS = ["RRLA-RRNA[c]", "RRSA-RRNA[c]", "RRFA-RRNA[c]"]
-		# ribosomeRnaIndexes = np.array([moleculeIds.index(rRnaId) for rRnaId in RIBOSOME_RNA_IDS], np.int)
-		# ribosomeRnaCountsBulk = bulkMolecules.readColumn("counts")[:, ribosomeRnaIndexes]
-
 		uniqueMoleculeCounts = TableReader(os.path.join(simOutDir, "UniqueMoleculeCounts"))
 		ribosomeIndex = uniqueMoleculeCounts.readAttribute("uniqueMoleculeIds").index('active_ribosome')
 

--- a/models/ecoli/analysis/single/rnapCounts.py
+++ b/models/ecoli/analysis/single/rnapCounts.py
@@ -14,7 +14,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from wholecell.io.tablereader import TableReader
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 
@@ -26,23 +26,18 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		if not os.path.exists(plotOutDir):
 			os.mkdir(plotOutDir)
 
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-		bulkMoleculeCounts = bulkMolecules.readColumn("counts")
-
-		moleculeIds = bulkMolecules.readAttribute("objectNames")
-		rnapId = "APORNAP-CPLX[c]"
-		rnapIndex = moleculeIds.index(rnapId)
-		rnapCountsBulk = bulkMoleculeCounts[:, rnapIndex]
+		rnapId = ["APORNAP-CPLX[c]"]
+		(rnapCountsBulk,) = read_bulk_molecule_counts(simOutDir, (rnapId,))
 
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))
 		mRNA_counts = mRNA_counts_reader.readColumn('mRNA_counts')
-		mRNA_ids = mRNA_counts_reader.readAttribute('mRNA_ids')
+		mRNA_idx = {rna: i for i, rna in enumerate(mRNA_counts_reader.readAttribute('mRNA_ids'))}
 
 		RNAP_RNA_IDS = [
 			"EG10893_RNA[c]", "EG10894_RNA[c]",
 			"EG10895_RNA[c]", "EG10896_RNA[c]"]
 
-		rnapRnaIndexes = np.array([mRNA_ids.index(rnapRnaId) for rnapRnaId in RNAP_RNA_IDS], np.int)
+		rnapRnaIndexes = np.array([mRNA_idx[rnapRnaId] for rnapRnaId in RNAP_RNA_IDS], np.int)
 		rnapRnaCounts = mRNA_counts[:, rnapRnaIndexes]
 
 		uniqueMoleculeCounts = TableReader(os.path.join(simOutDir, "UniqueMoleculeCounts"))

--- a/models/ecoli/analysis/single/transient_gene_dosage.py
+++ b/models/ecoli/analysis/single/transient_gene_dosage.py
@@ -40,8 +40,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			sim_data = cPickle.load(f)
 
 		# Read from sim_data
-		rna_ids = sim_data.process.transcription.rnaData["id"].tolist()
-		rna_idx = [rna_ids.index(x + "[c]") for x in RNA_ID_LIST]
+		rna_ids = {rna: i for i, rna in enumerate(sim_data.process.transcription.rnaData["id"])}
+		rna_idx = [rna_ids[x + "[c]"] for x in RNA_ID_LIST]
 		rna_coordinates = sim_data.process.transcription.rnaData[
 			"replicationCoordinate"][rna_idx]
 

--- a/models/ecoli/analysis/single/twoComponentSystem.py
+++ b/models/ecoli/analysis/single/twoComponentSystem.py
@@ -16,7 +16,7 @@ from matplotlib import pyplot as plt
 
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
-from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from models.ecoli.analysis import singleAnalysisPlot
 
 
@@ -38,16 +38,11 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			for idx, moleculeType in enumerate(moleculeTypeOrder):
 				TCS_IDS.append(str(system["molecules"][moleculeType]) + moleculeTypeLocation[idx])
 
-		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))
-		moleculeIds = bulkMolecules.readAttribute("objectNames")
-		moleculeIndexes = np.array([moleculeIds.index(moleculeId) for moleculeId in TCS_IDS], np.int)
-		moleculeCounts = bulkMolecules.readColumn("counts")[:, moleculeIndexes]
+		(moleculeCounts,) = read_bulk_molecule_counts(simOutDir, (TCS_IDS,))
 
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))
 		initialTime = main_reader.readAttribute("initialTime")
 		time = main_reader.readColumn("time") - initialTime
-
-		bulkMolecules.close()
 
 		# Convert molecule counts to concentrations
 		nAvogadro = sim_data.constants.nAvogadro.asNumber(1 / units.mol)


### PR DESCRIPTION
Inspired by #774, I decided to take a look at single analysis plots to speed them up since time waiting for them to finish has been creeping up.  This mostly replaces `.index()` calls with dictionary lookups (often under the hood with `read_bulk_molecule_counts()`) to partly address #296 and resulted in a 20% speedup locally.  Sherlock and daily builds might be a little more constrained by disk read speed so there might not be as much of an improvement but hopefully it prevents propagating the `.index()` method with very large lists.  Other analysis plots in cohort, multigen and variant scripts still use `.index()` if anyone wants to look into those.