### PR TITLE
Set upper bound for number of RNAs to degrade

### DIFF
--- a/models/ecoli/processes/rna_degradation.py
+++ b/models/ecoli/processes/rna_degradation.py
@@ -431,6 +431,7 @@ class RnaDegradation(wholecell.processes.process.Process):
 			molecules to degrade for each RNA
 		"""
 		n_rnas_to_degrade = np.zeros_like(rna_counts)
+		remaining_rna_counts = rna_counts
 
 		if rna_counts.sum() != 0:
 			while n_rnas_to_degrade.sum() < n_total_rnas_to_degrade:
@@ -439,7 +440,8 @@ class RnaDegradation(wholecell.processes.process.Process):
 						n_total_rnas_to_degrade - n_rnas_to_degrade.sum(),
 						rna_deg_probs
 						),
-					rna_counts
+					remaining_rna_counts
 					)
+				remaining_rna_counts = rna_counts - n_rnas_to_degrade
 
 		return n_rnas_to_degrade


### PR DESCRIPTION
This fixes #780. RNA degradation was not correctly setting upper bound for the number of RNAs to degrade, so in extremely rare cases `calculateRequest` was returning more RNAs to degrade than the existing counts of RNAs. I don't think this would be directly related to PR #775, but I'll keep looking out for any other failures we get.