### PR TITLE
Make printing the magnitude of error optional in voronoi plot

### DIFF
--- a/wholecell/utils/voronoi_plot_main.py
+++ b/wholecell/utils/voronoi_plot_main.py
@@ -723,6 +723,8 @@ class VoronoiMaster():
             ax_shape: the shape of the subplot, in (nrows, ncols)
             chained: whether the new subplot should be based on the previous
                 subplot or not.
+            verbose: If true, print the magnitude of the error in the areas
+                represented by the plot
 
         Returns:
             error_all: the error in total area representation.


### PR DESCRIPTION
This adds an option to the `plot()` method of the voronoi plot tool to make the printing of the magnitude of error optional, and off by default. This was done to make searching for errors in Jenkins outputs easier.