### PR TITLE
Handle collisions between replisomes and TFs in ChromosomeStructure

### DIFF
--- a/models/ecoli/listeners/replication_data.py
+++ b/models/ecoli/listeners/replication_data.py
@@ -45,8 +45,8 @@ class ReplicationData(wholecell.listeners.listener.Listener):
 		self.criticalMassPerOriC = 0.
 		self.criticalInitiationMass = 0.
 
-		self.free_DnaA_boxes = 0
 		self.total_DnaA_boxes = 0
+		self.free_DnaA_boxes = 0
 
 
 	def update(self):
@@ -67,6 +67,12 @@ class ReplicationData(wholecell.listeners.listener.Listener):
 			self.fork_coordinates[:fork_coordinates.size] = fork_coordinates
 			self.fork_domains[:fork_domains.size] = fork_domains
 			self.fork_unique_index[:fork_unique_index.size] = fork_unique_index
+
+		DnaA_boxes = self.uniqueMolecules.container.objectsInCollection('DnaA_box')
+		DnaA_box_bound = DnaA_boxes.attrs('DnaA_bound')
+
+		self.total_DnaA_boxes = len(DnaA_boxes)
+		self.free_DnaA_boxes = np.count_nonzero(np.logical_not(DnaA_box_bound))
 
 
 	def tableCreate(self, tableWriter):

--- a/models/ecoli/listeners/rna_synth_prob.py
+++ b/models/ecoli/listeners/rna_synth_prob.py
@@ -74,9 +74,11 @@ class RnaSynthProb(wholecell.listeners.listener.Listener):
 		promoters = self.uniqueMolecules.container.objectsInCollection('promoter')
 
 		if len(promoters) > 0:
-			all_coordinates, all_domains, bound_TFs = promoters.attrs(
-				"coordinates", "domain_index", "bound_TF"
+			TU_indexes, all_coordinates, all_domains, bound_TFs = promoters.attrs(
+				"TU_index", "coordinates", "domain_index", "bound_TF"
 				)
+
+			self.gene_copy_number = np.bincount(TU_indexes, minlength=self.n_TU)
 
 			bound_promoter_indexes, TF_indexes = np.where(bound_TFs)
 			n_bound_TFs = len(bound_promoter_indexes)

--- a/models/ecoli/processes/chromosome_structure.py
+++ b/models/ecoli/processes/chromosome_structure.py
@@ -1,7 +1,8 @@
 """
 ChromosomeStructure process
 
-- Resolve physical collisions between molecules on the chromosome.
+- Resolve collisions between molecules and replication forks on the chromosome.
+- Remove and replicate promoters and motifs that are traversed by replisomes.
 - TODO: Calculate the superhelical densities of each chromosomal segment
 
 @organization: Covert Lab, Department of Bioengineering, Stanford University
@@ -32,17 +33,24 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 
 		# Load parameters
 		self.RNA_sequences = sim_data.process.transcription.transcriptionSequences
+		self.n_TUs = len(sim_data.process.transcription.rnaData)
+		self.n_TFs = len(sim_data.process.transcription_regulation.tf_ids)
 
 		# Load bulk molecule views
 		self.inactive_RNAPs = self.bulkMoleculeView(sim_data.moleculeIds.rnapFull)
 		self.fragmentBases = self.bulkMoleculesView(
 			[id_ + '[c]' for id_ in sim_data.moleculeGroups.fragmentNT_IDs])
 		self.ppi = self.bulkMoleculeView(sim_data.moleculeIds.ppi)
+		self.active_tfs = self.bulkMoleculesView(
+			[x + "[c]" for x in sim_data.process.transcription_regulation.tf_ids])
 
 		# Load unique molecule views
 		self.active_replisomes = self.uniqueMoleculesView('active_replisome')
+		self.chromosome_domains = self.uniqueMoleculesView('chromosome_domain')
 		self.active_RNAPs = self.uniqueMoleculesView('active_RNAP')
 		self.RNAs = self.uniqueMoleculesView('RNA')
+		self.promoters = self.uniqueMoleculesView('promoter')
+		self.DnaA_boxes = self.uniqueMoleculesView('DnaA_box')
 
 
 	def calculateRequest(self):
@@ -50,45 +58,87 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 			# Request access to delete active RNAPs and RNAs
 			self.active_RNAPs.request_access(self.EDIT_DELETE_ACCESS)
 			self.RNAs.request_access(self.EDIT_DELETE_ACCESS)
+			self.promoters.request_access(self.EDIT_DELETE_ACCESS)
+			self.DnaA_boxes.request_access(self.EDIT_DELETE_ACCESS)
 
 	def evolveState(self):
 		# If there are no active replisomes, return immediately
 		if self.active_replisomes.total_counts()[0] == 0:
 			return
 
-		# Read attributes
+		# Read unique molecule attributes
 		replisome_domain_indexes, replisome_coordinates = self.active_replisomes.attrs(
 			'domain_index', 'coordinates')
+		all_chromosome_domain_indexes, child_domains = self.chromosome_domains.attrs(
+			'domain_index', 'child_domains')
 		RNAP_domain_indexes, RNAP_coordinates, RNAP_directions, RNAP_unique_indexes = self.active_RNAPs.attrs(
 			'domain_index', 'coordinates', 'direction', 'unique_index')
 		RNA_TU_indexes, transcript_lengths, RNA_RNAP_indexes = self.RNAs.attrs(
 			'TU_index', 'transcript_length', 'RNAP_index')
+		promoter_TU_indexes, promoter_domain_indexes, promoter_coordinates, promoter_bound_TFs = self.promoters.attrs(
+			'TU_index', 'domain_index', 'coordinates', 'bound_TF')
+		DnaA_box_domain_indexes, DnaA_box_coordinates, DnaA_box_bound = self.DnaA_boxes.attrs(
+			'domain_index', 'coordinates', 'DnaA_bound')
 
-		# Build mask for RNAPs that should be removed
-		RNAP_collision_mask = np.zeros_like(RNAP_domain_indexes, dtype=np.bool)
+		# Build dictionary of replisome coordinates with domain indexes as keys
+		replisome_coordinates_from_domains = {
+			domain_index: replisome_coordinates[replisome_domain_indexes == domain_index]
+			for domain_index in np.unique(replisome_domain_indexes)
+			}
 
-		# Loop through all domains with active replisomes
-		for domain_index in np.unique(replisome_domain_indexes):
-			domain_replisome_coordinates = replisome_coordinates[
-				replisome_domain_indexes == domain_index]
 
-			# Get mask for RNAPs on this domain that are "out of range"
-			domain_collision_mask = np.logical_and.reduce((
-				RNAP_domain_indexes == domain_index,
-				RNAP_coordinates > domain_replisome_coordinates.min(),
-				RNAP_coordinates < domain_replisome_coordinates.max()))
+		def get_removed_molecules_mask(domain_indexes, coordinates):
+			"""
+			Computes the boolean mask of unique molecules that should be
+			removed based on the progression of the replication forks.
+			"""
+			mask = np.zeros_like(domain_indexes, dtype=np.bool)
 
-			RNAP_collision_mask[domain_collision_mask] = True
+			# Loop through all domains
+			for domain_index in np.unique(domain_indexes):
+				# Domain has active replisomes
+				if domain_index in replisome_coordinates_from_domains:
+					domain_replisome_coordinates = replisome_coordinates_from_domains[
+						domain_index]
 
-		# Build separate masks for head-on and co-directional collisions
+					# Get mask for molecules on this domain that are out of range
+					domain_mask = np.logical_and.reduce((
+						domain_indexes == domain_index,
+						coordinates > domain_replisome_coordinates.min(),
+						coordinates < domain_replisome_coordinates.max()))
+
+				# Domain has no active replisomes
+				else:
+					# Domain has finished replicating
+					if np.all(domain_index < replisome_domain_indexes):
+						# Remove all molecules on this domain
+						domain_mask = (domain_indexes == domain_index)
+					# Domain has not started replication
+					else:
+						continue
+
+				mask[domain_mask] = True
+
+			return mask
+
+
+		# Build mask for molecules that should be removed
+		removed_RNAPs_mask = get_removed_molecules_mask(
+			RNAP_domain_indexes, RNAP_coordinates)
+		removed_promoters_mask = get_removed_molecules_mask(
+			promoter_domain_indexes, promoter_coordinates)
+		removed_DnaA_boxes_mask = get_removed_molecules_mask(
+			DnaA_box_domain_indexes, DnaA_box_coordinates)
+
+		# Build masks for head-on and co-directional collisions between RNAPs
+		# and replication forks
 		RNAP_headon_collision_mask = np.logical_and(
-			RNAP_collision_mask,
+			removed_RNAPs_mask,
 			np.logical_xor(RNAP_directions, RNAP_coordinates > 0))
 		RNAP_codirectional_collision_mask = np.logical_and(
-			RNAP_collision_mask,
-			np.logical_not(RNAP_headon_collision_mask))
+			removed_RNAPs_mask, np.logical_not(RNAP_headon_collision_mask))
 
-		n_total_collisions = np.count_nonzero(RNAP_collision_mask)
+		n_total_collisions = np.count_nonzero(removed_RNAPs_mask)
 		n_headon_collisions = np.count_nonzero(RNAP_headon_collision_mask)
 		n_codirectional_collisions = np.count_nonzero(
 			RNAP_codirectional_collision_mask)
@@ -111,11 +161,11 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 
 		# Get mask for RNAs that are transcribed from removed RNAPs
 		RNA_collision_mask = np.isin(
-			RNA_RNAP_indexes, RNAP_unique_indexes[RNAP_collision_mask])
+			RNA_RNAP_indexes, RNAP_unique_indexes[removed_RNAPs_mask])
 
 		# Remove RNAPs and RNAs that have collided with replisomes
 		if n_total_collisions > 0:
-			self.active_RNAPs.delByIndexes(np.where(RNAP_collision_mask)[0])
+			self.active_RNAPs.delByIndexes(np.where(removed_RNAPs_mask)[0])
 			self.RNAs.delByIndexes(np.where(RNA_collision_mask)[0])
 
 			# Increment counts of inactive RNAPs
@@ -141,3 +191,66 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 				# Increment counts of fragment NTPs and phosphates
 				self.fragmentBases.countsInc(base_counts)
 				self.ppi.countInc(n_initiated_sequences)
+
+
+		def get_replicated_motif_attributes(old_coordinates, old_domain_indexes):
+			"""
+			Computes the attributes of replicated motifs on the chromosome,
+			given the old coordinates and domain indexes of the original motifs.
+			"""
+			# Coordinates are simply repeated
+			new_coordinates = np.repeat(old_coordinates, 2)
+
+			# Domain indexes are set to the child indexes of the original index
+			new_domain_indexes = child_domains[
+				np.array([np.where(all_chromosome_domain_indexes == idx)[0][0]
+					for idx in old_domain_indexes]),
+				:].flatten()
+
+			return new_coordinates, new_domain_indexes
+
+
+		# Replicate promoters
+		n_new_promoters = 2*np.count_nonzero(removed_promoters_mask)
+
+		if n_new_promoters > 0:
+			# Delete original promoters
+			self.promoters.delByIndexes(np.where(removed_promoters_mask)[0])
+
+			# Add freed active tfs
+			self.active_tfs.countsInc(
+				promoter_bound_TFs[removed_promoters_mask, :].sum(axis=0))
+
+			# Set up attributes for the replicated promoters
+			promoter_TU_indexes_new = np.repeat(promoter_TU_indexes[removed_promoters_mask], 2)
+			promoter_coordinates_new, promoter_domain_indexes_new = get_replicated_motif_attributes(
+				promoter_coordinates[removed_promoters_mask],
+				promoter_domain_indexes[removed_promoters_mask])
+
+			# Add new promoters with new domain indexes
+			self.promoters.moleculesNew(
+				n_new_promoters,
+				TU_index=promoter_TU_indexes_new,
+				coordinates=promoter_coordinates_new,
+				domain_index=promoter_domain_indexes_new,
+				bound_TF=np.zeros((n_new_promoters, self.n_TFs), dtype=np.bool))
+
+
+		# Replicate DnaA boxes
+		n_new_DnaA_boxes = 2*np.count_nonzero(removed_DnaA_boxes_mask)
+
+		if n_new_DnaA_boxes > 0:
+			# Delete original DnaA boxes
+			self.DnaA_boxes.delByIndexes(np.where(removed_DnaA_boxes_mask)[0])
+
+			# Set up attributes for the replicated boxes
+			DnaA_box_coordinates_new, DnaA_box_domain_indexes_new = get_replicated_motif_attributes(
+				DnaA_box_coordinates[removed_DnaA_boxes_mask],
+				DnaA_box_domain_indexes[removed_DnaA_boxes_mask])
+
+			# Add new promoters with new domain indexes
+			self.DnaA_boxes.moleculesNew(
+				n_new_DnaA_boxes,
+				coordinates=DnaA_box_coordinates_new,
+				domain_index=DnaA_box_domain_indexes_new,
+				DnaA_bound=np.zeros(n_new_DnaA_boxes, dtype=np.bool))

--- a/wholecell/sim/divide_cell.py
+++ b/wholecell/sim/divide_cell.py
@@ -138,7 +138,6 @@ def chromosomeDivision(uniqueMolecules, randomState, no_child_place_holder):
 
 	# Check that the domains are being divided correctly
 	assert np.intersect1d(d1_all_domain_indexes, d2_all_domain_indexes).size == 0
-	assert d1_all_domain_indexes.size + d2_all_domain_indexes.size == domain_index_domains.size
 
 	d1_chromosome_count = d1_domain_index_full_chroms.size
 	d2_chromosome_count = d2_domain_index_full_chroms.size
@@ -253,6 +252,9 @@ def divideUniqueMolecules(uniqueMolecules, randomState,
 				d2_RNAP_unique_indexes = np.array([], dtype=np.int64)
 			continue
 
+		if molecule_name != 'chromosome_domain':
+			assert n_molecules == n_d1 + n_d2
+
 		# Add the divided unique molecules to the daughter cell containers
 		d1_divided_attributes_dict, d2_divided_attributes_dict = get_divided_attributes(
 			molecule_set, molecule_attribute_dict, d1_bool, d2_bool)
@@ -331,6 +333,8 @@ def divideUniqueMolecules(uniqueMolecules, randomState,
 				d1_RNA_unique_indexes = np.array([], dtype=np.int64)
 				d2_RNA_unique_indexes = np.array([], dtype=np.int64)
 			continue
+
+		assert n_molecules == n_d1 + n_d2
 
 		# Add the divided unique molecules to the daughter cell containers
 		d1_divided_attributes_dict, d2_divided_attributes_dict = get_divided_attributes(


### PR DESCRIPTION
This PR makes the new process `ChromosomeStructure` added by #808 also handle collisions between replicating forks and bound transcription factors. Before this PR this was being done by the `TfBinding` process by anticipating the length of DNA that would be traversed by the replication forks in this timestep. Now the `TfBinding` process binds transcription factors to the corresponding promoters without caring about replisomes, and any transcription factors that are bound to promoters that are traversed by replisomes are identified in `ChromosomeStructure` and the bound TFs released.

I also made this new process handle the replication of `promoter` and `DnaA_box` unique molecules instead of `ChromosomeReplication`, to eliminate cases where a promoter molecule gets deleted by `ChromosomeReplication` and is simultaneously bound/unbound by a transcription factor in `TfBinding` at the same process tier. This ensures that no transcription factors are lost in the simulation, and further simplifies the function of the `ChromosomeReplication` process to simple polymerization of DNA sequences.

Some other minor changes include:
- Computing the gene copy numbers & DnaA box counts internally inside listeners, instead of computing them inside processes.
- Not removing `chromosome_domain` unique molecules when the domains are fully replicated. This was needed to pass on the information needed to replicate promoters/DnaA boxes to the second tier of processes.