### PR TITLE
Fix inf ratio in metaboliteComparison

### DIFF
--- a/models/ecoli/analysis/single/metaboliteComparison.py
+++ b/models/ecoli/analysis/single/metaboliteComparison.py
@@ -53,8 +53,8 @@ def plot_data(gs, col, time, x, y, label, molecule_names):
 
 	# Plot outliers of ratio
 	means = np.mean(ratio, axis=0)
-	mean = np.mean(means)
-	std = np.std(means)
+	mean = np.mean(means[np.isfinite(means)])
+	std = np.std(means[np.isfinite(means)])
 	outliers = np.unique(
 		np.where((ratio[1:, :] > mean + std / 2) | (ratio[1:, :] < mean - std / 2))[1])
 	outliers = outliers[np.argsort(np.abs(means[outliers]))][::-1][:10]  # limit outliers to 10 with largest mean


### PR DESCRIPTION
This makes a minor adjustment to handle when a metabolite hits a concentration of 0.  The calculation lead to an inf so the bottom row was not being displayed.

New output:
![metaboliteComparison](https://user-images.githubusercontent.com/18123227/74368929-5c24df00-4d89-11ea-8217-3168ba287b4b.png)

Old output:
![old_metaboliteComparison](https://user-images.githubusercontent.com/18123227/74368936-5fb86600-4d89-11ea-8da7-15a3ed9d2912.png)