### PR TITLE
Prevent adding all equilibrium reaction edges in fathom

### DIFF
--- a/models/ecoli/analysis/causality_network/build_network.py
+++ b/models/ecoli/analysis/causality_network/build_network.py
@@ -769,6 +769,9 @@ class BuildNetwork(object):
 
 			# Loop through each element in column
 			for molecule_index, stoich in enumerate(equilibrium_stoich_matrix_column):
+				if stoich == 0:
+					continue
+
 				molecule_id = equilibrium_molecule_ids[molecule_index]
 
 				# Add Equilibrium edges
@@ -818,6 +821,9 @@ class BuildNetwork(object):
 
 			# Loop through each element in column
 			for molecule_index, stoich in enumerate(tcs_stoich_matrix_column):
+				if stoich == 0:
+					continue
+
 				molecule_id = tcs_molecule_ids[molecule_index]
 
 				if molecule_id not in monomer_ids + NONPROTEIN_MOLECULES_IN_2CS:


### PR DESCRIPTION
This fixes a bug that added all equilibrium reaction edges to every node in equilibrium.

Now:
![image](https://user-images.githubusercontent.com/18123227/74372831-318a5480-4d90-11ea-8ea8-8aae6820220d.png)

Before:
![image](https://user-images.githubusercontent.com/18123227/74372927-5a124e80-4d90-11ea-8feb-57f21079ae5c.png)

