### PR TITLE
Remove GTP info from translation

### DIFF
--- a/models/ecoli/analysis/single/growthLimits.py
+++ b/models/ecoli/analysis/single/growthLimits.py
@@ -31,7 +31,6 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			sim_data = cPickle.load(f)
 
 		moleculeIds = sim_data.moleculeGroups.aaIDs
-		moleculeIds.append('GTP[c] (translation)')
 		moleculeIds.extend(sim_data.moleculeGroups.ntpIds)
 
 		# Listeners used
@@ -43,11 +42,6 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		time = main_reader.readColumn("time") - initialTime
 
 		# Translation
-		gtpPoolSize = growth_limits_reader.readColumn("gtpPoolSize")
-		gtpRequestSize = growth_limits_reader.readColumn("gtpRequestSize")
-		gtpAllocated = growth_limits_reader.readColumn("gtpAllocated")
-		gtpUsed = growth_limits_reader.readColumn("gtpUsed")
-
 		aaPoolSize = growth_limits_reader.readColumn("aaPoolSize")
 		aaRequestSize = growth_limits_reader.readColumn("aaRequestSize")
 		aaAllocated = growth_limits_reader.readColumn("aaAllocated")
@@ -62,22 +56,18 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Create aggregate
 		poolSize = np.hstack((
 			aaPoolSize,
-			gtpPoolSize.reshape(gtpPoolSize.size, 1),
 			ntpPoolSize,
 			))
 		requestSize = np.hstack((
 			aaRequestSize,
-			gtpRequestSize.reshape(gtpPoolSize.size, 1),
 			ntpRequestSize,
 			)).astype(np.int64)
 		allocated = np.hstack((
 			aaAllocated,
-			gtpAllocated.reshape(gtpPoolSize.size, 1),
 			ntpAllocated,
 			))
 		used =  np.hstack((
 			aasUsed,
-			gtpUsed.reshape(gtpPoolSize.size, 1),
 			ntpUsed,
 			))
 

--- a/models/ecoli/analysis/single/rnaDegradationCounts.py
+++ b/models/ecoli/analysis/single/rnaDegradationCounts.py
@@ -58,13 +58,6 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		totalexoRnaseCounts = exoRnaseCounts.sum(axis = 1)
 		totalendoRnaseCounts = endoRnaseCounts.sum(axis = 1)
 
-		# Load data
-		growthLimitsDataFile = TableReader(os.path.join(simOutDir, "GrowthLimits"))
-
-		# Translation
-		gtpUsed = growthLimitsDataFile.readColumn("gtpAllocated")
-		growthLimitsDataFile.close()
-
 		# Load metabolism production
 		fbaResults = TableReader(os.path.join(simOutDir, "FBAResults"))
 		main_reader = TableReader(os.path.join(simOutDir, "Main"))
@@ -78,35 +71,31 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		plt.figure(figsize = (8.5, 11))
 		plt.rc('font', **FONT)
 		max_yticks = 5
+		n_rows = 6
+		n_cols = 2
 
-		ax = plt.subplot(7,2,1)
+		ax = plt.subplot(n_rows, n_cols, 1)
 		plt.plot(time / 60., countRnaSynthesized.sum(axis = 1))
 		plt.ylabel("RNAs synthesized", fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,2)
-		plt.plot(time / 60., gtpUsed / 1e6)
-		plt.ylabel("Translation ($10^{%d}$nt)" % 6, fontsize = 9)
-		plt.title("GTPs needed (x$10^{%d}$) = %.2f" % (6, (gtpUsed.sum() / 1e6)), fontsize = 9)
-		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
-
-		ax = plt.subplot(7,2,3)
+		ax = plt.subplot(n_rows, n_cols, 3)
 		plt.plot(time / 60., countRnaDegraded.sum(axis = 1))
 		plt.ylabel("RNAs degraded", fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,5)
+		ax = plt.subplot(n_rows, n_cols, 5)
 		plt.plot(time / 60., totalendoRnaseCounts)
 		plt.ylabel("EndoRNase counts", fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,4)
+		ax = plt.subplot(n_rows, n_cols, 2)
 		plt.plot(time / 60., countNTPsUSed / 1e6)
 		plt.ylabel("Transcription ($10^{%d}$nt)" % 6, fontsize = 9)
 		plt.title("NTPs needed(x$10^{%d}$) = %.2f" % (6, (countNTPsUSed.sum() / 1e6)), fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,7)
+		ax = plt.subplot(n_rows, n_cols, 7)
 		plt.plot(time / 60., totalexoRnaseCounts)
 		plt.ylabel("ExoRNase counts", fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
@@ -116,29 +105,30 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		IdxCtp = (np.where("CTP[c]" == outputMoleculeIDs))[0][0]; CTP = np.sum(deltaMetabolites[:, IdxCtp])
 		IdxUtp = (np.where("UTP[c]" == outputMoleculeIDs))[0][0]; UTP = np.sum(deltaMetabolites[:, IdxUtp])
 		NtpsProduced = ATP + GTP + CTP + UTP
-		ax = plt.subplot(7,2,6)
+		ax = plt.subplot(n_rows, n_cols, 4)
 		plt.plot(time / 60., (deltaMetabolites[:, IdxAtp] + deltaMetabolites[:, IdxGtp] + deltaMetabolites[:, IdxCtp] + deltaMetabolites[:, IdxUtp]) / 1e6)
 		plt.ylabel("Metabolism ($10^{%d}$nt)" % 6, fontsize = 9)
 		plt.title("NTPs produced (x$10^{%d}$) = %.2f" % (6, (sum(deltaMetabolites[:, IdxAtp] + deltaMetabolites[:, IdxGtp] + deltaMetabolites[:, IdxCtp] + deltaMetabolites[:, IdxUtp])  / 1e6)), fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,9)
+		ax = plt.subplot(n_rows, n_cols, 9)
 		plt.plot(time / 60., FractionActiveEndoRNases * 100)
 		plt.ylabel("EndoRN capacity (%)", fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,8)
+		ax = plt.subplot(n_rows, n_cols, 6)
 		plt.plot(time / 60., fragmentBasesDigested / 1e6)
 		plt.ylabel("Exo-digestion ($10^{%d}$nt)" % 6, fontsize = 9)
 		plt.title("NTPs recycled (x$10^{%d}$) = %.2f" % (6, (fragmentBasesDigested.sum() / 1e6)), fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,11)
+		ax = plt.subplot(n_rows, n_cols, 12)
 		plt.plot(time / 60., DiffRelativeFirstOrderDecay)
+		plt.xlabel("Time (min)")
 		plt.ylabel("sum(Residuals)", fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
-		ax = plt.subplot(7,2,10)
+		ax = plt.subplot(n_rows, n_cols, 8)
 		plt.plot(time / 60., (ntpCounts[:, 0] + ntpCounts[:, 1] + ntpCounts[:, 2] + ntpCounts[:, 3]) / 1e6)
 		plt.ylabel("Net production ($10^{%d}$nt)" % 6, fontsize = 9)
 		plt.title("NTPs required for cell division (x$10^{%d}$) = %.2f" % (6, ((ntpCounts[0, 0] + ntpCounts[0, 1] + ntpCounts[0, 2] + ntpCounts[0, 3])  / 1e6)), fontsize = 9)
@@ -147,18 +137,17 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# compute active ExoRNase capacity (%)
 		ActiveExoRNcapacity = fragmentBasesDigested.astype(float) / (totalexoRnaseCounts * sim_data.constants.KcatExoRNase.asNumber()) * 100
 
-		ax = plt.subplot(7,2,13)
+		ax = plt.subplot(n_rows, n_cols, 11)
 		plt.plot(time / 60., ActiveExoRNcapacity)
 		plt.xlabel("Time (min)")
 		plt.ylabel("ExoRN capacity (%)", fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)
 
 		# compute instantaneous balance of nTPs
-		InstantaneousNTPs = - gtpUsed - countNTPsUSed + (deltaMetabolites[:, IdxAtp] + deltaMetabolites[:, IdxGtp] + deltaMetabolites[:, IdxCtp] + deltaMetabolites[:, IdxUtp]) + fragmentBasesDigested
+		InstantaneousNTPs = - countNTPsUSed + (deltaMetabolites[:, IdxAtp] + deltaMetabolites[:, IdxGtp] + deltaMetabolites[:, IdxCtp] + deltaMetabolites[:, IdxUtp]) + fragmentBasesDigested
 
-		ax = plt.subplot(7,2,12)
+		ax = plt.subplot(n_rows, n_cols, 10)
 		plt.plot(time / 60., InstantaneousNTPs / 1e6)
-		plt.xlabel("Time (min)")
 		plt.ylabel("Balance ($10^{%d}$nt)" % 6, fontsize = 9)
 		plt.title("Average instantaneous balance (x$10^{%d}$) = %.4f" % (6, (np.mean(InstantaneousNTPs) / 1e6)), fontsize = 9)
 		yloc = plt.MaxNLocator(max_yticks); ax.yaxis.set_major_locator(yloc)

--- a/models/ecoli/listeners/growth_limits.py
+++ b/models/ecoli/listeners/growth_limits.py
@@ -44,11 +44,6 @@ class GrowthLimits(wholecell.listeners.listener.Listener):
 		super(GrowthLimits, self).allocate()
 
 		# For translation
-		self.gtpPoolSize = 0
-		self.gtpRequestSize = 0
-		self.gtpAllocated = 0
-		self.gtpUsed = 0
-
 		self.activeRibosomeAllocated = 0
 
 		n_aa = len(self.aaIds)
@@ -100,10 +95,6 @@ class GrowthLimits(wholecell.listeners.listener.Listener):
 		tableWriter.append(
 			time = self.time(),
 			simulationStep = self.simulationStep(),
-			gtpPoolSize = self.gtpPoolSize,
-			gtpRequestSize = self.gtpRequestSize,
-			gtpAllocated = self.gtpAllocated,
-			gtpUsed = self.gtpUsed,
 			activeRibosomeAllocated = self.activeRibosomeAllocated,
 			aaPoolSize = self.aaPoolSize,
 			aaRequestSize = self.aaRequestSize,


### PR DESCRIPTION
This does some cleanup for GTP in translation.  Since GTP usage is not handled in `polypeptide_elongation`, it doesn't make sense to keep track of these value or set the time step limits based on GTP usage.  GTP was not being requested by `polypeptide_elongation`, so `gtpAllocated` and `gtpUsed` were always 0.

A few plots needed to be updated to remove these values.

Old plots:
![growthLimits](https://user-images.githubusercontent.com/18123227/74985076-9f1b2e00-53eb-11ea-8af8-45b16a7d47ed.png)
![rnaDegradationCounts](https://user-images.githubusercontent.com/18123227/74985077-9fb3c480-53eb-11ea-8e77-0b04b944a4e0.png)

New plots:
![growthLimits](https://user-images.githubusercontent.com/18123227/74985060-96c2f300-53eb-11ea-8e9d-a0c1537f94b9.png)
![rnaDegradationCounts](https://user-images.githubusercontent.com/18123227/74985062-975b8980-53eb-11ea-9479-e483f166f93a.png)
