### PR TITLE
Print stack trace for fathom exceptions

### DIFF
--- a/wholecell/utils/scriptBase.py
+++ b/wholecell/utils/scriptBase.py
@@ -18,6 +18,7 @@ import re
 import os
 import pprint as pp
 import time
+import traceback
 from typing import Any, Callable, Iterable, List, Optional, Tuple
 
 import wholecell.utils.filepath as fp
@@ -546,7 +547,8 @@ class ScriptBase(object):
 				self.run(args)
 			except Exception as e:
 				# Handle exceptions after completion if running multiple params
-				if range_args:
+				if range_args and max([len(a) for a in range_args]) > 1:
+					traceback.print_exc()
 					exceptions.append((params, e))
 				else:
 					raise


### PR DESCRIPTION
When running `runscripts/manual/buildCausalityNetwork.py` errors were not being properly handled so this prints the stack trace for any exception that is caught in all scripts (other analysis scripts were explicitly handling this and raising another exception after the fact).

`range_args` also gets set even without a range argument given (eg `[[0], [0], [0]]` for variant, seed, gen) so we can directly raise the error if only running one combination of these parameters.