### PR TITLE
Revert secretion penalty to 1e-5

### DIFF
--- a/reconstruction/ecoli/flat/parameters.tsv
+++ b/reconstruction/ecoli/flat/parameters.tsv
@@ -26,7 +26,7 @@ metabolismInRangeObjWeight	0
 metabolismKineticObjectiveWeightLinear	1e-6	
 metabolismKineticObjectiveWeightQuadratic	1e-9	
 metabolism_kinetic_objective_weight_in_range	0.01	
-secretion_penalty_coeff	1e-3		Use variant metabolism_secretion_penalty to optimize
+secretion_penalty_coeff	1e-5		Use variant metabolism_secretion_penalty to optimize
 SensitivityAnalysisAlpha	0	
 SensitivityAnalysisKcatEndo	0	
 synthetase_charging_rate	100	1/units.s	Bosdriesz et al. FEBS. 2015.


### PR DESCRIPTION
It looks like the secretion penalty adjustment in #825 was too aggressive and is causing some sims in later generations to no longer produce UTP (halting transcription).  This leads to an error at division and otherwise undesired behavior so I'll revert to the old value for now.

@ggsun - is this division error worth handling properly?  It's effectively a dead cell if it's not producing RNA.
```
20709.59    698.19        2.125        2.382        1.075        2.200        3.328
Traceback (most recent call last):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/fireworks/firetasks/simulationDaughter.py", line 78, in run_task
    sim.run()
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/sim/simulation.py", line 239, in run
    self.finalize()
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/sim/simulation.py", line 287, in finalize
    self.daughter_paths = self._divideCellFunction()
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/sim/divide_cell.py", line 80, in divide_cell
    uniqueMolecules, randomState, chromosome_division_results, sim)
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/sim/divide_cell.py", line 408, in divideUniqueMolecules
    lost_ribosome_indexes, size=n_lost_d1, replace=False)
  File "mtrand.pyx", line 1126, in mtrand.RandomState.choice
ValueError: a must be non-empty
```