### PR TITLE
Add checks for empty index arrays during cell division

### DIFF
--- a/wholecell/sim/divide_cell.py
+++ b/wholecell/sim/divide_cell.py
@@ -252,8 +252,12 @@ def divideUniqueMolecules(uniqueMolecules, randomState,
 				d2_RNAP_unique_indexes = np.array([], dtype=np.int64)
 			continue
 
+		# Only the chromosome domains that physically exist are handed down to
+		# daughter cells
 		if molecule_name != 'chromosome_domain':
 			assert n_molecules == n_d1 + n_d2
+
+		assert np.count_nonzero(np.logical_and(d1_bool, d2_bool)) == 0
 
 		# Add the divided unique molecules to the daughter cell containers
 		d1_divided_attributes_dict, d2_divided_attributes_dict = get_divided_attributes(
@@ -336,6 +340,7 @@ def divideUniqueMolecules(uniqueMolecules, randomState,
 			continue
 
 		assert n_molecules == n_d1 + n_d2
+		assert np.count_nonzero(np.logical_and(d1_bool, d2_bool)) == 0
 
 		# Add the divided unique molecules to the daughter cell containers
 		d1_divided_attributes_dict, d2_divided_attributes_dict = get_divided_attributes(
@@ -424,6 +429,7 @@ def divideUniqueMolecules(uniqueMolecules, randomState,
 			continue
 
 		assert n_molecules == n_d1 + n_d2
+		assert np.count_nonzero(np.logical_and(d1_bool, d2_bool)) == 0
 
 		# Add the divided unique molecules to the daughter cell containers
 		d1_divided_attributes_dict, d2_divided_attributes_dict = get_divided_attributes(


### PR DESCRIPTION
This PR adds checks for empty index arrays before using `randomState.choice()` to prevent errors like the one in PR #832. These arrays should not be really be empty for "normal" simulations.

I also made the division of "lost" ribosomes that are bound to mRNAs that have already been degraded somewhat more realistic, by making sure that the ribosomes bound to the same (degraded) mRNA are always allocated to the same daughter cell.

The division routine now also checks for any overlaps between the `d1_bool` and `d2_bool` arrays through assertions.