### PR TITLE
Track and plot evaluation times for listeners and loggers

### DIFF
--- a/models/ecoli/analysis/single/evaluationTime.py
+++ b/models/ecoli/analysis/single/evaluationTime.py
@@ -35,8 +35,9 @@ def subplot(gs, x, y, title, labels, sort=False):
 	ax.grid(True, which='major')
 	ax.set_xlabel('Simulation time (min)')
 	ax.set_ylabel('Evaluation time (ms)')
-	ax.set_title(title)
-	ax.legend(legend_labels[idx], bbox_to_anchor=(1,1), prop={'size':6})
+	ax.set_title(title + ' (total {:.2f} mins)'.format(total_time.sum()))
+	ax.legend(legend_labels[idx], bbox_to_anchor=(1,1), prop={'size':6},
+		loc='upper left')
 
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
@@ -50,27 +51,46 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		evaluationTime = TableReader(os.path.join(simOutDir, "EvaluationTime"))
 		mainReader = TableReader(os.path.join(simOutDir, "Main"))
 
-		stateNames = evaluationTime.readAttribute("stateNames")
-		processNames = evaluationTime.readAttribute("processNames")
+		state_names = evaluationTime.readAttribute("state_names")
+		process_names = evaluationTime.readAttribute("process_names")
+		listener_names = evaluationTime.readAttribute("listener_names")
+		logger_names = evaluationTime.readAttribute("logger_names")
 
-		update_queries = evaluationTime.readColumn("updateQueries_times")
+		clock_times = evaluationTime.readColumn("clock_time")
+		update_queries = evaluationTime.readColumn("update_queries_times")
 		partition = evaluationTime.readColumn("partition_times")
 		merge = evaluationTime.readColumn("merge_times")
-		calculate_request = evaluationTime.readColumn("calculateRequest_times")
-		evolve_state = evaluationTime.readColumn("evolveState_times")
+		calculate_mass = evaluationTime.readColumn("calculate_mass_times")
+		calculate_request = evaluationTime.readColumn("calculate_request_times")
+		evolve_state = evaluationTime.readColumn("evolve_state_times")
+		update = evaluationTime.readColumn("update_times")
+		append = evaluationTime.readColumn("append_times")
 
 		initialTime = mainReader.readAttribute("initialTime")
 		time = (mainReader.readColumn("time") - initialTime) / 60  # min
 
-		plt.figure(figsize=(10, 10))
-		gs = GridSpec(3, 2)
-		subplot(gs[0, 0], time, update_queries, 'State.updateQueries', stateNames)
-		subplot(gs[1, 0], time, partition, 'State.partition', stateNames)
-		subplot(gs[2, 0], time, merge, 'State.merge', stateNames)
-		subplot(gs[0, 1], time, calculate_request, 'Process.calculateRequest', processNames, sort=True)
-		subplot(gs[1, 1], time, evolve_state, 'Process.evolveState', processNames, sort=True)
+		fig = plt.figure(figsize=(12, 15))
+		gs = GridSpec(4, 2)
+		subplot(gs[0, 0], time, update_queries, 'State.updateQueries', state_names)
+		subplot(gs[1, 0], time, partition, 'State.partition', state_names)
+		subplot(gs[2, 0], time, merge, 'State.merge', state_names)
+		subplot(gs[3, 0], time, calculate_mass, 'State.calculateMass', state_names)
+		subplot(gs[0, 1], time, calculate_request, 'Process.calculateRequest', process_names, sort=True)
+		subplot(gs[1, 1], time, evolve_state, 'Process.evolveState', process_names, sort=True)
+		subplot(gs[2, 1], time, update, 'Listener.update', listener_names, sort=True)
+		subplot(gs[3, 1], time, append, 'Logger.append', logger_names)
 
-		plt.tight_layout()
+		total_sim_eval_time = (clock_times[-1] - clock_times[0]) / 60  # min
+		accounted_eval_time = np.sum(np.hstack((
+			update_queries, partition, merge, calculate_mass,
+			calculate_request, evolve_state, update, append))) / 60  # min
+
+		fig.suptitle(
+			'Total sim evaluation time = {:.2f} mins, Accounted evaluation time = {:.2f} mins'.format(
+			total_sim_eval_time, accounted_eval_time))
+
+		gs.tight_layout(fig)
+		gs.update(top=0.95)
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
 		plt.close("all")
 

--- a/wholecell/listeners/evaluation_time.py
+++ b/wholecell/listeners/evaluation_time.py
@@ -5,12 +5,13 @@ EvaluationTime
 
 Large-scale, low-overhead evaluation time tracker for process/state operations.
 
-@author: John Mason
 @organization: Covert Lab, Department of Bioengineering, Stanford University
 @date: Created 6/10/2014
 """
 
 from __future__ import division
+
+import time
 
 import numpy as np
 
@@ -29,98 +30,141 @@ class EvaluationTime(wholecell.listeners.listener.Listener):
 	# Construct object graph
 	def initialize(self, sim, sim_data):
 		super(EvaluationTime, self).initialize(sim, sim_data)
+		# Clock time
+		self.clock_time = None
 
-		self.stateNames = sim.internal_states.keys()
-		self.processNames = sim.processes.keys()
+		self.state_names = sim.internal_states.keys()
+		self.process_names = sim.processes.keys()
+		self.listener_names = sim.listeners.keys()
+		self.logger_names = sim.loggers.keys()
 
-		self.nStates = len(sim.internal_states)
-		self.nProcesses = len(sim.processes)
+		self.n_states = len(sim.internal_states)
+		self.n_processes = len(sim.processes)
+		self.n_listeners = len(sim.listeners)
+		self.n_loggers = len(sim.loggers)
 
 		# State evaluation times
-		self.updateQueries_times = None
+		self.update_queries_times = None
 		self.partition_times = None
 		self.merge_times = None
-
-		self.updateQueries_total = None
+		self.calculate_mass_times = None
+		self.update_queries_total = None
 		self.partition_total = None
 		self.merge_total = None
+		self.calculate_mass_total = None
 
 		# Process evaluation times
-		self.calculateRequest_times = None
-		self.evolveState_times = None
+		self.calculate_request_times = None
+		self.evolve_state_times = None
+		self.calculate_request_total = None
+		self.evolve_state_total = None
 
-		self.calculateRequest_total = None
-		self.evolveState_total = None
+		# Listener evaluation times
+		self.update_times = None
+		self.update_total = None
+
+		# Logger evaluation times
+		self.append_times = None
+		self.append_total = None
 
 
 	# Allocate memory
 	def allocate(self):
 		super(EvaluationTime, self).allocate()
 
-		# State evaluation times
-		self.updateQueries_times = np.zeros(self.nStates, np.float64)
-		self.partition_times = np.zeros_like(self.updateQueries_times)
-		self.merge_times = np.zeros_like(self.updateQueries_times)
+		# Clock time
+		self.clock_time = 0
 
-		self.updateQueries_total = 0
+		# State evaluation times
+		self.update_queries_times = np.zeros(self.n_states, np.float64)
+		self.partition_times = np.zeros_like(self.update_queries_times)
+		self.merge_times = np.zeros_like(self.update_queries_times)
+		self.calculate_mass_times = np.zeros_like(self.update_queries_times)
+		self.update_queries_total = 0
 		self.partition_total = 0
 		self.merge_total = 0
+		self.calculate_mass_total = 0
 
 		# Process evaluation times
-		self.calculateRequest_times = np.zeros(self.nProcesses, np.float64)
-		self.evolveState_times = np.zeros_like(self.calculateRequest_times)
+		self.calculate_request_times = np.zeros(self.n_processes, np.float64)
+		self.evolve_state_times = np.zeros_like(self.calculate_request_times)
+		self.calculate_request_total = 0
+		self.evolve_state_total = 0
 
-		self.calculateRequest_total = 0
-		self.evolveState_total = 0
+		# Listener evaluation times
+		self.update_times = np.zeros(self.n_listeners, np.float64)
+		self.update_total = 0
+
+		# Logger evaluation times
+		self.append_times = np.zeros(self.n_loggers, np.float64)
+		self.append_total = 0
 
 
-	def reset_evaluation_time(self):
+	def reset_evaluation_times(self):
 		"""
-		Reset evaluation time vectors for processes and states.
+		Reset evaluation time vectors of process and state methods that are
+		run for each tier in the process hierarchy to zero.
 		"""
-		self.updateQueries_times.fill(0)
-		self.calculateRequest_times.fill(0)
+		self.update_queries_times.fill(0)
 		self.partition_times.fill(0)
-		self.evolveState_times.fill(0)
 		self.merge_times.fill(0)
+
+		self.calculate_request_times.fill(0)
+		self.evolve_state_times.fill(0)
 
 
 	def update(self):
-		self.updateQueries_total = self.updateQueries_times.sum()
+		self.clock_time = time.time()
+
+		self.update_queries_total = self.update_queries_times.sum()
 		self.partition_total = self.partition_times.sum()
 		self.merge_total = self.merge_times.sum()
+		self.calculate_mass_total = self.calculate_mass_times.sum()
 
-		self.calculateRequest_total = self.calculateRequest_times.sum()
-		self.evolveState_total = self.evolveState_times.sum()
+		self.calculate_request_total = self.calculate_request_times.sum()
+		self.evolve_state_total = self.evolve_state_times.sum()
+
+		self.update_total = self.update_times.sum()
+
+		self.append_total = self.append_times.sum()
 
 
 	def tableCreate(self, tableWriter):
 		# Handle the edge case of a simulation with no processes
-		if self.nProcesses == 0:
+		if self.n_processes == 0:
 			return
 
 		tableWriter.writeAttributes(
-			stateNames = self.stateNames,
-			processNames = self.processNames
+			state_names = self.state_names,
+			process_names = self.process_names,
+			listener_names = self.listener_names,
+			logger_names = self.logger_names,
 			)
 
 
 	def tableAppend(self, tableWriter):
 		# Handle the edge case of a simulation with no processes
-		if self.nProcesses == 0:
+		if self.n_processes == 0:
 			return
 
 		tableWriter.append(
 			time = self.time(),
 			simulationStep = self.simulationStep(),
-			updateQueries_times = self.updateQueries_times,
+			clock_time=self.clock_time,
+			update_queries_times = self.update_queries_times,
 			partition_times = self.partition_times,
 			merge_times = self.merge_times,
-			calculateRequest_times = self.calculateRequest_times,
-			evolveState_times = self.evolveState_times,
-			updateQueries_total = self.updateQueries_total,
+			calculate_mass_times = self.calculate_mass_times,
+			calculate_request_times = self.calculate_request_times,
+			evolve_state_times = self.evolve_state_times,
+			update_times = self.update_times,
+			append_times = self.append_times,
+			update_queries_total = self.update_queries_total,
 			partition_total = self.partition_total,
 			merge_total = self.merge_total,
-			calculateRequest_total = self.calculateRequest_total,
-			evolveState_total = self.evolveState_total,
+			calculate_mass_total = self.calculate_mass_total,
+			calculate_request_total = self.calculate_request_total,
+			evolve_state_total = self.evolve_state_total,
+			update_total = self.update_total,
+			append_total = self.append_total,
 			)

--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -191,7 +191,7 @@ class Simulation(lens.actor.inner.Simulation):
 			hook.postCalcInitialConditions(self)
 
 		# Make permanent reference to evaluation time listener
-		self._evalTime = self.listeners["EvaluationTime"]
+		self._eval_time = self.listeners["EvaluationTime"]
 
 		# Perform initial mass calculations
 		for state in self.internal_states.itervalues():
@@ -230,7 +230,6 @@ class Simulation(lens.actor.inner.Simulation):
 		Run the simulation for the time period specified in `self._lengthSec`
 		and then clean up.
 		"""
-
 		try:
 			self.run_incremental(self._lengthSec + self.initialTime())
 			if not self._raise_on_time_limit:
@@ -304,7 +303,7 @@ class Simulation(lens.actor.inner.Simulation):
 			state.reset_process_mass_diffs()
 
 		# Reset values in evaluationTime listener
-		self._evalTime.reset_evaluation_time()
+		self._eval_time.reset_evaluation_times()
 
 	# Calculate temporal evolution
 	def _evolveState(self, processes):
@@ -313,27 +312,27 @@ class Simulation(lens.actor.inner.Simulation):
 		for i, state in enumerate(self.internal_states.itervalues()):
 			t = time.time()
 			state.updateQueries()
-			self._evalTime.updateQueries_times[i] += time.time() - t
+			self._eval_time.update_queries_times[i] += time.time() - t
 
 		# Calculate requests
 		for i, process in enumerate(self.processes.itervalues()):
 			if process.__class__ in processes:
 				t = time.time()
 				process.calculateRequest()
-				self._evalTime.calculateRequest_times[i] += time.time() - t
+				self._eval_time.calculate_request_times[i] += time.time() - t
 
 		# Partition states among processes
 		for i, state in enumerate(self.internal_states.itervalues()):
 			t = time.time()
 			state.partition(processes)
-			self._evalTime.partition_times[i] += time.time() - t
+			self._eval_time.partition_times[i] += time.time() - t
 
 		# Simulate submodels
 		for i, process in enumerate(self.processes.itervalues()):
 			if process.__class__ in processes:
 				t = time.time()
 				process.evolveState()
-				self._evalTime.evolveState_times[i] += time.time() - t
+				self._eval_time.evolve_state_times[i] += time.time() - t
 
 		# Check that timestep length was short enough
 		for process_name, process in self.processes.iteritems():
@@ -344,7 +343,7 @@ class Simulation(lens.actor.inner.Simulation):
 		for i, state in enumerate(self.internal_states.itervalues()):
 			t = time.time()
 			state.merge(processes)
-			self._evalTime.merge_times[i] += time.time() - t
+			self._eval_time.merge_times[i] += time.time() - t
 
 		# update environment state
 		for state in self.external_states.itervalues():
@@ -352,20 +351,28 @@ class Simulation(lens.actor.inner.Simulation):
 
 	def _post_evolve_state(self):
 		# Calculate mass of all molecules after evolution
-		for state in self.internal_states.itervalues():
+		for i, state in enumerate(self.internal_states.itervalues()):
+			t = time.time()
 			state.calculateMass()
+			self._eval_time.calculate_mass_times[i] = time.time() - t
 
 		# Update listeners
-		for listener in self.listeners.itervalues():
+		for i, listener in enumerate(self.listeners.itervalues()):
+			t = time.time()
 			listener.update()
+			self._eval_time.update_times[i] = time.time() - t
 
 		# Run post-evolveState hooks
 		for hook in self.hooks.itervalues():
 			hook.postEvolveState(self)
 
 		# Append loggers
-		for logger in self.loggers.itervalues():
+		for i, logger in enumerate(self.loggers.itervalues()):
+			t = time.time()
 			logger.append(self)
+			# Note: these values are written at the next timestep
+			self._eval_time.append_times[i] = time.time() - t
+
 
 	def _seedFromName(self, name):
 		return np.uint32((self._seed + hash(name)) % np.iinfo(np.uint64).max)


### PR DESCRIPTION
This PR adds tracking and plotting of evaluation times for the `update()` methods of listeners and the `append()` methods of loggers. The new `single/evaluationTime.py` plot is attached below - we also now calculate the difference between the total running time of the sim and the sum of all evaluation times being accounted for in this plot, such that we'll know when something outside of this plot is using up a good chunk of our runtime.

![evaluationTime](https://user-images.githubusercontent.com/32276711/75600095-26a61400-5a60-11ea-9e0d-b23dd049cae9.png)

Note that since the object that keeps track of the evaluation times is in itself a listener, and these time values are written to disc during `Logger.append()`, the evaluation times for the `Logger.append()` are always written one timestep behind the actual timestep for which this value was measured. This should offset what we're seeing in the plot by one timestep, but shouldn't really impact the bigger picture.

Fixes #831.