### PR TITLE
Adjust pyrE expression 2x for UTP synthesis

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -42,6 +42,7 @@ RNA_EXPRESSION_ADJUSTMENTS = {
 	"EG12298_RNA[c]": 10,  # yibQ, Predicted polysaccharide deacetylase; This RNA is fit for the anaerobic condition viability
 	"EG11672_RNA[c]": 10,  # atoB, acetyl-CoA acetyltransferase; This RNA is fit for the anaerobic condition viability
 	"EG10238_RNA[c]": 10,  # dnaE, DNA polymerase III subunit alpha; This RNA is fit for the sims to produce enough DNAPs for timely replication
+	"EG10808_RNA[c]": 2,  # pyrE, orotate phosphoribosyltransferase; Needed for UTP synthesis, transcriptional regulation by UTP is not included in the model
 	}
 RNA_DEG_RATES_ADJUSTMENTS = {
 	"EG11493_RNA[c]": 2,  # pabC, aminodeoxychorismate lyase


### PR DESCRIPTION
This should fix the underlying modeling problem that lead to the error and stack trace reported in #832.  With the removal of CYTOSINE[c] from the environment in #824, pyrE becomes an essential gene in our model (confirmed with KO sim before and after the change).  This is in line with it's EcoCyc annotation as essential in minimal + glc.  The problem is we don't appear to be making enough pyrE so counts were going to 0, preventing UTP synthesis and stopping further transcription that could produce the gene.  UTP acts as a transcriptional regulator of pyrE by causing termination of an upstream gene (rph) that could be in the same transcription unit as pyrE so when levels of UTP drop we should see more expression of pyrE.  Ideally the model would have this transcription unit structure and UTP regulation but until that point we'll have to settle for an adjustment to the expression to ensure UTP synthesis.

This number may need to be bumped if we keep running into a lack of pyrE but with a 2x value we should actually be closer to the protein copy number reported on EcoCyc than we were before - reported 119 proteins/cell in MOPS + glc vs ~50 starting monomers/cell before this change (the enzyme is a dimer so it is easier to dilute out to 0 in the model).