### PR TITLE
Encapsulate flow bounds performance boost in solver class

### DIFF
--- a/models/ecoli/processes/metabolism.py
+++ b/models/ecoli/processes/metabolism.py
@@ -120,8 +120,6 @@ class Metabolism(wholecell.processes.process.Process):
 		shape = (catalysisMatrixI.max() + 1, catalysisMatrixJ.max() + 1)
 		self.catalysisMatrix = csr_matrix((catalysisMatrixV, (catalysisMatrixI, catalysisMatrixJ)), shape = shape)
 
-		self.catalyzedReactionBoundsPrev = np.inf * np.ones(len(self.reactions_with_catalyst))
-
 		# Function to compute reaction targets based on kinetic parameters and molecule concentrations
 		self.getKineticConstraints = sim_data.process.metabolism.getKineticConstraints
 
@@ -310,13 +308,8 @@ class Metabolism(wholecell.processes.process.Process):
 		catalyzedReactionBounds[rxnPresence == 0] = 0
 		if self.shuffleCatalyzedIdxs is not None:
 			catalyzedReactionBounds = catalyzedReactionBounds[self.shuffleCatalyzedIdxs]
-
-		## Only update reaction limits that are different from previous time step
-		updateIdxs = np.where(catalyzedReactionBounds != self.catalyzedReactionBoundsPrev)[0]
-		updateRxns = [self.reactions_with_catalyst[idx] for idx in updateIdxs]
-		updateVals = catalyzedReactionBounds[updateIdxs]
-		self.fba.setReactionFluxBounds(updateRxns, upperBounds=updateVals, raiseForReversible=False)
-		self.catalyzedReactionBoundsPrev = catalyzedReactionBounds
+		self.fba.setReactionFluxBounds(self.reactions_with_catalyst,
+			upperBounds=catalyzedReactionBounds, raiseForReversible=False)
 
 		# Constrain reactions based on kinetic values
 		kineticsEnzymesCountsInit = self.kineticsEnzymes.counts()

--- a/wholecell/utils/_netflow/nf_glpk.py
+++ b/wholecell/utils/_netflow/nf_glpk.py
@@ -299,26 +299,29 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 			upperBound (float) - upper bound for flow (None if unchanged)
 		"""
 
+		reset_bounds = False
 		idx = self._getVar(flow)
-		if lowerBound is not None:
+		if lowerBound is not None and self._lb[flow] != lowerBound:
 			self._lb[flow] = lowerBound
-		if upperBound is not None:
+			reset_bounds = True
+		if upperBound is not None and self._ub[flow] != upperBound:
 			self._ub[flow] = upperBound
+			reset_bounds = True
 
-		self._set_col_bounds(
-			1 + idx,				# GLPK does 1 indexing
-			self._lb[flow],
-			self._ub[flow],
-			)
-
-		self._solved = False
+		if reset_bounds:
+			self._set_col_bounds(
+				1 + idx,  # GLPK does 1 indexing
+				self._lb[flow],
+				self._ub[flow],
+				)
+			self._solved = False
 
 	def setFlowObjectiveCoeff(self, flow, coefficient):
 		idx = self._getVar(flow)
 		self._objective[flow] = coefficient
 		glp.glp_set_obj_coef(
 			self._lp,
-			1 + idx,				# GLPK does 1 indexing
+			1 + idx,  # GLPK does 1 indexing
 			coefficient
 			)
 


### PR DESCRIPTION
This moves a performance modification from the metabolism process file to the underlying LP solver class.  This should make sure that FBA functionality is encapsulated in the modular_fba and solver classes so that creating a new `FluxBalanceAnalysis` in metabolism is not affected by other class attributes in metabolism.  The old implementation required resetting both `self.fba` and `self.catalyzedReactionBoundsPrev` when creating a new FBA object, otherwise bounds would not be set properly for the new object.  Performance seems comparable with identical sim output.