### PR TITLE
Calculate number of ribosomes bound to each RNAP

### DIFF
--- a/models/ecoli/analysis/single/chromosome_visualization.py
+++ b/models/ecoli/analysis/single/chromosome_visualization.py
@@ -79,6 +79,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		rnap_coordinates = rnap_data_reader.readColumn("active_rnap_coordinates")
 		rnap_domain_indexes = rnap_data_reader.readColumn("active_rnap_domain_indexes")
 		rnap_unique_indexes = rnap_data_reader.readColumn("active_rnap_unique_indexes")
+		rnap_n_bound_ribosomes = rnap_data_reader.readColumn("active_rnap_n_bound_ribosomes")
 
 		# Load bound TF attributes
 		bound_TF_coordinates = rna_synth_prob_reader.readColumn("bound_TF_coordinates")
@@ -93,7 +94,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# replisome. The status array is set to the appropriate flag values
 		# depending on the status of the corresponding replisome (column)
 		# at the given timestep (row).
-		fork_coordinates_parsed = np.zeros((n_timesteps, n_unique_replisomes))
+		fork_coordinates_parsed = np.zeros((n_timesteps, n_unique_replisomes), dtype=np.int64)
 		fork_status = np.zeros((n_timesteps, n_unique_replisomes), dtype=np.int64)
 		fork_domain_indexes_parsed = np.zeros(n_unique_replisomes, dtype=np.int64)
 
@@ -115,9 +116,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		rnap_isnan = np.isnan(rnap_coordinates)
 
 		rnap_status = np.logical_not(rnap_isnan)
-		rnap_coordinates = np.nan_to_num(rnap_coordinates)
-		rnap_domain_indexes = np.nan_to_num(rnap_domain_indexes)
-		rnap_unique_indexes = np.nan_to_num(rnap_unique_indexes)
+		rnap_coordinates = np.nan_to_num(rnap_coordinates).astype(np.int64)
+		rnap_domain_indexes = np.nan_to_num(rnap_domain_indexes).astype(np.int64)
+		rnap_unique_indexes = np.nan_to_num(rnap_unique_indexes).astype(np.int64)
+		rnap_n_bound_ribosomes = np.nan_to_num(rnap_n_bound_ribosomes).astype(np.int64)
 
 		# Build array for quick indexing into the identical RNAP molecule that
 		# shares the same unique ID in the next timestep.
@@ -186,6 +188,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 				"coordinates": rnap_coordinates.tolist(),
 				"domain_indexes": rnap_domain_indexes.tolist(),
 				"flag_last_timestep": LAST_TIMESTEP,
+				"n_bound_ribosomes": rnap_n_bound_ribosomes.tolist(),
 				"next_indexes": rnap_next_indexes.tolist(),
 				"status": rnap_status.tolist(),
 				},

--- a/models/ecoli/listeners/rnap_data.py
+++ b/models/ecoli/listeners/rnap_data.py
@@ -11,6 +11,7 @@ from __future__ import division
 import numpy as np
 
 import wholecell.listeners.listener
+from models.ecoli.processes.transcript_elongation import get_mapping_arrays
 
 VERBOSE = False
 
@@ -53,6 +54,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 		self.active_rnap_coordinates = np.array([], np.int64)
 		self.active_rnap_domain_indexes = np.array([], np.int32)
 		self.active_rnap_unique_indexes = np.array([], np.int64)
+		self.active_rnap_n_bound_ribosomes = np.array([], np.int64)
 		self.headon_collision_coordinates = np.array([], np.int64)
 		self.codirectional_collision_coordinates = np.array([], np.int64)
 
@@ -60,18 +62,43 @@ class RnapData(wholecell.listeners.listener.Listener):
 	def update(self):
 		active_rnaps = self.uniqueMolecules.container.objectsInCollection(
 			'active_RNAP')
+		RNAs = self.uniqueMolecules.container.objectsInCollection('RNA')
+		active_ribosomes = self.uniqueMolecules.container.objectsInCollection('active_ribosome')
 
 		# Read coordinates of all active RNAPs
 		if len(active_rnaps) > 0:
-			coordinates, domain_indexes, unique_indexes = active_rnaps.attrs(
+			coordinates, domain_indexes, RNAP_unique_indexes = active_rnaps.attrs(
 				"coordinates", "domain_index", "unique_index")
 			self.active_rnap_coordinates = coordinates
 			self.active_rnap_domain_indexes = domain_indexes
-			self.active_rnap_unique_indexes = unique_indexes
+			self.active_rnap_unique_indexes = RNAP_unique_indexes
+
+			RNA_RNAP_index, is_full_transcript, RNA_unique_indexes = RNAs.attrs(
+				'RNAP_index', 'is_full_transcript', 'unique_index')
+			is_partial_transcript = np.logical_not(is_full_transcript)
+			partial_RNA_RNAP_indexes = RNA_RNAP_index[is_partial_transcript]
+			partial_RNA_unique_indexes = RNA_unique_indexes[is_partial_transcript]
+
+			if len(active_ribosomes) > 0:
+				ribosome_RNA_index = active_ribosomes.attr('mRNA_index')
+			else:
+				ribosome_RNA_index = np.array([])
+
+			RNA_index_counts = dict(
+				zip(*np.unique(ribosome_RNA_index, return_counts=True)))
+
+			partial_RNA_to_RNAP_mapping, _ = get_mapping_arrays(
+				partial_RNA_RNAP_indexes, RNAP_unique_indexes)
+
+			self.active_rnap_n_bound_ribosomes = np.array(
+				[RNA_index_counts.get(partial_RNA_unique_indexes[i], 0)
+					for i in partial_RNA_to_RNAP_mapping])
+
 		else:
 			self.active_rnap_coordinates = np.array([])
 			self.active_rnap_domain_indexes = np.array([])
 			self.active_rnap_unique_indexes = np.array([])
+			self.active_rnap_n_bound_ribosomes = np.array([])
 
 
 	def tableCreate(self, tableWriter):
@@ -87,6 +114,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 			'active_rnap_coordinates',
 			'active_rnap_domain_indexes',
 			'active_rnap_unique_indexes',
+			'active_rnap_n_bound_ribosomes',
 			'headon_collision_coordinates',
 			'codirectional_collision_coordinates',
 			)
@@ -99,6 +127,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 			active_rnap_coordinates=self.active_rnap_coordinates,
 			active_rnap_domain_indexes=self.active_rnap_domain_indexes,
 			active_rnap_unique_indexes=self.active_rnap_unique_indexes,
+			active_rnap_n_bound_ribosomes=self.active_rnap_n_bound_ribosomes,
 			actualElongations = self.actualElongations,
 			didTerminate = self.didTerminate,
 			didInitialize = self.didInitialize,

--- a/models/ecoli/processes/transcript_elongation.py
+++ b/models/ecoli/processes/transcript_elongation.py
@@ -16,7 +16,6 @@ TODO:
 from __future__ import division
 
 import numpy as np
-from itertools import izip
 
 import wholecell.processes.process
 from wholecell.utils.polymerize import buildSequences, polymerize, computeMassIncrease
@@ -174,7 +173,7 @@ class TranscriptElongation(wholecell.processes.process.Process):
 		assert (np.count_nonzero(RNAP_index_partial_RNAs == -1) == 0)
 
 		# Get mapping indexes between partial RNAs to RNAPs
-		partial_RNA_to_RNAP_mapping, RNAP_to_partial_RNA_mapping = self._get_mapping_arrays(
+		partial_RNA_to_RNAP_mapping, RNAP_to_partial_RNA_mapping = get_mapping_arrays(
 			RNAP_index_partial_RNAs, RNAP_unique_index)
 
 		# Rescale boolean array of directions to an array of 1's and -1's.
@@ -286,21 +285,17 @@ class TranscriptElongation(wholecell.processes.process.Process):
 			(terminal_lengths - length_partial_RNAs)[did_terminate_mask].sum())
 
 
-	def _get_mapping_arrays(self, x, y):
-		"""
-		Returns the array of indexes of each element of array x in array y, and
-		vice versa. Assumes that the elements of x and y are unique, and
-		set(x) == set(y).
-		"""
-		x_argsort = np.argsort(x)
-		y_argsort = np.argsort(y)
+	def isTimeStepShortEnough(self, inputTimeStep, timeStepSafetyFraction):
+		return inputTimeStep <= self.max_time_step
 
-		x_to_y = x_argsort[self._argsort_unique(y_argsort)]
-		y_to_x = y_argsort[self._argsort_unique(x_argsort)]
 
-		return x_to_y, y_to_x
-
-	def _argsort_unique(self, idx):
+def get_mapping_arrays(x, y):
+	"""
+	Returns the array of indexes of each element of array x in array y, and
+	vice versa. Assumes that the elements of x and y are unique, and
+	set(x) == set(y).
+	"""
+	def argsort_unique(idx):
 		"""
 		Quicker argsort for arrays that are permutations of np.arange(n).
 		"""
@@ -309,5 +304,10 @@ class TranscriptElongation(wholecell.processes.process.Process):
 		argsort_idx[idx] = np.arange(n)
 		return argsort_idx
 
-	def isTimeStepShortEnough(self, inputTimeStep, timeStepSafetyFraction):
-		return inputTimeStep <= self.max_time_step
+	x_argsort = np.argsort(x)
+	y_argsort = np.argsort(y)
+
+	x_to_y = x_argsort[argsort_unique(y_argsort)]
+	y_to_x = y_argsort[argsort_unique(x_argsort)]
+
+	return x_to_y, y_to_x


### PR DESCRIPTION
This PR allows the model to keep track of the number of ribosomes that are attached to each RNA polymerase, i.e. ribosomes that are translating polypeptides in the nascent mRNA that is being polymerized by the RNA polymerase. The resulting values are used in the `chromosome_visualization.py` analysis script to generate a JSON file, which is used as an input to the SVG visualization of the chromosome.