### PR TITLE
Abort translation from ribosomes on mRNAs removed by collisions

### DIFF
--- a/models/ecoli/analysis/single/replisome_rnap_collisions.py
+++ b/models/ecoli/analysis/single/replisome_rnap_collisions.py
@@ -37,23 +37,39 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		n_total_collisions = rnap_data_reader.readColumn("n_total_collisions")
 		n_headon_collisions = rnap_data_reader.readColumn("n_headon_collisions")
 		n_codirectional_collisions = rnap_data_reader.readColumn("n_codirectional_collisions")
+		n_removed_ribosomes = rnap_data_reader.readColumn("n_removed_ribosomes")
+
+		# Get cumulative sums
+		n_total_collisions_cumulative = np.cumsum(n_total_collisions)
+		n_headon_collisions_cumulative = np.cumsum(n_headon_collisions)
+		n_codirectional_collisions_cumulative = np.cumsum(n_codirectional_collisions)
+		n_removed_ribosomes_cumulative = np.cumsum(n_removed_ribosomes)
 
 		# Plot
 		plt.figure(figsize = (8.5, 11))
 
-		ax = plt.subplot(3, 1, 1)
-		ax.plot(time / 60., np.cumsum(n_total_collisions))
-		ax.set_title("All collisions")
+		ax = plt.subplot(4, 1, 1)
+		ax.plot(time / 60., n_total_collisions_cumulative)
+		ax.set_title("All collisions (Total {})".format(
+			n_total_collisions_cumulative[-1]))
 		ax.set_ylabel("Cumulative Counts")
 
-		ax = plt.subplot(3, 1, 2)
-		ax.plot(time / 60., np.cumsum(n_headon_collisions))
-		ax.set_title("Head-on collisions")
+		ax = plt.subplot(4, 1, 2)
+		ax.plot(time / 60., n_headon_collisions_cumulative)
+		ax.set_title("Head-on collisions (Total {})".format(
+			n_headon_collisions_cumulative[-1]))
 		ax.set_ylabel("Cumulative Counts")
 
-		ax = plt.subplot(3, 1, 3)
-		ax.plot(time / 60., np.cumsum(n_codirectional_collisions))
-		ax.set_title("Co-directional collisions")
+		ax = plt.subplot(4, 1, 3)
+		ax.plot(time / 60., n_codirectional_collisions_cumulative)
+		ax.set_title("Co-directional collisions (Total {})".format(
+			n_codirectional_collisions_cumulative[-1]))
+		ax.set_ylabel("Cumulative Counts")
+
+		ax = plt.subplot(4, 1, 4)
+		ax.plot(time / 60., n_removed_ribosomes_cumulative)
+		ax.set_title("Removed ribosomes (Total {})".format(
+			n_removed_ribosomes_cumulative[-1]))
 		ax.set_ylabel("Cumulative Counts")
 		ax.set_xlabel("Time (min)")
 

--- a/models/ecoli/listeners/rnap_data.py
+++ b/models/ecoli/listeners/rnap_data.py
@@ -48,6 +48,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 		self.n_total_collisions = 0
 		self.n_headon_collisions = 0
 		self.n_codirectional_collisions = 0
+		self.n_removed_ribosomes = 0
 
 		# Entries with variable lengths
 		self.active_rnap_coordinates = np.array([], np.int64)
@@ -107,6 +108,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 			n_total_collisions=self.n_total_collisions,
 			n_headon_collisions=self.n_headon_collisions,
 			n_codirectional_collisions=self.n_codirectional_collisions,
+			n_removed_ribosomes=self.n_removed_ribosomes,
 			headon_collision_coordinates=self.headon_collision_coordinates,
 			codirectional_collision_coordinates=self.codirectional_collision_coordinates,
 			)


### PR DESCRIPTION
This PR makes the `ChromosomeStructure` process remove active ribosomes bound to mRNAs that are removed by collisions with replication forks. The nascent polypeptides attached to these ribosomes are instantly degraded into amino acids. The number of ribosomes removed in this way were added to the `replisome_rnap_collisions.py` analysis plot - at basal conditions the number is around 650 for one generation.

![replisome_rnap_collisions](https://user-images.githubusercontent.com/32276711/75739856-e7bfca80-5cba-11ea-82f7-9154b5acbf04.png)
