### PR TITLE
Order Toya IDs for matching index to data

### DIFF
--- a/wholecell/utils/toya.py
+++ b/wholecell/utils/toya.py
@@ -41,10 +41,10 @@ def adjust_toya_data(data, cell_masses, dry_masses, cell_density):
 
 
 def get_common_ids(toya_reaction_ids, root_to_id_indices_map):
-	return (
+	return list(sorted((
 		set(toya_reaction_ids)
 		& set(root_to_id_indices_map.keys())
-	)
+	)))
 
 
 def get_root_to_id_indices_map(sim_reaction_ids):


### PR DESCRIPTION
This orders the IDs that are used to extract flux data so that IDs can be matched to data by indexing into the list instead of returning a set.