### PR TITLE
Add freed TFs to total count

### DIFF
--- a/models/ecoli/processes/tf_binding.py
+++ b/models/ecoli/processes/tf_binding.py
@@ -118,7 +118,9 @@ class TfBinding(wholecell.processes.process.Process):
 			active_tf_view.countInc(bound_tf_counts)
 
 			# Get counts of transcription factors
-			active_tf_counts = active_tf_view.total_counts()
+			# countInc() above increases count() but not total_counts() value
+			# so need to add freed TFs to the total active
+			active_tf_counts = active_tf_view.total_counts() + bound_tf_counts
 			n_available_active_tfs = active_tf_view.count()
 
 			# If there are no active transcription factors to work with,


### PR DESCRIPTION
This fixes the error in the jenkins builds today introduced in #843.  `counts()` and `total_counts()` do not have the same behavior - `counts()` is affected by `countInc()` but `total_counts()` is not so freed counts need to be added to the total.


Error in minimal, +AA and anaerobic builds.
```
Traceback (most recent call last):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/fireworks/firetasks/simulationDaughter.py", line 78, in run_task
    sim.run()
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/sim/simulation.py", line 234, in run
    self.run_incremental(self._lengthSec + self.initialTime())
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/sim/simulation.py", line 266, in run_incremental
    self._evolveState(processes)
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/sim/simulation.py", line 334, in _evolveState
    process.evolveState()
  File "/scratch/groups/mcovert/jenkins/workspace@2/models/ecoli/processes/tf_binding.py", line 135, in evolveState
    active_tf_counts, inactive_tf_counts)
  File "/scratch/groups/mcovert/jenkins/workspace@2/reconstruction/ecoli/dataclasses/process/transcription_regulation.py", line 67, in pPromoterBoundTF
    return float(tfActive) / (float(tfActive) + float(tfInactive))
ZeroDivisionError: float division by zero
```