### PR TITLE
Raise exception if adding a constraint to metabolism after problem is set up

### DIFF
--- a/wholecell/utils/_netflow/nf_cplex.py
+++ b/wholecell/utils/_netflow/nf_cplex.py
@@ -49,7 +49,7 @@ class NetworkFlowCPLEX(NetworkFlowProblemBase):
 		if flow in self._flows:
 			idx = self._flows[flow]
 		elif self._eqConstBuilt:
-			raise Exception('Equality constraints already built. Unable to add new flow: "{}".'.format(flow))
+			raise ValueError('Equality constraints already built. Unable to add new flow: "{}".'.format(flow))
 		else:
 			self._model.variables.add(obj=[0])
 			idx = len(self._flows)
@@ -65,11 +65,11 @@ class NetworkFlowCPLEX(NetworkFlowProblemBase):
 		if self._eqConstBuilt:
 			materialIdx = self._materialIdxLookup.get(material, None)
 			if materialIdx is None:
-				raise Exception("Invalid material")
+				raise ValueError("Invalid material: {}".format(material))
 
 			flowIdx = self._flows.get(flow, None)
 			if flowIdx is None:
-				raise Exception("Invalid flow")
+				raise ValueError("Invalid flow: {}".format(flow))
 
 			coeffs, flowIdxs = zip(*self._materialCoeffs[material])
 			coeffs = list(coeffs)
@@ -137,7 +137,7 @@ class NetworkFlowCPLEX(NetworkFlowProblemBase):
 	def getShadowPrices(self, materials):
 		# reduced cost of row
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
 
 		self._solve()
 
@@ -147,7 +147,7 @@ class NetworkFlowCPLEX(NetworkFlowProblemBase):
 	def getReducedCosts(self, fluxNames):
 		# reduced cost of col
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
 
 		self._solve()
 
@@ -160,7 +160,7 @@ class NetworkFlowCPLEX(NetworkFlowProblemBase):
 
 	def getSMatrix(self):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing S matrix.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing S matrix.")
 		A = np.zeros((len(self._materialCoeffs), len(self._flows)))
 		self._materialIdxLookup = {}
 		for materialIdx, (material, pairs) in enumerate(sorted(self._materialCoeffs.viewitems())):
@@ -171,12 +171,12 @@ class NetworkFlowCPLEX(NetworkFlowProblemBase):
 
 	def getFlowNames(self):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing flow names.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing flow names.")
 		return sorted(self._flows, key=self._flows.__getitem__)
 
 	def getMaterialNames(self):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing material names.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing material names.")
 		return sorted(self._materialIdxLookup, key=self._materialIdxLookup.__getitem__)
 
 	def getUpperBounds(self):
@@ -190,7 +190,7 @@ class NetworkFlowCPLEX(NetworkFlowProblemBase):
 
 	def buildEqConst(self):
 		if self._eqConstBuilt:
-			raise Exception("Equality constraints already built.")
+			raise RuntimeError("Equality constraints already built.")
 
 		nMaterials = len(self._materialCoeffs)
 		nFlows = len(self._flows)

--- a/wholecell/utils/_netflow/nf_glpk.py
+++ b/wholecell/utils/_netflow/nf_glpk.py
@@ -102,7 +102,7 @@ def _toDoubleArray(array):
 class NetworkFlowGLPK(NetworkFlowProblemBase):
 	def __init__(self, quadratic_objective=False):
 		if quadratic_objective:
-			raise Exception('Quadratic objective not supported for GLPK')
+			raise ValueError('Quadratic objective not supported for GLPK')
 
 		self._lp = glp.glp_create_prob()
 		self._smcp = glp.glp_smcp()  # simplex solver control parameters
@@ -248,7 +248,7 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 		if flow in self._flows:
 			idx = self._flows[flow]
 		elif self._eqConstBuilt:
-			raise Exception('Equality constraints already built. Unable to add new flow: "{}".'.format(flow))
+			raise ValueError('Equality constraints already built. Unable to add new flow: "{}".'.format(flow))
 		else:
 			self._add_cols(1)
 			idx = len(self._flows)
@@ -267,9 +267,9 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 	def setFlowMaterialCoeff(self, flow, material, coefficient):
 		if self._eqConstBuilt:
 			if material not in self._materialIdxLookup:
-				raise Exception("Invalid material")
+				raise ValueError("Invalid material: {}".format(material))
 			if flow not in self._flows:
-				raise Exception("Invalid flow")
+				raise ValueError("Invalid flow: {}".format(flow))
 
 			length = len(self._flow_locations[material])
 			flow_loc = self._flow_locations[material][self._flows[flow]]
@@ -338,7 +338,7 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 
 	def getShadowPrices(self, materials):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
 
 		self._solve()
 
@@ -350,7 +350,7 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 
 	def getReducedCosts(self, fluxNames):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing dual values.")
 
 		self._solve()
 
@@ -367,7 +367,7 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 
 	def getSMatrix(self):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing S matrix.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing S matrix.")
 		A = np.zeros((len(self._materialCoeffs), len(self._flows)))
 		for materialIdx, material in enumerate(sorted(self._materialCoeffs)):
 			coeffs = self._coeff_arrays[material]
@@ -377,12 +377,12 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 
 	def getFlowNames(self):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing flow names.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing flow names.")
 		return sorted(self._flows, key=self._flows.__getitem__)
 
 	def getMaterialNames(self):
 		if not self._eqConstBuilt:
-			raise Exception("Equality constraints not yet built. Finish construction of the problem before accessing material names.")
+			raise RuntimeError("Equality constraints not yet built. Finish construction of the problem before accessing material names.")
 		return sorted(self._materialIdxLookup, key=self._materialIdxLookup.__getitem__)
 
 	def getUpperBounds(self):
@@ -396,7 +396,7 @@ class NetworkFlowGLPK(NetworkFlowProblemBase):
 
 	def buildEqConst(self):
 		if self._eqConstBuilt:
-			raise Exception("Equality constraints already built.")
+			raise RuntimeError("Equality constraints already built.")
 		n_coeffs = len(self._materialCoeffs)
 		n_flows = len(self._flows)
 


### PR DESCRIPTION
This adds a check to make sure functions don't try to add a flow to a metabolism problem that is already set up.  This didn't catch any issues with the current code (just some code I was trying to add) but it will be a good check for adding things in the future to prevent silent failures.