### PR TITLE
Fix formatting for limitedMetabolites multigen plot

### DIFF
--- a/models/ecoli/analysis/multigen/limitedMetabolites.py
+++ b/models/ecoli/analysis/multigen/limitedMetabolites.py
@@ -34,27 +34,31 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 		allDir = ap.get_cells()
 
-		sim_data = cPickle.load(open(simDataFile, "rb"))
-		metaboliteNames = np.array(sorted(sim_data.process.metabolism.concDict.keys()))
-		nMetabolites = len(metaboliteNames)
-
 		fig, axesList = plt.subplots(3)
 		fig.set_size_inches(11, 11)
 
 		histo = np.zeros(4)
-		limitedCounts = np.zeros(len(metaboliteNames))
 
 		ax2 = axesList[2]
+		metaboliteNames = None
 		for simDir in allDir:
 			simOutDir = os.path.join(simDir, "simOut")
 
+			# Listeners used
 			enzymeKineticsData = TableReader(os.path.join(simOutDir, "EnzymeKinetics"))
+			main_reader = TableReader(os.path.join(simOutDir, "Main"))
+
+			# Get names of metabolites and set up to track limited generations
+			# in the first sim analyzed
+			if metaboliteNames is None:
+				metaboliteNames = np.array(enzymeKineticsData.readAttribute("metaboliteNames"))
+				nMetabolites = len(metaboliteNames)
+				limitedCounts = np.zeros(len(metaboliteNames))
+
 			metaboliteCounts = enzymeKineticsData.readColumn("metaboliteCountsFinal")
 			normalizedCounts = metaboliteCounts / metaboliteCounts[1, :]
-			enzymeKineticsData.close()
 
 			# Read time info from the listener
-			main_reader = TableReader(os.path.join(simOutDir, "Main"))
 			initialTime = main_reader.readAttribute("initialTime")
 			time = main_reader.readColumn("time")
 


### PR DESCRIPTION
This makes some minor tweaks to the x axis of the plot for readability as shown below and also corrects the ordering for metabolite names:

old:
![old_limitedMetabolites](https://user-images.githubusercontent.com/18123227/81321928-0c804780-9048-11ea-86aa-26e5d196a103.png)

new:
![limitedMetabolites](https://user-images.githubusercontent.com/18123227/81336823-e023f580-905e-11ea-901d-eca089122316.png)

