### PR TITLE
Add summary stats for metabolism kinetics

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/metabolism.py
+++ b/reconstruction/ecoli/dataclasses/process/metabolism.py
@@ -232,6 +232,15 @@ class Metabolism(object):
 		self._compiled_enzymes = None
 		self._compiled_saturation = None
 
+		# TODO: move this to a sim_data analysis script
+		if VERBOSE:
+			print('\nSummary of included metabolism kinetics:')
+			print('Reactions with kinetics: {}'.format(len(self.kinetic_constraint_reactions)))
+			print('Enzymes with kinetics: {}'.format(len(self.kinetic_constraint_enzymes)))
+			print('Metabolites in kinetics: {}'.format(len(self.kinetic_constraint_substrates)))
+			print('Number of kcat values: {}'.format(len([k for c in constraints.values() for k in c['kcat']])))
+			print('Number of saturation terms: {}'.format(len([s for c in constraints.values() for s in c['saturation']])))
+
 		# Verify no substrates with unknown concentrations have been added
 		unknown = {m for m in self.kinetic_constraint_substrates
 			if m not in known_metabolites}


### PR DESCRIPTION
This prints some information about the kinetic constraints included in the model.  I've temporarily recreated this several times to see how changes impact the kinetic constraints so I wanted to commit it ot make things easier.  It might be better to think about a new class of analysis that only requires a `sim_data` object and no simulation results to print summaries like this and generate other plots for deeper insights into `sim_data`.