### PR TITLE
Remove RNAP expression adjustment

### DIFF
--- a/reconstruction/ecoli/dataclasses/growthRateDependentParameters.py
+++ b/reconstruction/ecoli/dataclasses/growthRateDependentParameters.py
@@ -14,7 +14,6 @@ from wholecell.utils import units
 import unum
 
 DNA_CRITICAL_MASS = {100: 600, 44: 975} # units of fg
-FRACTION_INCREASE_RNAP_PROTEINS = {100: 0, 44: 0.05}
 
 class Mass(object):
 	""" Mass """
@@ -391,9 +390,6 @@ class GrowthRateParameters(object):
 
 	def getDnaCriticalMass(self, doubling_time):
 		return DNA_CRITICAL_MASS.get(doubling_time.asNumber(units.min), DNA_CRITICAL_MASS[44]) * units.fg
-
-	def getFractionIncreaseRnapProteins(self, doubling_time):
-		return FRACTION_INCREASE_RNAP_PROTEINS.get(doubling_time.asNumber(units.min), FRACTION_INCREASE_RNAP_PROTEINS[44])
 
 def _getFitParameters(list_of_dicts, key):
 	# Load rows of data

--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -1377,11 +1377,6 @@ def setRNAPCountsConstrainedByPhysiology(
 	(2) Expected RNAP subunit counts based on (mRNA) distribution recorded in
 		bulkContainer
 
-	Requires
-	--------
-	- the return value from getFractionIncreaseRnapProteins(doubling_time),
-	described in growthRateDependentParameters.py
-
 	Inputs
 	------
 	- bulkContainer (BulkObjectsContainer object) - counts of bulk molecules
@@ -1450,14 +1445,9 @@ def setRNAPCountsConstrainedByPhysiology(
 	nRnapsNeeded = nActiveRnapNeeded / sim_data.growthRateParameters.getFractionActiveRnap(doubling_time)
 
 	# Convert nRnapsNeeded to the number of RNA polymerase subunits required
-	# Note: The return value from getFractionIncreaseRnapProteins() is
-	# determined in growthRateDependentParameters.py
 	rnapIds = sim_data.process.complexation.getMonomers(sim_data.moleculeIds.rnapFull)['subunitIds']
 	rnapStoich = sim_data.process.complexation.getMonomers(sim_data.moleculeIds.rnapFull)['subunitStoich']
-
-	minRnapSubunitCounts = (
-		nRnapsNeeded * rnapStoich # Subunit stoichiometry
-		) * (1 + sim_data.growthRateParameters.getFractionIncreaseRnapProteins(doubling_time))
+	minRnapSubunitCounts = nRnapsNeeded * rnapStoich
 
 	# -- CONSTRAINT 2: Expected RNAP subunit counts based on distribution -- #
 	rnapCounts = bulkContainer.counts(rnapIds)


### PR DESCRIPTION
This removes a tweak that adjusted RNAP expression 5% higher.  I'm not sure why it was needed in the first place but it appears our sims are producing excess amount of RNA in the first generation.  Removing this tweak brings those levels back down closer to balanced growth.  See massFractionSummary plots below for before and after, particularly note the relative drop in rRNA and tRNA production.

Before:
![massFractionSummary](https://user-images.githubusercontent.com/18123227/81741065-cca7ce80-9452-11ea-9920-d03271df6325.png)

After:
![massFractionSummary](https://user-images.githubusercontent.com/18123227/81741117-e47f5280-9452-11ea-8e0c-57eb7f22ccd6.png)


