### PR TITLE
Adjust atol for smaller negative values in TCS

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -393,7 +393,7 @@ class TwoComponentSystem(object):
 
 		sol = scipy.integrate.solve_ivp(
 			self.derivatives, [0, timeStepSec], y_init,
-			method=method, t_eval=[0, timeStepSec],
+			method=method, t_eval=[0, timeStepSec], atol=1e-7,
 			jac=self.derivatives_jacobian
 			)
 		y = sol.y.T


### PR DESCRIPTION
This sets the atol for `solve_ivp` so that negative count results from numerical precision are smaller to fix the recent Jenkins failure.  This issue was likely introduced in #869 by removing `odeint` as the fallback method which has a lower default atol than `solve_ivp`.  The issue was not caught in the PR build and might only have come up in the 2 gen build because other changes were also merged into master at the same time.

```
Traceback (most recent call last):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/fireworks/firetasks/simulation.py", line 75, in run_task
    sim.run()
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/sim/simulation.py", line 234, in run
    self.run_incremental(self._lengthSec + self.initialTime())
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/sim/simulation.py", line 266, in run_incremental
    self._evolveState(processes)
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/sim/simulation.py", line 321, in _evolveState
    process.calculateRequest()
  File "/scratch/groups/mcovert/jenkins/workspace/models/ecoli/processes/two_component_system.py", line 62, in calculateRequest
    self.timeStepSec(), self.randomState, method="LSODA",
  File "/scratch/groups/mcovert/jenkins/workspace/reconstruction/ecoli/dataclasses/process/two_component_system.py", line 416, in moleculesToNextTimeStep
    "Solution to ODE for two-component systems has negative values."
Exception: Solution to ODE for two-component systems has negative values.
```