### PR TITLE
Update critical mass calculation

### DIFF
--- a/models/ecoli/processes/chromosome_replication.py
+++ b/models/ecoli/processes/chromosome_replication.py
@@ -35,9 +35,9 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 		self.max_time_step = sim_data.process.replication.max_time_step
 
 		# Load parameters
-		self.criticalInitiationMass = sim_data.growthRateParameters.getDnaCriticalMass(
+		self.get_dna_critical_mass = sim_data.mass.get_dna_critical_mass
+		self.criticalInitiationMass = self.get_dna_critical_mass(
 			sim_data.conditionToDoublingTime[sim_data.condition])
-		self.getDnaCriticalMass = sim_data.growthRateParameters.getDnaCriticalMass
 		self.nutrientToDoublingTime = sim_data.nutrientToDoublingTime
 		self.replichore_lengths = sim_data.process.replication.replichore_lengths
 		self.sequences = sim_data.process.replication.replication_sequences
@@ -86,7 +86,7 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 
 		# Get critical initiation mass for current simulation environment
 		current_media_id = self._external_states['Environment'].current_media_id
-		self.criticalInitiationMass = self.getDnaCriticalMass(
+		self.criticalInitiationMass = self.get_dna_critical_mass(
 			self.nutrientToDoublingTime[current_media_id])
 
 		# Calculate mass per origin of replication, and compare to critical


### PR DESCRIPTION
This makes the critical mass calculation for cells smaller than normal a function of mass instead of a lookup based on doubling time.  This will make it easier to add more conditions that are slow growing without having to adjust the critical mass explicitly for each one.  This keeps the critical mass for anaerobic roughly the same (now 592 vs 600 fg).