### PR TITLE
Update metabolites single analysis plot

### DIFF
--- a/models/ecoli/analysis/single/__init__.py
+++ b/models/ecoli/analysis/single/__init__.py
@@ -69,6 +69,7 @@ TAGS = {
 		"evaluationTime.py",
 		"external_exchange_fluxes.py",
 		"massFractionSummary.py",
+		"metabolites.py",
 		"mrnaCounts.py",
 		"ntpCounts.py",
 		"processMassBalance.py",


### PR DESCRIPTION
This updates the metabolites single analysis plot to make it more useful.  AA concentrations, which vary more than other metabolites, are separated from the rest and outliers are now highlighted for easier troubleshooting.

Before:
![old_metabolites](https://user-images.githubusercontent.com/18123227/82502574-4c194b80-9aac-11ea-97da-4a7237634e6e.png)

After:
![metabolites](https://user-images.githubusercontent.com/18123227/82502806-d5c91900-9aac-11ea-8698-79367fb9087d.png)
