### PR TITLE
go ahead with `units` `__future__ division`

### DIFF
--- a/wholecell/tests/utils/test_units.py
+++ b/wholecell/tests/utils/test_units.py
@@ -30,10 +30,8 @@ class Test_units(unittest.TestCase):
 		x = 1 * units.s
 		y = 100 * units.s
 		quotient = (x / y).asNumber()
-		
-		# TODO: Fix this test once we are using future division with units
-		# self.assertEqual(0.01, quotient)
-		self.assertEqual(0, quotient)
+
+		self.assertEqual(0.01, quotient)
 
 	def test_truediv(self):
 		"""Test __truediv__."""
@@ -41,9 +39,7 @@ class Test_units(unittest.TestCase):
 		y = 100 * units.s
 		quotient = x.__truediv__(y).asNumber()
 
-		# TODO: Fix this test once we are using future division with units
-		# self.assertEqual(0.01, quotient)
-		self.assertEqual(0, quotient)
+		self.assertEqual(0.01, quotient)
 
 	def test_div_int(self):
 		"""Test __div__ with ints."""
@@ -103,9 +99,7 @@ class Test_units(unittest.TestCase):
 		y = 100 * units.s
 		quotient = (x / y).asNumber()   # __rtruediv__
 
-		# TODO: Fix this test once we are using future division with units
-		# self.assertEqual(0.01, quotient)
-		self.assertEqual(0, quotient)
+		self.assertEqual(0.01, quotient)
 
 		d = np.array([1, 2, 3])
 		d2 = 2 / d
@@ -114,9 +108,8 @@ class Test_units(unittest.TestCase):
 		a1 = 2 / (1 / units.s * d)      # __rtruediv__
 		a2 = 2 / (units.s * d)          # __rtruediv__
 
-		# TODO: Fix these assertions once we are using future division with units
-		# np.testing.assert_array_equal(e1, e2)
-		# np.testing.assert_array_equal(e1, a1)
-		# np.testing.assert_array_equal(d2, a2.asNumber())
+		np.testing.assert_array_equal(e1, e2)
+		np.testing.assert_array_equal(e1, a1)
+		np.testing.assert_array_equal(d2, a2.asNumber())
 
 	# TODO(jerry): Test the array functions.

--- a/wholecell/utils/units.py
+++ b/wholecell/utils/units.py
@@ -46,9 +46,8 @@ Unum.__bool__ = Unum.__nonzero__ = __bool__
 # #244 workaround: Monkey patch Unum if it still has the broken implementation.
 # The test also ensures this only patches it once.
 # For some reason, `is` won't work here.
-
-# Turn off for now, see https://github.com/CovertLab/wcEcoli/issues/433
-if Unum.__truediv__ == Unum.__div__ and False:
+# See also https://github.com/CovertLab/wcEcoli/issues/433
+if Unum.__truediv__ == Unum.__div__:
 	Unum.__truediv__ = __truediv__
 	Unum.__rtruediv__ = __rtruediv__
 


### PR DESCRIPTION
Fix #433

The two lines in `fit_sim_data_1.py` that compute `productLengths / elongationRates` on integer arrays will get different results now, but it should be more sensible results even if it requires adjustments.