### PR TITLE
Handle cubic spline object in parca object tree

### DIFF
--- a/runscripts/reflect/object_tree.py
+++ b/runscripts/reflect/object_tree.py
@@ -259,7 +259,7 @@ def diff_trees(a, b):
 		diff = {}
 		attrs = SPECIAL_OBJECTS[type(a)]
 		for attr in attrs:
-			subdiff = diff_trees(getattr(a, attr), getattr(b, attr, None))
+			subdiff = diff_trees(getattr(a, attr), getattr(b, attr))
 			if subdiff:
 				diff[attr] = subdiff
 		return diff


### PR DESCRIPTION
This handles a new attribute object type in sim_data (scipy.interpolate._cubic.CubicSpline) that was introduced in #864 so that compareParca.py works properly.  Before it was showing a diff because of different memory addresses for the two objects (even though their attributes are the same):

```
{'growthRateParameters': {'fractionActiveRibosomeParams': {'function': (<scipy.interpolate._cubic.CubicSpline object at 0x7f0cdf07c470>,
                                                                        <scipy.interpolate._cubic.CubicSpline object at 0x7f0ce2f9f5f0>)},
                          'fractionActiveRnapParams': {'function': (<scipy.interpolate._cubic.CubicSpline object at 0x7f0cdf07c410>,
                                                                    <scipy.interpolate._cubic.CubicSpline object at 0x7f0ce2f9f590>)},
                          'ppGppConcentration': {'function': (<scipy.interpolate._cubic.CubicSpline object at 0x7f0cdf07c3b0>,
                                                              <scipy.interpolate._cubic.CubicSpline object at 0x7f0ce2f9f530>)},
                          'ribosomeElongationRateParams': {'function': (<scipy.interpolate._cubic.CubicSpline object at 0x7f0cdf07c2f0>,
                                                                        <scipy.interpolate._cubic.CubicSpline object at 0x7f0ce2f9f470>)},
                          'rnaPolymeraseElongationRateParams': {'function': (<scipy.interpolate._cubic.CubicSpline object at 0x7f0cdf07c350>,
                                                                             <scipy.interpolate._cubic.CubicSpline object at 0x7f0ce2f9f4d0>)}}}
```

It should be easy to expand for any other objects we need to add in this manner and just require one line in the file.