### PR TITLE
Option for jit ODEs when calling integration functions

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/equilibrium.py
+++ b/reconstruction/ecoli/dataclasses/process/equilibrium.py
@@ -298,24 +298,41 @@ class Equilibrium(object):
 		self.symbolic_rates_jacobian = J
 
 	def derivatives(self, t, y):
-		return self._stoichMatrix.dot(self._rates(t, y, self.ratesFwd, self.ratesRev))
+		return self._stoichMatrix.dot(self._rates[0](t, y, self.ratesFwd, self.ratesRev))
 
 	def derivatives_jacobian(self, t, y):
-		return self._stoichMatrix.dot(self._rates_jacobian(t, y, self.ratesFwd, self.ratesRev))
+		return self._stoichMatrix.dot(self._rates_jacobian[0](t, y, self.ratesFwd, self.ratesRev))
 
-	def fluxesAndMoleculesToSS(self, moleculeCounts, cellVolume, nAvogadro, random_state, time_limit=1e20, max_iter=100):
+	def derivatives_jit(self, t, y):
+		return self._stoichMatrix.dot(self._rates[1](t, y, self.ratesFwd, self.ratesRev))
+
+	def derivatives_jacobian_jit(self, t, y):
+		return self._stoichMatrix.dot(self._rates_jacobian[1](t, y, self.ratesFwd, self.ratesRev))
+
+	def fluxesAndMoleculesToSS(self, moleculeCounts, cellVolume, nAvogadro,
+			random_state, time_limit=1e20, max_iter=100, jit=True):
 		y_init = moleculeCounts / (cellVolume * nAvogadro)
+
+		# In this version of SciPy, solve_ivp does not support args so need to
+		# select the derivatives functions to use. Could be simplified to single
+		# functions that take a jit argument from solve_ivp in the future.
+		if jit:
+			derivatives = self.derivatives_jit
+			derivatives_jacobian = self.derivatives_jacobian_jit
+		else:
+			derivatives = self.derivatives
+			derivatives_jacobian = self.derivatives_jacobian
 
 		# Note: odeint has issues solving with a long time step so need to use solve_ivp
 		sol = integrate.solve_ivp(
-			self.derivatives, [0, time_limit], y_init,
+			derivatives, [0, time_limit], y_init,
 			method="LSODA", t_eval=[0, time_limit],
-			jac=self.derivatives_jacobian)
+			jac=derivatives_jacobian)
 		y = sol.y.T
 
 		if np.any(y[-1, :] * (cellVolume * nAvogadro) <= -1):
 			raise ValueError('Have negative values at equilibrium steady state -- probably due to numerical instability.')
-		if np.linalg.norm(self.derivatives(0, y[-1, :]), np.inf) * (cellVolume * nAvogadro) > 1:
+		if np.linalg.norm(derivatives(0, y[-1, :]), np.inf) * (cellVolume * nAvogadro) > 1:
 			raise RuntimeError('Did not reach steady state for equilibrium.')
 		y[y < 0] = 0
 		yMolecules = y * (cellVolume * nAvogadro)

--- a/wholecell/utils/build_ode.py
+++ b/wholecell/utils/build_ode.py
@@ -10,10 +10,12 @@ from sympy import Matrix
 from typing import Callable
 
 
-def build_function(arguments, expression, jit=True):
-	# type: (str, str, bool) -> Callable
+def build_functions(arguments, expression):
+	# type: (str, str) -> (Callable, Callable)
 	"""Build a function from its arguments and source code expression, give it
 	access to `Numpy as np`, and set up Numba to JIT-compile it on demand.
+	There will be overhead to compile the first time the jit version is called
+	so two functions are returned and can be selected for optimal performance.
 
 	Numba will optimize expressions like 1.0*y[2]**1.0 while compiling it
 	to machine code.
@@ -21,19 +23,17 @@ def build_function(arguments, expression, jit=True):
 	Args:
 		arguments (str): comma-separated lambda argument names
 		expression (str): expression to compile
-		jit (bool): whether to JIT-compile the function; this option is just to
-			work around Numba compiler bugs
 
 	Returns:
+		a lambda function(arguments)
 		a Numba Dispatcher function(arguments)
 	"""
 	f = eval('lambda {}: {}'.format(arguments, expression), {'np': np}, {})
 
-	if jit:
-		# Too bad cache=True doesn't work with string source code.
-		f_jit = njit(f, error_model='numpy')
-		return f_jit
-	return f
+	# Too bad cache=True doesn't work with string source code.
+	f_jit = njit(f, error_model='numpy')
+
+	return f, f_jit
 
 
 # TODO(jerry): Surely we can extract the argument array of "Matrix([...])" via
@@ -46,25 +46,25 @@ def _matrix_to_array(matrix):
 	return 'np.array({})'.format(matrix_string[7:-1])
 
 
-def derivatives(matrix, jit=True):
-	# type: (Matrix, bool) -> Callable
+def derivatives(matrix):
+	# type: (Matrix) -> (Callable, Callable)
 	"""Build an optimized derivatives ODE function(y, t)."""
-	return build_function('y, t',
-		_matrix_to_array(matrix) + '.reshape(-1)', jit)
+	return build_functions('y, t',
+		_matrix_to_array(matrix) + '.reshape(-1)')
 
-def derivatives_jacobian(jacobian_matrix, jit=True):
-	# type: (Matrix, bool) -> Callable
+def derivatives_jacobian(jacobian_matrix):
+	# type: (Matrix) -> (Callable, Callable)
 	"""Build an optimized derivatives ODE Jacobian function(y, t)."""
-	return build_function('y, t', _matrix_to_array(jacobian_matrix), jit)
+	return build_functions('y, t', _matrix_to_array(jacobian_matrix))
 
-def rates(matrix, jit=True):
-	# type: (Matrix, bool) -> Callable
+def rates(matrix):
+	# type: (Matrix) -> (Callable, Callable)
 	"""Build an optimized rates function(t, y, kf, kr)."""
-	return build_function('t, y, kf, kr',
-		_matrix_to_array(matrix) + '.reshape(-1)', jit)
+	return build_functions('t, y, kf, kr',
+		_matrix_to_array(matrix) + '.reshape(-1)')
 
-def rates_jacobian(jacobian_matrix, jit=True):
-	# type: (Matrix, bool) -> Callable
+def rates_jacobian(jacobian_matrix):
+	# type: (Matrix) -> (Callable, Callable)
 	"""Build an optimized rates Jacobian function(t, y, kf, kr)."""
-	return build_function('t, y, kf, kr',
-		_matrix_to_array(jacobian_matrix), jit)
+	return build_functions('t, y, kf, kr',
+		_matrix_to_array(jacobian_matrix))


### PR DESCRIPTION
This adds an option to use or not use jit functions when calling the sim_data functions that use ODE integration instead of forcing the decision at the time of making a sim_data object.  Both the jit and lambda function are now stored in the classes so the decision can be made at call time - it's not an option for the functions that gave lowering errors during jit compilation.

After seeing a minimal benefit for a parallel parca run in #884, I realized that it was probably being held up by jit compiling for each process after pickling/unpickling sim_data to send to each thread.  Sure enough, disabling jit in the parca leads to about 2.5 min execution (from 4.25 min) with 8 cores on my machine.

TODO: this should make it easier to pass an option to sims to disable jit if desired (better for short sims that can't make use of the jit optimization enough to make up for the compile time) and I'll make a new PR soon to handle that.