### PR TITLE
Show stack trace for errors in parca when using multiprocessing

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -271,7 +271,7 @@ def fitSimData_1(
 	return sim_data
 
 def apply_updates(func, args, labels, dest, cpus):
-	# type: (Callable[[Any], Dict[Any, Any]], List[Tuple[Any]], List[str], Dict[Any, Any], int) -> None
+	# type: (Callable[..., dict], List[tuple], List[str], dict, int) -> None
 	"""
 	Use multiprocessing (if cpus > 1) to apply args to a function to get
 	dictionary updates for a destination dictionary.

--- a/wholecell/utils/parallelization.py
+++ b/wholecell/utils/parallelization.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 import functools
 import multiprocessing as mp
 import os
+import sys
 import traceback
 
 from typing import Any, Callable, Dict, Iterable, List, Optional
@@ -27,7 +28,7 @@ def full_traceback(func):
 		except Exception as e:
 			msg = "{}\n\nOriginal {}".format(e, traceback.format_exc())
 			raise type(e)(msg)
-	return wrapper
+	return wrapper if sys.version_info[0] < 3 else func
 
 def is_macos():
 	# type: () -> bool


### PR DESCRIPTION
This gives a much more useful error message when running the parca in parallel and hitting an error.  Because a wrapper is needed to get the full stack trace (a python2 problem with multiprocessing stack traces) it will slightly change any errors that arise in the single CPU case but the info will still be there.

Changes:
- reduced code duplication in parca for the different parallel sections by wrapping it into a function (`apply_updates`)
- more detailed handling of errors in new `apply_updates` function
- added a wrapper (`@parallelization.full_traceback`) [from this helpful post](https://stackoverflow.com/questions/6126007/python-getting-a-traceback-from-a-multiprocessing-process)

Instead of a message like:
```
Traceback (most recent call last):
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 69, in <module>
    script.cli()
  File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 547, in cli
    self.run(args)
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 64, in run
    task.run_task({})
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/parca.py", line 76, in run_task
    task.run_task(fw_spec)
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/fitSimData.py", line 68, in run_task
    disable_rnapoly_capacity_fitting=self['disable_rnapoly_capacity_fitting'],
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 173, in fitSimData_1
    assert(result.successful())
AssertionError
```

It will now show messages from each process that fails (these could be different messages) and list the conditions that were unsuccessful (without the wrapper, only the initial Traceback would be shown which doesn't give line info or nested function call info):
```
Traceback (most recent call last):
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 307, in apply_updates
    result.get()
  File "/home/travis/.pyenv/versions/2.7.16/lib/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value
NameError: global name 'a' is not defined

Original Traceback (most recent call last):
  File "/home/travis/wcEcoli/wholecell/utils/parallelization.py", line 26, in wrapper
    return func(*args, **kwargs)
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 451, in buildTfConditionCellSpecifications
    print(a)
NameError: global name 'a' is not defined


... same for each condition but all will be shown ...


Traceback (most recent call last):
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 307, in apply_updates
    result.get()
  File "/home/travis/.pyenv/versions/2.7.16/lib/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value
NameError: global name 'a' is not defined

Original Traceback (most recent call last):
  File "/home/travis/wcEcoli/wholecell/utils/parallelization.py", line 26, in wrapper
    return func(*args, **kwargs)
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 451, in buildTfConditionCellSpecifications
    print(a)
NameError: global name 'a' is not defined

Traceback (most recent call last):
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 69, in <module>
    script.cli()
  File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 547, in cli
    self.run(args)
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 64, in run
    task.run_task({})
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/parca.py", line 76, in run_task
    task.run_task(fw_spec)
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/fitSimData.py", line 68, in run_task
    disable_rnapoly_capacity_fitting=self['disable_rnapoly_capacity_fitting'],
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 163, in fitSimData_1
    apply_updates(buildTfConditionCellSpecifications, args, conditions, cellSpecs, cpus)
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 315, in apply_updates
    .format(', '.join(failed)))
RuntimeError: Error(s) raised while using multiple processes for CPLX0-7705, CPLX0-7671, CPLX-172, CPLX0-7916, PD00519, MONOMER0-160, MONOMER0-162, PD00288, PHOSPHO-NARL, PHOSPHO-DCUR, PC00027, CPLX0-228, CPLX-125, PHOSPHO-BAER, CPLX0-7796, PHOSPHO-BASR, PUTA-CPLX, FNR-4FE-4S-CPLX, MONOMER0-155, PHOSPHO-ARCA, PC00010, CPLX0-7740
```