### PR TITLE
Raise RuntimeError instead of caught error for full_traceback

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -311,7 +311,7 @@ def apply_updates(func, args, labels, dest, cpus):
 
 		# Cleanup
 		if failed:
-			raise RuntimeError('Error(s) raised while using multiple processes for {}'
+			raise RuntimeError('Error(s) raised for {} while using multiple processes'
 				.format(', '.join(failed)))
 		pool = None
 		print("End parallel processing")

--- a/wholecell/utils/parallelization.py
+++ b/wholecell/utils/parallelization.py
@@ -26,8 +26,9 @@ def full_traceback(func):
 		try:
 			return func(*args, **kwargs)
 		except Exception as e:
-			msg = "{}\n\nOriginal {}".format(e, traceback.format_exc())
-			raise type(e)(msg)
+			msg = '{} in wrapped function {}\n\nOriginal {}'.format(
+				type(e).__name__, func.__name__, traceback.format_exc())
+			raise RuntimeError(msg)
 	return wrapper if sys.version_info[0] < 3 else func
 
 def is_macos():


### PR DESCRIPTION
This makes a minor update to the changes introduced in #888 to address some formatting issues with certain errors (`KeyError` and others) where newlines were not handled.  Now only a `RuntimeError` will be raised to guarantee proper formatting of the message.

Before:
```
Traceback (most recent call last):                                                   
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 307, in apply_updates
    result.get()                                                                                                     
  File "/home/travis/.pyenv/versions/2.7.16/lib/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value                                                                                                
KeyError: '"PHOSPHO-CREC"\n\nOriginal Traceback (most recent call last):\n  File "/home/travis/wcEcoli/wholecell/utils/parallelization.py", lin
e 27, in wrapper\n    return func(*args, **kwargs)\n  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 460, in buildTfC
onditionCellSpecifications\n    fcData = sim_data.tfToFC[tf]\nKeyError: "PHOSPHO-CREC"\n'
Traceback (most recent call last):                                         
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 69, in <module>                                                                  script.cli()                                                                                                                                 File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 547, in cli  
    self.run(args)                                
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 64, in run                             
    task.run_task({})                                                                                                                          
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/parca.py", line 76, in run_task
    task.run_task(fw_spec)                                                           
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/fitSimData.py", line 68, in run_task
    disable_rnapoly_capacity_fitting=self['disable_rnapoly_capacity_fitting'],                                       
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 163, in fitSimData_1
    apply_updates(buildTfConditionCellSpecifications, args, conditions, cellSpecs, cpus)
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 315, in apply_updates
    .format(', '.join(failed)))     
RuntimeError: Error(s) raised while using multiple processes for PHOSPHO-CREC
```

After:
```
Traceback (most recent call last):                                  
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 307, in apply_updates
    result.get()
  File "/home/travis/.pyenv/versions/2.7.16/lib/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value                          
RuntimeError: KeyError in wrapped function buildTfConditionCellSpecifications

Original Traceback (most recent call last):
  File "/home/travis/wcEcoli/wholecell/utils/parallelization.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 460, in buildTfConditionCellSpecifications
    fcData = sim_data.tfToFC[tf]
KeyError: 'PHOSPHO-CREC'

Traceback (most recent call last):
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 69, in <module>
    script.cli()
  File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 547, in cli
    self.run(args)
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 64, in run
    task.run_task({})
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/parca.py", line 76, in run_task
    task.run_task(fw_spec)
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/fitSimData.py", line 68, in run_task
    disable_rnapoly_capacity_fitting=self['disable_rnapoly_capacity_fitting'],
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 163, in fitSimData_1
    apply_updates(buildTfConditionCellSpecifications, args, conditions, cellSpecs, cpus)
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 315, in apply_updates
    .format(', '.join(failed)))
RuntimeError: Error(s) raised for PHOSPHO-CREC while using multiple processes
```
