### PR TITLE
Automatically open fathom server when running buildCausalityNetwork

### DIFF
--- a/runscripts/manual/buildCausalityNetwork.py
+++ b/runscripts/manual/buildCausalityNetwork.py
@@ -87,9 +87,11 @@ class BuildCausalityNetwork(AnalysisBase):
 				.format(cmd))
 			filepath.run_cmdline(cmd, timeout=None)
 		else:
-			print('\nNOTE: Use the --show flag and have ${} set to your local'
-				' path to site/server.py in the causality repo to automatically'
-				' open the viewer for this data.\n'.format(CAUSALITY_ENV_VAR))
+			print('\nNOTE: Use the --show flag and have ${0} set to your local'
+				' path to site/server.py in the causality repo (eg. run'
+				' `export {0}=~/path/to/causality/site/server.py` with your'
+				' path) to automatically open the viewer for this data.\n'
+				.format(CAUSALITY_ENV_VAR))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes it a lot easier to view the causality visualization after running `buildCausalityNetwork` with automatic opening.  We will no longer have to pass the deeply nested paths to `site/server.py` on the command line.  If you set your environment variable `CAUSALITY_SERVER` to the path to your local `causality/site/server.py` file and use the `--show` flag with the manual runscript, it will automatically open the browser after processing the data.  This seemed much easier than the alternatives of making `causality` a pip for this repo, moving `causality` into this repo or moving the convenient manual runscript variant, seed, generation etc parsing to `causality`.