### PR TITLE
Fix empty array in metabolites analysis

### DIFF
--- a/models/ecoli/analysis/single/metabolites.py
+++ b/models/ecoli/analysis/single/metabolites.py
@@ -63,9 +63,19 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Plot everything but amino acids
 		ax = plt.subplot(2, 1, 1)
 		ax.set_prop_cycle('color', colors)
-		plt.plot(time, normalizedCounts[:, ~aa_mask & highlighted])
-		plt.plot(time, normalizedCounts[:, ~aa_mask & ~highlighted])
-		plt.legend(metaboliteNames[~aa_mask & highlighted], fontsize=8)
+
+		## Plot and label metabolites that are different from the mean
+		mask = ~aa_mask & highlighted
+		if np.any(mask):
+			plt.plot(time, normalizedCounts[:, mask])
+			plt.legend(metaboliteNames[mask], fontsize=8)
+
+		## Plot the rest of the metabolites that are not amino acids
+		mask = ~aa_mask & ~highlighted
+		if np.any(mask):
+			plt.plot(time, normalizedCounts[:, mask])
+
+		## Formatting
 		plt.xlabel("Time (min)")
 		plt.ylabel("Metabolite fold change")
 		plt.title('All metabolites (excluding amino acids)')


### PR DESCRIPTION
This fixes the error from today's daily build that came up when there were no metabolites to be highlighted on the analysis plot:
```
Traceback (most recent call last):
  File "/scratch/groups/mcovert/jenkins/workspace@3/wholecell/fireworks/firetasks/analysisBase.py", line 171, in run_task
    mod.Plot.main(*args)
  File "/scratch/groups/mcovert/jenkins/workspace@3/models/ecoli/analysis/analysisPlot.py", line 120, in main
    validationDataFile, metadata)
  File "/scratch/groups/mcovert/jenkins/workspace@3/models/ecoli/analysis/analysisPlot.py", line 110, in plot
    validationDataFile, metadata)
  File "/scratch/groups/mcovert/jenkins/workspace@3/models/ecoli/analysis/single/metabolites.py", line 66, in do_plot
    plt.plot(time, normalizedCounts[:, ~aa_mask & highlighted])
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/matplotlib/pyplot.py", line 3358, in plot
    ret = ax.plot(*args, **kwargs)
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/matplotlib/__init__.py", line 1855, in inner
    return func(ax, *args, **kwargs)
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/matplotlib/axes/_axes.py", line 1527, in plot
    for line in self._get_lines(*args, **kwargs):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/matplotlib/axes/_base.py", line 406, in _grab_next_args
    for seg in self._plot_args(this, kwargs):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli2/lib/python2.7/site-packages/matplotlib/axes/_base.py", line 396, in _plot_args
    seg = func(x[:, j % ncx], y[:, j % ncy], kw, kwargs)
ZeroDivisionError: integer division or modulo by zero
```