### PR TITLE
Add jit sim option

### DIFF
--- a/models/ecoli/processes/equilibrium.py
+++ b/models/ecoli/processes/equilibrium.py
@@ -31,6 +31,9 @@ class Equilibrium(wholecell.processes.process.Process):
 	def initialize(self, sim, sim_data):
 		super(Equilibrium, self).initialize(sim, sim_data)
 
+		# Simulation options
+		self.jit = sim._jit
+
 		# Get constants
 		self.nAvogadro = sim_data.constants.nAvogadro.asNumber(1 / units.mol)
 		self.cellDensity = sim_data.constants.cellDensity.asNumber(units.g / units.L)
@@ -55,7 +58,9 @@ class Equilibrium(wholecell.processes.process.Process):
 
 		# Solve ODEs to steady state
 		self.rxnFluxes, self.req = self.fluxesAndMoleculesToSS(
-			moleculeCounts, cellVolume, self.nAvogadro, self.randomState)
+			moleculeCounts, cellVolume, self.nAvogadro, self.randomState,
+			jit=self.jit,
+			)
 
 		# Request counts of molecules needed
 		self.molecules.requestIs(self.req)

--- a/models/ecoli/processes/two_component_system.py
+++ b/models/ecoli/processes/two_component_system.py
@@ -29,6 +29,9 @@ class TwoComponentSystem(wholecell.processes.process.Process):
 	def initialize(self, sim, sim_data):
 		super(TwoComponentSystem, self).initialize(sim, sim_data)
 
+		# Simulation options
+		self.jit = sim._jit
+
 		# Get constants
 		self.nAvogadro = sim_data.constants.nAvogadro.asNumber(1 / units.mmol)
 		self.cellDensity = sim_data.constants.cellDensity.asNumber(units.g / units.L)
@@ -58,7 +61,7 @@ class TwoComponentSystem(wholecell.processes.process.Process):
 		# by the scipy ODE suite.
 		self.molecules_required, self.all_molecule_changes = self.moleculesToNextTimeStep(
 			moleculeCounts, self.cellVolume, self.nAvogadro,
-			self.timeStepSec(), self.randomState, method="LSODA",
+			self.timeStepSec(), self.randomState, method="LSODA", jit=self.jit,
 			)
 
 		# Request counts of molecules needed
@@ -80,6 +83,7 @@ class TwoComponentSystem(wholecell.processes.process.Process):
 			_, self.all_molecule_changes = self.moleculesToNextTimeStep(
 				moleculeCounts, self.cellVolume, self.nAvogadro,
 				10000, self.randomState, method="BDF", min_time_step=self.timeStepSec(),
+				jit=self.jit,
 				)
 
 		# Increment changes in molecule counts

--- a/runscripts/fireworks/fw_queue.py
+++ b/runscripts/fireworks/fw_queue.py
@@ -67,6 +67,8 @@ Simulation parameters:
 	TIMESTEP_SAFETY_FRAC (float, "1.3"): increases the time step by this factor
 		if conditions are favorable; up the the limit of the max time step
 	TIMESTEP_UPDATE_FREQ (int, "5"): frequency at which the time step is updated
+	JIT (int, "1"): if nonzero, jit compiled functions are used for certain
+		processes, otherwise only uses lambda functions
 
 Modeling options:
 	MASS_DISTRIBUTION (int, "1"): if nonzero, a mass coefficient is drawn from
@@ -239,6 +241,7 @@ WC_LENGTHSEC = int(get_environment("WC_LENGTHSEC", DEFAULT_SIMULATION_KWARGS["le
 TIMESTEP_SAFETY_FRAC = float(get_environment("TIMESTEP_SAFETY_FRAC", DEFAULT_SIMULATION_KWARGS["timeStepSafetyFraction"]))
 TIMESTEP_MAX = float(get_environment("TIMESTEP_MAX", DEFAULT_SIMULATION_KWARGS["maxTimeStep"]))
 TIMESTEP_UPDATE_FREQ = int(get_environment("TIMESTEP_UPDATE_FREQ", DEFAULT_SIMULATION_KWARGS["updateTimeStepFreq"]))
+JIT = bool(int(get_environment("JIT", DEFAULT_SIMULATION_KWARGS["jit"])))
 MASS_DISTRIBUTION = bool(int(get_environment("MASS_DISTRIBUTION", DEFAULT_SIMULATION_KWARGS["massDistribution"])))
 GROWTH_RATE_NOISE = bool(int(get_environment("GROWTH_RATE_NOISE", DEFAULT_SIMULATION_KWARGS["growthRateNoise"])))
 D_PERIOD_DIVISION = bool(int(get_environment("D_PERIOD_DIVISION", DEFAULT_SIMULATION_KWARGS["dPeriodDivision"])))
@@ -678,6 +681,7 @@ for i in VARIANTS_TO_RUN:
 							timestep_safety_frac = TIMESTEP_SAFETY_FRAC,
 							timestep_max = TIMESTEP_MAX,
 							timestep_update_freq = TIMESTEP_UPDATE_FREQ,
+							jit=JIT,
 							mass_distribution = MASS_DISTRIBUTION,
 							growth_rate_noise = GROWTH_RATE_NOISE,
 							d_period_division = D_PERIOD_DIVISION,
@@ -707,6 +711,7 @@ for i in VARIANTS_TO_RUN:
 							timestep_safety_frac = TIMESTEP_SAFETY_FRAC,
 							timestep_max = TIMESTEP_MAX,
 							timestep_update_freq = TIMESTEP_UPDATE_FREQ,
+							jit=JIT,
 							mass_distribution = MASS_DISTRIBUTION,
 							growth_rate_noise = GROWTH_RATE_NOISE,
 							d_period_division = D_PERIOD_DIVISION,

--- a/wholecell/fireworks/firetasks/simulation.py
+++ b/wholecell/fireworks/firetasks/simulation.py
@@ -24,6 +24,7 @@ class SimulationTask(FiretaskBase):
 		"timestep_update_freq",
 		"log_to_shell",
 		"log_to_disk_every",
+		"jit",
 		"mass_distribution",
 		"growth_rate_noise",
 		"d_period_division",
@@ -60,6 +61,7 @@ class SimulationTask(FiretaskBase):
 		options["updateTimeStepFreq"] = self._get_default("timestep_update_freq", "updateTimeStepFreq")
 		options["logToShell"] = self._get_default("log_to_shell", "logToShell")
 		options["logToDiskEvery"] = self._get_default("log_to_disk_every", "logToDiskEvery")
+		options["jit"] = self._get_default("jit")
 		options["massDistribution"] = self._get_default("mass_distribution", "massDistribution")
 		options["growthRateNoise"] = self._get_default("growth_rate_noise", "growthRateNoise")
 		options["dPeriodDivision"] = self._get_default("d_period_division", "dPeriodDivision")

--- a/wholecell/fireworks/firetasks/simulationDaughter.py
+++ b/wholecell/fireworks/firetasks/simulationDaughter.py
@@ -25,6 +25,7 @@ class SimulationDaughterTask(FiretaskBase):
 		"timestep_update_freq",
 		"log_to_shell",
 		"log_to_disk_every",
+		"jit",
 		"mass_distribution",
 		"growth_rate_noise",
 		"d_period_division",
@@ -62,6 +63,7 @@ class SimulationDaughterTask(FiretaskBase):
 		options["updateTimeStepFreq"] = self._get_default("timestep_update_freq", "updateTimeStepFreq")
 		options["logToShell"] = self._get_default("log_to_shell", "logToShell")
 		options["logToDiskEvery"] = self._get_default("log_to_disk_every", "logToDiskEvery")
+		options["jit"] = self._get_default("jit")
 		options["massDistribution"] = self._get_default("mass_distribution", "massDistribution")
 		options["growthRateNoise"] = self._get_default("growth_rate_noise", "growthRateNoise")
 		options["dPeriodDivision"] = self._get_default("d_period_division", "dPeriodDivision")

--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -31,6 +31,7 @@ DEFAULT_SIMULATION_KWARGS = dict(
 	seed = 0,
 	lengthSec = 3*60*60, # 3 hours max
 	initialTime = 0.,
+	jit = True,
 	massDistribution = True,
 	dPeriodDivision = False,
 	growthRateNoise = False,

--- a/wholecell/utils/scriptBase.py
+++ b/wholecell/utils/scriptBase.py
@@ -50,6 +50,7 @@ SIM_KEYS = (
 	'timestep_safety_frac',
 	'timestep_max',
 	'timestep_update_freq',
+	'jit',
 	'mass_distribution',
 	'growth_rate_noise',
 	'd_period_division',
@@ -402,6 +403,9 @@ class ScriptBase(object):
 		add_option('timestep_update_freq', 'updateTimeStepFreq', int,
 			help='frequency at which the time step is updated')
 
+		add_bool_option('jit', 'jit',
+			help='If true, jit compiled functions are used for certain'
+				 ' processes, otherwise only uses lambda functions')
 		add_bool_option('mass_distribution', 'massDistribution',
 			help='If true, a mass coefficient is drawn from a normal distribution'
 				 ' centered on 1; otherwise it is set equal to 1')


### PR DESCRIPTION
This adds the option to run sims with or without jit compilation in equilibrium and two_component_systems.  By default, it is enabled like current functionality since it leads to a performance benefit over the length of a sim (although performance is nearly identical now that time steps are 2 sec instead of 0.9).  This option will be helpful for troubleshooting (just looking to run a few time steps at once) or for cases with shorter sims (parameter sensitivity scripts etc).  For example, we can run a 10 sec sim in <2 sec without jit vs ~15 sec with compilation.

Disable with manual runscript (same for wcm.py):
```
python runscripts/manual/runSim.py --no-jit
```

Disable with fw_queue.py:
```
JIT=0 python runscripts/fireworks/fw_queue.py
```