### PR TITLE
run the mypy type checker in PR builds & ecoli-small

### DIFF
--- a/runscripts/jenkins/ecoli-small.sh
+++ b/runscripts/jenkins/ecoli-small.sh
@@ -5,10 +5,9 @@ module load wcEcoli/sherlock2
 WCECOLI_PYENV=wcEcoli2
 pyenv local ${WCECOLI_PYENV}
 
-make clean
-make compile
+make clean compile
 
 PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=wholecell --cov-report xml \
     --junitxml=unittests.xml
 
-(export PYENV_VERSION="mypy:${WCECOLI_PYENV}"; mypy --py2)
+(export PYENV_VERSION="mypy:${WCECOLI_PYENV}"; echo ---Running mypy---; mypy --py2)


### PR DESCRIPTION
Q: Let mypy errors fail the build right away, or just print the messages for now? Or run it early in the script but make it fail the build after the other steps run?

TODO: Test this before checkin!

[This could evaluate `$(pyenv version-name)` where needed but it seems more reliable to just use an environment variable `PYENV_VERSION`.]