### PR TITLE
Do not raise exception with no RNAPs

### DIFF
--- a/wholecell/sim/divide_cell.py
+++ b/wholecell/sim/divide_cell.py
@@ -248,6 +248,8 @@ def divideUniqueMolecules(uniqueMolecules, randomState,
 				# If molecule is RNA polymerase, save data for future use
 				d1_RNAP_unique_indexes = np.array([], dtype=np.int64)
 				d2_RNAP_unique_indexes = np.array([], dtype=np.int64)
+				d1_RNAP_unique_indexes_new = np.array([], dtype=np.int64)
+				d2_RNAP_unique_indexes_new = np.array([], dtype=np.int64)
 			continue
 
 		# Only the chromosome domains that physically exist are handed down to
@@ -276,7 +278,7 @@ def divideUniqueMolecules(uniqueMolecules, randomState,
 	if any(v is None for v in [d1_RNAP_unique_indexes, d2_RNAP_unique_indexes,
 			d1_RNAP_unique_indexes_new, d2_RNAP_unique_indexes_new]):
 		raise UniqueMoleculeDivisionError(
-			'Active RNAPs must be divided and it new unique indexes be known before dividing RNAs.')
+			'Active RNAPs must be divided and new unique indexes be known before dividing RNAs.')
 
 	# Divide molecules with division mode "RNA"
 	for molecule_name in uniqueMolecules.division_mode['RNA']:


### PR DESCRIPTION
This fixes a small issue that caused an exception if there were no active RNAPs at division:
```
Traceback (most recent call last):                                                                                                             
  File "/home/travis/.pyenv/versions/2.7.16/envs/wcEcoli2/lib/python2.7/site-packages/fireworks/core/rocket.py", line 262, in run              
    m_action = t.run_task(my_spec)                                                                                                             
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/simulationDaughter.py", line 80, in run_task                                        
    sim.run()                                                                                                                                  
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 239, in run                                                                    
    self.finalize()                                                                
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 287, in finalize   
    self.daughter_paths = self._divideCellFunction()                               
  File "/home/travis/wcEcoli/wholecell/sim/divide_cell.py", line 78, in divide_cell
    uniqueMolecules, randomState, chromosome_division_results, sim)                                  
  File "/home/travis/wcEcoli/wholecell/sim/divide_cell.py", line 279, in divideUniqueMolecules
    'Active RNAPs must be divided and it new unique indexes be known before dividing RNAs.')
UniqueMoleculeDivisionError: Active RNAPs must be divided and it new unique indexes be known before dividing RNAs.
```

Not having active RNAPs is exceptional behavior but the cell should still be able to divide and I think the check for the error is for a different circumstance.  Because the error was raised during `finalize()` in `simulation.py`, listeners were not finalized so analysis could not be performed:
```
Traceback (most recent call last):                                                 
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/analysisBase.py", line 172, in run_task                                    
    mod.Plot.main(*args)                                                           
  File "/home/travis/wcEcoli/models/ecoli/analysis/analysisPlot.py", line 120, in main                                                         
    validationDataFile, metadata)                                                  
  File "/home/travis/wcEcoli/models/ecoli/analysis/analysisPlot.py", line 110, in plot 
    validationDataFile, metadata)                                                                                                              
  File "/home/travis/wcEcoli/models/ecoli/analysis/single/metabolites.py", line 41, in do_plot
    metaboliteCounts = enzymeKineticsdata.readColumn("metaboliteCountsFinal")                              
  File "/home/travis/wcEcoli/wholecell/io/tablereader.py", line 317, in readColumn 
    return self.readColumn2D(name, indices).squeeze()                              
  File "/home/travis/wcEcoli/wholecell/io/tablereader.py", line 236, in readColumn2D                                    
    len(raw_entry), chunk.getsize()))                                                       
EOFError: Data block cut short 4374/6724
```

We might want to consider adjusting `finalize()` so that everything can finalize even with an error in one of the parts of `finalize()`.