### PR TITLE
Fix condition fold changes

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -39,6 +39,7 @@ RNA_EXPRESSION_ADJUSTMENTS = {
 	"EG12298_RNA[c]": 10,  # yibQ, Predicted polysaccharide deacetylase; This RNA is fit for the anaerobic condition viability
 	"EG11672_RNA[c]": 10,  # atoB, acetyl-CoA acetyltransferase; This RNA is fit for the anaerobic condition viability
 	"EG10238_RNA[c]": 10,  # dnaE, DNA polymerase III subunit alpha; This RNA is fit for the sims to produce enough DNAPs for timely replication
+	"EG11673_RNA[c]": 10,  # folB, dihydroneopterin aldolase; needed for growth (METHYLENE-THF) in acetate condition
 	"EG10808_RNA[c]": 2,  # pyrE, orotate phosphoribosyltransferase; Needed for UTP synthesis, transcriptional regulation by UTP is not included in the model
 	}
 RNA_DEG_RATES_ADJUSTMENTS = {


### PR DESCRIPTION
This fixes a bug with fold changes calculated for different conditions.  It removes the need for most of the parameters adjustments that were made for the acetate condition in #895 (although now requires an adjustment to folB for METHYLENE-THF production).  It also starts the acetate condition with a more appropriate number of RNAPs (about 2x) so that its doubling time is closer to the expected 138 min (instead of starting at >170 min):

![cellCycleLength](https://user-images.githubusercontent.com/18123227/84218570-91191800-aa83-11ea-992e-136bc8e2725b.png)
