### PR TITLE
Add transertion pane to cotranscriptional translation analysis plot

### DIFF
--- a/models/ecoli/analysis/single/cotranscriptional_translation.py
+++ b/models/ecoli/analysis/single/cotranscriptional_translation.py
@@ -88,13 +88,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		membrane_protein_y = []
 
 		for coordinates in membrane_protein_coordinates:
-			if coordinates >= 0:
-				theta = np.pi*coordinates/right_replichore_length
-				membrane_protein_x.append(np.sin(theta))
-			else:
-				theta = -np.pi*coordinates/left_replichore_length
-				membrane_protein_x.append(-np.sin(theta))
-
+			theta = np.pi * coordinates/(right_replichore_length if coordinates >= 0 else left_replichore_length)
+			membrane_protein_x.append(np.sin(theta))
 			membrane_protein_y.append(np.cos(theta))
 
 		membrane_protein_x = np.array(membrane_protein_x)


### PR DESCRIPTION
This adds a new pane to the existing cotranscriptional translation analysis plot that focuses on the chromosomal locations of genes that produce membrane proteins, and have ribosomes bound to partially transcribed transcripts. Example of a resulting plot is shown below:

![cotranscriptional_translation](https://user-images.githubusercontent.com/32276711/84969820-53913c00-b0ce-11ea-85ce-69f6a9b92e91.png)
