### PR TITLE
Create metadata file during runParca.py

### DIFF
--- a/runscripts/manual/runSim.py
+++ b/runscripts/manual/runSim.py
@@ -47,7 +47,7 @@ def parse_timestamp_description(sim_path):
 		description = match.group(2).replace('_', ' ')
 	else:
 		timestamp = fp.timestamp()
-		description = 'a manual run'
+		description = sim_dir
 
 	return timestamp, description
 


### PR DESCRIPTION
This writes a metadata file when running `runParca.py`.  This file will likely be overwritten when running `runSim.py` afterwards but if it does not get written, then `analysisParca.py` can't run without first running a sim to write a metadata file.  This also changes the default description for manual runs if there is no timestamp to be the output directory name.  This will be more helpful when comparing figures that have the metadata signature instead of the current default description ('a manual run').