### PR TITLE
Add total_count() method for singleton views

### DIFF
--- a/models/ecoli/processes/cell_division.py
+++ b/models/ecoli/processes/cell_division.py
@@ -67,7 +67,7 @@ class CellDivision(wholecell.processes.process.Process):
 		# chromosome if the chromosome has already induced division to avoid
 		# double counting.
 		if self.d_period_division:
-			if self.full_chromosomes.total_counts() >= 2:
+			if self.full_chromosomes.total_count() >= 2:
 				# Extract attributes from existing full chromosomes
 				division_time, has_triggered_division = self.full_chromosomes.attrs(
 					"division_time", "has_triggered_division"

--- a/models/ecoli/processes/chromosome_replication.py
+++ b/models/ecoli/processes/chromosome_replication.py
@@ -74,7 +74,7 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 
 	def calculateRequest(self):
 		# Get total count of existing oriC's
-		n_oric = self.oriCs.total_counts()[0]
+		n_oric = self.oriCs.total_count()
 
 		# If there are no origins, return immediately
 		if n_oric == 0:
@@ -105,7 +105,7 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 			self.chromosome_domains.request_access(self.EDIT_ACCESS)
 
 		# If there are no active forks return
-		n_active_replisomes = self.active_replisomes.total_counts()[0]
+		n_active_replisomes = self.active_replisomes.total_count()
 		if n_active_replisomes == 0:
 			return
 
@@ -145,8 +145,8 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 	def evolveState(self):
 		## Module 1: Replication initiation
 		# Get number of existing replisomes and oriCs
-		n_active_replisomes = self.active_replisomes.total_counts()[0]
-		n_oriC = self.oriCs.total_counts()[0]
+		n_active_replisomes = self.active_replisomes.total_count()
+		n_oriC = self.oriCs.total_count()
 
 		# If there are no origins, return immediately
 		if n_oriC == 0:

--- a/models/ecoli/processes/chromosome_structure.py
+++ b/models/ecoli/processes/chromosome_structure.py
@@ -291,7 +291,7 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 	
 			# Delete all existing chromosomal segments
 			self.chromosomal_segments.delByIndexes(
-				np.arange(self.chromosomal_segments.total_counts()[0]))
+				np.arange(self.chromosomal_segments.total_count()))
 	
 			# Add new chromosomal segments
 			n_segments = len(all_new_linking_numbers)

--- a/models/ecoli/processes/polypeptide_elongation.py
+++ b/models/ecoli/processes/polypeptide_elongation.py
@@ -111,7 +111,7 @@ class PolypeptideElongation(wholecell.processes.process.Process):
 		self.ribosomeElongationRate = self.elongation_model.elongation_rate(current_media_id)
 
 		# If there are no active ribosomes, return immediately
-		if self.active_ribosomes.total_counts()[0] == 0:
+		if self.active_ribosomes.total_count() == 0:
 			return
 
 		# Build sequences to request appropriate amount of amino acids to
@@ -161,7 +161,7 @@ class PolypeptideElongation(wholecell.processes.process.Process):
 		self.writeToListener("GrowthLimits", "aaAllocated", self.aas.counts())
 
 		# Get number of active ribosomes
-		n_active_ribosomes = self.active_ribosomes.total_counts()[0]
+		n_active_ribosomes = self.active_ribosomes.total_count()
 		self.writeToListener("GrowthLimits", "activeRibosomeAllocated", n_active_ribosomes)
 
 		if n_active_ribosomes == 0:
@@ -410,7 +410,7 @@ class SteadyStateElongationModel(TranslationSupplyElongationModel):
 		aa_counts = self.process.aas.total_counts()
 		uncharged_trna_counts = np.dot(self.process.aa_from_trna, self.uncharged_trna.total_counts())
 		charged_trna_counts = np.dot(self.process.aa_from_trna, self.charged_trna.total_counts())
-		ribosome_counts = self.process.active_ribosomes.total_counts()[0]
+		ribosome_counts = self.process.active_ribosomes.total_count()
 
 		# Get concentration
 		f = aasInSequences / aasInSequences.sum()
@@ -473,9 +473,9 @@ class SteadyStateElongationModel(TranslationSupplyElongationModel):
 			total_trna_conc = self.counts_to_molar * (uncharged_trna_counts + charged_trna_counts)
 			updated_charged_trna_conc = total_trna_conc * fraction_charged
 			updated_uncharged_trna_conc = total_trna_conc - updated_charged_trna_conc
-			ppgpp_conc = self.counts_to_molar * self.ppgpp.total_counts()[0]
-			rela_conc = self.counts_to_molar * self.rela.total_counts()[0]
-			spot_conc = self.counts_to_molar * self.spot.total_counts()[0]
+			ppgpp_conc = self.counts_to_molar * self.ppgpp.total_count()
+			rela_conc = self.counts_to_molar * self.rela.total_count()
+			spot_conc = self.counts_to_molar * self.spot.total_count()
 			delta_metabolites, _, _, _, _, _ = self.ppgpp_metabolite_changes(
 				updated_uncharged_trna_conc, updated_charged_trna_conc, ribosome_conc,
 				f, rela_conc, spot_conc, ppgpp_conc, self.counts_to_molar, v_rib, request=True
@@ -516,16 +516,16 @@ class SteadyStateElongationModel(TranslationSupplyElongationModel):
 		## Concentrations of interest
 		if self.process.ppgpp_regulation:
 			v_rib = (nElongations * self.counts_to_molar).asNumber(MICROMOLAR_UNITS) / self.process.timeStepSec()
-			ribosome_conc = self.counts_to_molar * self.process.active_ribosomes.total_counts()[0]
+			ribosome_conc = self.counts_to_molar * self.process.active_ribosomes.total_count()
 			updated_uncharged_trna_counts = self.uncharged_trna.total_counts() - net_charged
 			updated_charged_trna_counts = self.charged_trna.total_counts() + net_charged
 			uncharged_trna_conc = self.counts_to_molar * np.dot(
 				self.process.aa_from_trna, updated_uncharged_trna_counts)
 			charged_trna_conc = self.counts_to_molar * np.dot(
 				self.process.aa_from_trna, updated_charged_trna_counts)
-			ppgpp_conc = self.counts_to_molar * self.ppgpp.total_counts()[0]
-			rela_conc = self.counts_to_molar * self.rela.total_counts()[0]
-			spot_conc = self.counts_to_molar * self.spot.total_counts()[0]
+			ppgpp_conc = self.counts_to_molar * self.ppgpp.total_count()
+			rela_conc = self.counts_to_molar * self.rela.total_count()
+			spot_conc = self.counts_to_molar * self.spot.total_count()
 
 			f = aas_used / aas_used.sum()
 			limits = self.ppgpp_reaction_metabolites.counts()

--- a/models/ecoli/processes/rna_degradation.py
+++ b/models/ecoli/processes/rna_degradation.py
@@ -150,9 +150,9 @@ class RnaDegradation(wholecell.processes.process.Process):
 		# Get total counts of RNAs including rRNAs, charged tRNAs, and active
 		# (translatable) unique mRNAs
 		bulk_RNA_counts = self.bulk_RNAs.total_counts().copy()
-		bulk_RNA_counts[self.rrsaIdx] += self.ribosome30S.total_counts()
-		bulk_RNA_counts[[self.rrlaIdx, self.rrfaIdx]] += self.ribosome50S.total_counts()
-		bulk_RNA_counts[[self.rrlaIdx, self.rrfaIdx, self.rrsaIdx]] += self.activeRibosomes.total_counts()
+		bulk_RNA_counts[self.rrsaIdx] += self.ribosome30S.total_count()
+		bulk_RNA_counts[[self.rrlaIdx, self.rrfaIdx]] += self.ribosome50S.total_count()
+		bulk_RNA_counts[[self.rrlaIdx, self.rrfaIdx, self.rrsaIdx]] += self.activeRibosomes.total_count()
 		bulk_RNA_counts[self.is_tRNA.astype(np.bool)] += self.charged_trna.total_counts()
 
 		TU_index, can_translate, is_full_transcript = self.unique_RNAs.attrs(

--- a/models/ecoli/processes/tf_binding.py
+++ b/models/ecoli/processes/tf_binding.py
@@ -93,7 +93,7 @@ class TfBinding(wholecell.processes.process.Process):
 
 	def evolveState(self):
 		# If there are no promoters, return immediately
-		if self.promoters.total_counts() == 0:
+		if self.promoters.total_count() == 0:
 			return
 
 		# Get attributes of all promoters

--- a/models/ecoli/processes/transcript_elongation.py
+++ b/models/ecoli/processes/transcript_elongation.py
@@ -76,7 +76,7 @@ class TranscriptElongation(wholecell.processes.process.Process):
 			self.variable_elongation)
 
 		# If there are no active RNA polymerases, return immediately
-		if self.active_RNAPs.total_counts()[0] == 0:
+		if self.active_RNAPs.total_count() == 0:
 			return
 
 		# Determine total possible sequences of nucleotides that can be
@@ -117,7 +117,7 @@ class TranscriptElongation(wholecell.processes.process.Process):
 		ntpCounts = self.ntps.counts()
 		self.writeToListener("GrowthLimits", "ntpAllocated", ntpCounts)
 
-		if self.active_RNAPs.total_counts()[0] == 0:
+		if self.active_RNAPs.total_count() == 0:
 			return
 
 		# Get attributes from existing RNAs

--- a/models/ecoli/processes/transcript_initiation.py
+++ b/models/ecoli/processes/transcript_initiation.py
@@ -116,7 +116,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 		# Read current environment
 		current_media_id = self._external_states['Environment'].current_media_id
 
-		if self.full_chromosomes.total_counts()[0] > 0:
+		if self.full_chromosomes.total_count() > 0:
 			# Get attributes of promoters
 			TU_index, bound_TF = self.promoters.attrs("TU_index", "bound_TF")
 
@@ -124,7 +124,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 				cell_mass = self.readFromListener("Mass", "cellMass") * units.fg
 				cell_volume = cell_mass / self.cell_density
 				counts_to_molar = 1 / (self.n_avogadro * cell_volume)
-				ppgpp_conc = self.ppgpp.total_counts()[0] * counts_to_molar
+				ppgpp_conc = self.ppgpp.total_count() * counts_to_molar
 				basal_prob = self.synth_prob(ppgpp_conc, self.copy_number)
 			else:
 				basal_prob = self.basal_prob
@@ -177,7 +177,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 
 		# If there are no chromosomes in the cell, set all probs to zero
 		else:
-			self.promoter_init_probs = np.zeros(self.promoters.total_counts())
+			self.promoter_init_probs = np.zeros(self.promoters.total_count())
 
 		self.fracActiveRnap = self.fracActiveRnapDict[current_media_id]
 		self.rnaPolymeraseElongationRate = self.rnaPolymeraseElongationRateDict[current_media_id]
@@ -190,7 +190,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 
 	def evolveState(self):
 		# no synthesis if no chromosome
-		if self.full_chromosomes.total_counts()[0] == 0:
+		if self.full_chromosomes.total_count() == 0:
 			self.writeToListener(
 				"RnaSynthProb", "rnaSynthProb", np.zeros(self.n_TUs))
 			return
@@ -200,7 +200,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 			"TU_index", "coordinates", "domain_index", "bound_TF")
 
 		# Construct matrix that maps promoters to transcription units
-		n_promoters = self.promoters.total_counts()
+		n_promoters = self.promoters.total_count()
 		TU_to_promoter = scipy.sparse.csr_matrix(
 			(np.ones(n_promoters), (TU_index, np.arange(n_promoters))),
 			shape = (self.n_TUs, n_promoters))

--- a/wholecell/views/view.py
+++ b/wholecell/views/view.py
@@ -11,6 +11,9 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+class TotalCountError(Exception):
+	pass
+
 class View(object):
 	_stateID = 'View'
 
@@ -52,6 +55,12 @@ class View(object):
 
 	def total_counts(self):
 		return self._totalCount.copy()
+
+	def total_count(self):
+		if self._totalCount.size != 1:
+			raise TotalCountError('total_count() can only be used for views that cover a single molecule type.')
+
+		return self._totalCount[0]
 
 	# TODO (ggsun): deprecated alias, should be deleted
 	total = total_counts


### PR DESCRIPTION
Based off the suggestion by @tahorst in PR #911, this PR adds a new method called `total_count()` to the base `View` class that returns a scalar count value for views that look into a single type of molecule, instead of returning a singleton array. Using this method for views that look into multiple types of molecules at once will throw an exception. 