### PR TITLE
Update python version on PyCharm config file

### DIFF
--- a/.idea/wcEcoli.iml
+++ b/.idea/wcEcoli.iml
@@ -8,7 +8,7 @@
       <excludeFolder url="file://$MODULE_DIR$/out" />
       <excludeFolder url="file://$MODULE_DIR$/runscripts/metabolism/homeostaticFBA_modularFBA_toy_model/svg_plots" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 2.7 (wcEcoli2)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (wcEcoli3)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PackageRequirementsSettings">


### PR DESCRIPTION
This PR updates the `wcEcoli.iml` PyCharm config file that was automatically updated with the port to Python 3.8. 