### PR TITLE
Skip plotting replisome coordinates for cells without active replisomes

### DIFF
--- a/models/ecoli/analysis/multigen/replication.py
+++ b/models/ecoli/analysis/multigen/replication.py
@@ -47,7 +47,9 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			m = m.reshape(fork_coordinates.shape)
 			fork_coordinates[~m] = np.nan
 
-			axesList[0].plot(time, fork_coordinates, marker=',', markersize=1, linewidth=0)
+			# Skip plot if there are no replication forks in this generation
+			if fork_coordinates.shape[1] > 0:
+				axesList[0].plot(time, fork_coordinates, marker=',', markersize=1, linewidth=0)
 			axesList[0].set_xlim([0, time.max()])
 			axesList[0].set_yticks([-1 * genomeLength / 2, 0, genomeLength / 2])
 			axesList[0].set_yticklabels(['-terC', 'oriC', '+terC'])

--- a/models/ecoli/analysis/single/active_rnap_coordinates.py
+++ b/models/ecoli/analysis/single/active_rnap_coordinates.py
@@ -124,11 +124,14 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			"marker": "x", "markersize": 10, "linewidth": 0,
 			"color": "darkblue", "label": "co-directional"}
 
-		# Plot coordinates of collisions between RNAPs and replisomes
-		ax.plot(time_mins, headon_collision_coordinates,
-			**headon_params)
-		ax.plot(time_mins, codirectional_collision_coordinates,
-			**codirectional_params)
+		# Plot coordinates of collisions between RNAPs and replisomes. Skip
+		# if there are no collisions (no replication forks)
+		if headon_collision_coordinates.shape[1] > 0:
+			ax.plot(time_mins, headon_collision_coordinates,
+				**headon_params)
+		if codirectional_collision_coordinates.shape[1] > 0:
+			ax.plot(time_mins, codirectional_collision_coordinates,
+				**codirectional_params)
 
 		ax.set_xticks([0, time_mins.max()])
 		ax.set_yticks([-replichore_lengths[1], 0, replichore_lengths[0]])

--- a/models/ecoli/analysis/single/replication.py
+++ b/models/ecoli/analysis/single/replication.py
@@ -67,7 +67,9 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		plt.figure(figsize = (8.5, 11))
 
 		ax = plt.subplot(7,1,1)
-		ax.plot(time / 60., fork_coordinates, marker='.', markersize=1, linewidth=0)
+		# Skip if there are no replication forks
+		if fork_coordinates.shape[1] > 0:
+			ax.plot(time / 60., fork_coordinates, marker='.', markersize=1, linewidth=0)
 		ax.set_xticks([0, time.max() / 60])
 		ax.set_yticks([-1 * genomeLength / 2, 0, genomeLength / 2])
 		ax.set_yticklabels(['-terC', 'oriC', '+terC'])


### PR DESCRIPTION
This PR makes modifications to multigen and single analyses that plot the coordinates of replisomes over time such that the plots are not done for cells without any active replisomes. This should address the CI build failures for anaerobic conditions observed today after the Python 3 port - I'm guessing that this error showed up as a result of upgrading matplotlib to the new version. It looks like it no longer supports plotting empty arrays where one of the axes lengths is zero. 