### PR TITLE
update FireWorks and Theano pips

### DIFF
--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -11,7 +11,7 @@ module load wcEcoli/python3
 ### Edit this line to make the PR build use another pyenv like wcEcoli3-staging.
 ### Revert it to `wcEcoli3` before merging the PR into master.
 ### -------------------------------------------------------------------
-pyenv local wcEcoli3-staging
+pyenv local wcEcoli3
 
 make clean compile
 


### PR DESCRIPTION
* Update to the `FireWorks==1.9.6` pip. That enables a workaround for the `lpad webgui` getting a `TypeError: cannot pickle '_thread.lock' object` exception.
  To wit: run `lpad webgui -s` which runs it in "server mode" without trying to open a browser window. Then manually open the browser window. If you're using iTerm2, just command-click on the URL http://127.0.0.1:5000
* Update to the `Theano==1.0.5` pip. That fixes its DeprecationWarnings seen in pytest (leaving just the DeprecationWarning from `pymunk`).

Here's a screen snapshot of a workflow in the webgui. The live webgui can pan, zoom, click on nodes, and drag nodes.
![image](https://user-images.githubusercontent.com/1043120/88598787-ebb00880-d01e-11ea-8468-bca809e2ee84.png)
