### PR TITLE
Remove O(n^2) operations in parca data load

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -222,15 +222,12 @@ class Transcription(object):
 		# Load RNA expression from RNA-seq data
 		expression = []
 
+		seq_data = {x['Gene']: x[sim_data.basal_expression_condition] for x in getattr(raw_data.rna_seq_data, f'rnaseq_{RNA_SEQ_ANALYSIS}_mean')}
 		for rna in raw_data.rnas:
-			arb_exp = [x[sim_data.basal_expression_condition]
-                for x in eval("raw_data.rna_seq_data.rnaseq_{}_mean".format(RNA_SEQ_ANALYSIS))
-                if x['Gene'] == rna['geneId']]
-
 			# If sequencing data is not found for rRNA or tRNA, initialize
             # expression to zero. For other RNA types, raise exception.
-			if len(arb_exp) > 0:
-				expression.append(arb_exp[0])
+			if rna['geneId'] in seq_data:
+				expression.append(seq_data[rna['geneId']])
 			elif rna['type'] == 'mRNA' or rna['type'] == 'miscRNA':
 				raise Exception('No RNA-seq data found for {}'.format(rna['id']))
 			elif rna['type'] == 'rRNA' or rna['type'] == 'tRNA':
@@ -417,7 +414,6 @@ class Transcription(object):
 		self.rnaSynthProb["basal"] = synthProb / synthProb.sum()
 
 		self.rnaData = UnitStructArray(rnaData, field_units)
-
 
 	def _build_transcription(self, raw_data, sim_data):
 		"""

--- a/reconstruction/ecoli/dataclasses/process/translation.py
+++ b/reconstruction/ecoli/dataclasses/process/translation.py
@@ -59,20 +59,16 @@ class Translation(object):
 		ids = ['{}[{}]'.format(protein['id'], protein['location'][0]) for protein in raw_data.proteins]
 
 		rnaIds = []
-
+		rna_locations = {rna['id']: rna['location'] for rna in raw_data.rnas}
 		for protein in raw_data.proteins:
 			rnaId = protein['rnaId']
 
-			rnaLocation = None
-			for rna in raw_data.rnas:
-				if rna['id'] == rnaId:
-					assert len(rna['location']) == 1
-					rnaLocation = rna['location'][0]
-					break
+			locations = rna_locations.get(rnaId, [])
+			assert len(locations) == 1
 
 			rnaIds.append('{}[{}]'.format(
 				rnaId,
-				rnaLocation
+				locations[0]
 				))
 
 		lengths = []
@@ -220,7 +216,6 @@ class Translation(object):
 
 		self.translationEfficienciesByMonomer = np.array(trEffs)
 		self.translationEfficienciesByMonomer[np.isnan(self.translationEfficienciesByMonomer)] = np.nanmean(self.translationEfficienciesByMonomer)
-
 
 	def _build_elongation_rates(self, raw_data, sim_data):
 		protein_ids = self.monomerData['id']


### PR DESCRIPTION
I was going through some parca code and noticed there are a couple places where we have O(n^2) operations that could easily be converted to a lookup and O(n).  The data likely won't change but if additional data were to be added, it could quickly slow things down.  It seems to make things a little more efficient and doesn't change the output.