### PR TITLE
Set OPENBLAS_NUM_THREADS to 1 for consistency

### DIFF
--- a/wholecell/fireworks/firetasks/__init__.py
+++ b/wholecell/fireworks/firetasks/__init__.py
@@ -4,6 +4,14 @@ from __future__ import absolute_import, division, print_function
 # noinspection PyCompatibility
 import faulthandler; faulthandler.enable()
 
+# Set OPENBLAS_NUM_THREADS to 1 to avoid threading bugs in OpenBLAS
+# that can lead to irreproducible results across different systems. It may have
+# performance implications and could be removed if a library test is created to
+# make sure the installed version of OpenBLAS is not dependent on the number of
+# threads allowed. Must be set before numpy (and maybe scipy) is loaded.
+import os
+os.environ['OPENBLAS_NUM_THREADS'] = '1'
+
 from .initRawData import InitRawDataTask
 from .fitSimData import FitSimDataTask
 from .variantSimData import VariantSimDataTask


### PR DESCRIPTION
This sets the `OPENBLAS_NUM_THREADS` environment variable to 1 for all firetasks that are run.  This should work for any parca or simulation script to get around the inconsistencies that can occur in some version of OpenBLAS as noted in #931.  I have found that performance is very slow when I don't have this value set to 1 so there could be multiple benefits to this addition.  This is a bit of a hack so we could explore other solutions but I think this should get us consistency for now (making it easier to test Sherlock failures and have reproducible results) and we can test different versions of OpenBLAS and possibly develop a test for the library in the future.