### PR TITLE
Use OPENBLAS_NUM_THREADS=1 in Jenkins scripts

### DIFF
--- a/runscripts/jenkins/ecoli-anaerobic.sh
+++ b/runscripts/jenkins/ecoli-anaerobic.sh
@@ -10,6 +10,11 @@ runscripts/jenkins/purge.sh anaerobic 10
 module load wcEcoli/python3
 pyenv local wcEcoli3
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean
 make compile
 

--- a/runscripts/jenkins/ecoli-glucose-minimal.sh
+++ b/runscripts/jenkins/ecoli-glucose-minimal.sh
@@ -10,6 +10,11 @@ runscripts/jenkins/purge.sh daily_build 10
 module load wcEcoli/python3
 pyenv local wcEcoli3
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean
 make compile
 

--- a/runscripts/jenkins/ecoli-optional-features.sh
+++ b/runscripts/jenkins/ecoli-optional-features.sh
@@ -9,6 +9,11 @@ module load wcEcoli/python3
 pyenv local wcEcoli3
 export PYTHONPATH=$PWD
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean
 make compile
 

--- a/runscripts/jenkins/ecoli-performance-test.sh
+++ b/runscripts/jenkins/ecoli-performance-test.sh
@@ -1,6 +1,11 @@
 module load wcEcoli/python3
 pyenv local wcEcoli3
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean
 make compile
 

--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -13,6 +13,11 @@ module load wcEcoli/python3
 ### -------------------------------------------------------------------
 pyenv local wcEcoli3
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean compile
 
 # Get mypy type checker warnings now but defer failing on its error detections.

--- a/runscripts/jenkins/ecoli-small.sh
+++ b/runscripts/jenkins/ecoli-small.sh
@@ -3,6 +3,11 @@ set -e
 module load wcEcoli/python3
 pyenv local wcEcoli3
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean compile
 
 PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=wholecell --cov-report xml \

--- a/runscripts/jenkins/ecoli-two-generations.sh
+++ b/runscripts/jenkins/ecoli-two-generations.sh
@@ -8,6 +8,11 @@ set -e
 module load wcEcoli/python3
 pyenv local wcEcoli3
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean
 make compile
 

--- a/runscripts/jenkins/ecoli-with-aa.sh
+++ b/runscripts/jenkins/ecoli-with-aa.sh
@@ -10,6 +10,11 @@ runscripts/jenkins/purge.sh with_aa 10
 module load wcEcoli/python3
 pyenv local wcEcoli3
 
+# Prevent differences when run with more than one thread using the current
+# OpenBLAS library. This could be removed if a test shows the current library
+# is not thread sensitive.
+export OPENBLAS_NUM_THREADS=1
+
 make clean
 make compile
 


### PR DESCRIPTION
This should make it easier to reproduce Jenkins builds and failures across multiple machines by avoiding variable results from OpenBLAS depending on the number of threads used.  This works to address #931 and extends the fix introduced in #938 to Jenkins scripts (#938 does not set `OPENBLAS_NUM_THREADS` before fireworks' `rlaunch` loads numpy so it doesn't work when using `rlaunch`).

This was set for all Jenkins scripts but maybe for the test scripts (ecoli-performance-test and ecoli-small) we would be better off not setting it in case we want to include this issue in a unit test.

Since #938 isn't a universal fix, we could revert it and let users decide to set the environment variable or not.  That way there shouldn't be any differences between running the manual scripts and fw_queue version of sims on a single machine.