### PR TITLE
Repeat FBA solve multiple times for robustness

### DIFF
--- a/models/ecoli/processes/metabolism.py
+++ b/models/ecoli/processes/metabolism.py
@@ -155,7 +155,9 @@ class Metabolism(wholecell.processes.process.Process):
 			kinetic_substrate_counts, counts_to_molar, time_step)
 
 		# Solve FBA problem and update states
+		n_retries = 3
 		fba = self.model.fba
+		fba.solve(n_retries)
 
 		## Internal molecule changes
 		delta_metabolites = (1 / counts_to_molar) * (CONC_UNITS * fba.getOutputMoleculeLevelsChange())

--- a/runscripts/debug/metabolism.py
+++ b/runscripts/debug/metabolism.py
@@ -150,6 +150,10 @@ class MetabolismDebug(scriptBase.ScriptBase):
 			counts_to_molar, self.time_step_sizes[timestep],
 			)
 
+		# Solve multiple times (if needed) for robustness
+		n_retries = 3
+		model.fba.solve(n_retries)
+
 	def validation(self, n_steps):
 		# type: (int) -> None
 		"""


### PR DESCRIPTION
This retries FBA solves if the first try fails.  This should fix a lot of the issues we've seen in Jenkins builds with error messages like:

```
Traceback (most recent call last):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli3/lib/python3.8/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/fireworks/firetasks/simulationDaughter.py", line 82, in run_task
    sim.run()
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/sim/simulation.py", line 242, in run
    self.run_incremental(self._lengthSec + self.initialTime())
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/sim/simulation.py", line 274, in run_incremental
    self._evolveState(processes)
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/sim/simulation.py", line 343, in _evolveState
    process.evolveState()
  File "/scratch/groups/mcovert/jenkins/workspace/models/ecoli/processes/metabolism.py", line 161, in evolveState
    delta_metabolites = (1 / counts_to_molar) * (CONC_UNITS * fba.getOutputMoleculeLevelsChange())
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/utils/modular_fba.py", line 1195, in getOutputMoleculeLevelsChange
    flowRates = self._solver.getFlowRates(six.viewkeys(stoich))
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/utils/_netflow/nf_glpk.py", line 334, in getFlowRates
    self._solve()
  File "/scratch/groups/mcovert/jenkins/workspace/wholecell/utils/_netflow/nf_glpk.py", line 482, in _solve
    raise RuntimeError(self.status_string)
RuntimeError: GLP_NOFEAS: no feasible
```

When we updated to python3, swiglpk updated from 1.4.4 to 4.65.1 and it looks like it does a poor job finding a solution compared to the earlier version.