### PR TITLE
Revert "Set OPENBLAS_NUM_THREADS to 1 for consistency"

### DIFF
--- a/wholecell/fireworks/firetasks/__init__.py
+++ b/wholecell/fireworks/firetasks/__init__.py
@@ -4,14 +4,6 @@ from __future__ import absolute_import, division, print_function
 # noinspection PyCompatibility
 import faulthandler; faulthandler.enable()
 
-# Set OPENBLAS_NUM_THREADS to 1 to avoid threading bugs in OpenBLAS
-# that can lead to irreproducible results across different systems. It may have
-# performance implications and could be removed if a library test is created to
-# make sure the installed version of OpenBLAS is not dependent on the number of
-# threads allowed. Must be set before numpy (and maybe scipy) is loaded.
-import os
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
-
 from .initRawData import InitRawDataTask
 from .fitSimData import FitSimDataTask
 from .variantSimData import VariantSimDataTask


### PR DESCRIPTION
Reverts CovertLab/wcEcoli#938

This change did not reliably set the environment before numpy was loaded (in the case of using `rlaunch`) so it could lead to inconsistent output when running manual scripts vs fireworks workflows (if `OPENBLAS_NUM_THREADS` is not already set to 1 in the environment) and could cause confusion about how many threads numpy has been loaded with, which would possibly hinder debugging of future issues.