### PR TITLE
Add Science paper to relevant papers list in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,8 @@ There are two alternative ways to set up to run the model:
 
 ## relevant papers
 
-* [A Whole-Cell Computational Model Predicts Phenotype from Genotype](https://www.cell.com/cell/abstract/S0092-8674(12)00776-3)
+* [Simultaneous cross-evaluation of heterogeneous _E. coli_ datasets via mechanistic simulation](https://science.sciencemag.org/content/369/6502/eaav3751.full), _Science_, 24 July 2020
+* [A Whole-Cell Computational Model Predicts Phenotype from Genotype](https://www.cell.com/cell/abstract/S0092-8674(12)00776-3), _Cell_, July 20, 2012
 
 ## dissertations
 * _Computational Simulations of Whole Cells: Strategies for Framework Design and Model Parameterization_, John Mason


### PR DESCRIPTION
I noticed that a link to the Science paper was added in the release repo, but not here. @1fish2, is there anything else I should add here that you added to the docs in the release repo, while I'm at it?