### PR TITLE
Lowercase repo name for Docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ See [docs/README.md](docs/README.md) for more info on setting up and running the
 In short, there are two alternative setups to run the model: inside a Docker container vs. in a manually constructed `pyenv` virtual environment.  With Docker, you can start running a simulation with three commands:
 1.  Pull the Docker image:
     ```shell script
-    docker pull docker.pkg.github.com/CovertLab/WholeCellEcoliRelease/wcm-full:latest
+    docker pull docker.pkg.github.com/covertlab/wholecellecolirelease/wcm-full:latest
     ```
 1. Run the Docker container:
     ```shell script
-    docker run --name=wcm -it --rm docker.pkg.github.com/CovertLab/WholeCellEcoliRelease/wcm-full
+    docker run --name=wcm -it --rm docker.pkg.github.com/covertlab/wholecellecolirelease/wcm-full
     ```
 1. Inside the container, run the model:
     ```shell script

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,13 +12,13 @@ There are two alternative ways to set up to run the model:
 
    Pull the full docker image from the package registry in this repo:
    ```shell script
-   docker pull docker.pkg.github.com/CovertLab/WholeCellEcoliRelease/wcm-full:latest
+   docker pull docker.pkg.github.com/covertlab/wholecellecolirelease/wcm-full:latest
    ```
 
    You can then run the wcEcoli model inside the Container like this:
 
    ```shell script
-   docker run --name=wcm -it --rm wcm-full
+   docker run --name=wcm -it --rm docker.pkg.github.com/covertlab/wholecellecolirelease/wcm-full
    ```
 
    The `-it` option starts an interactive shell.
@@ -32,7 +32,7 @@ There are two alternative ways to set up to run the model:
    to `out/` (eg. `$PWD/out`), not just a relative path from your current directory:
 
    ```shell script
-   docker run --name=wcm -v $PWD/out:/wcEcoli/out -it wcm-full
+   docker run --name=wcm -v $PWD/out:/wcEcoli/out -it docker.pkg.github.com/covertlab/wholecellecolirelease/wcm-full
    ```
 
    In this case, the output files will be owned by root. You can fix


### PR DESCRIPTION
Another update to go along with #947.  I ran into another little Docker gotcha when trying to tag the new image for upload.  Apparently, you can't have uppercase letters in a Docker tag since I got this error:
```
Error parsing reference: "docker.pkg.github.com/CovertLab/WholeCellEcoliRelease/wcm-full:latest" is not a valid repository/tag: invalid reference format: repository name must be lowercase
```

Docker does not seem to be the most friendly to work with...