### PR TITLE
Fix deprecation warning

### DIFF
--- a/models/ecoli/sim/initial_conditions.py
+++ b/models/ecoli/sim/initial_conditions.py
@@ -610,7 +610,7 @@ def initialize_transcription_factors(bulkMolCntr, uniqueMolCntr, sim_data, rando
 			bound_locs[
 				randomState.choice(
 					n_available_promoters,
-					size=np.min((n_to_bind, active_tf_view[tf_id].counts())),
+					size=min(n_to_bind, active_tf_view[tf_id].counts()[0]),
 					replace=False)
 			] = True
 


### PR DESCRIPTION
This fixes the deprecation warning we were getting at the beginning of sims:
```
VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
```