### PR TITLE
Fix cache dimension mismatch

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -3229,7 +3229,7 @@ def setKmCooperativeEndoRNonLinearRNAdecay(sim_data, bulkContainer):
 		# R_aux calculates the difference of the degradation rate based on these
 		# Km values and the expected rate so this sum seems like a reliable test of
 		# whether the cache fits current input data.
-		if np.sum(np.abs(R_aux(KmcountsCached))) > 1e-15:
+		if Kmcounts.shape != KmcountsCached.shape or np.sum(np.abs(R_aux(KmcountsCached))) > 1e-15:
 			needToUpdate = True
 	else:
 		needToUpdate = True


### PR DESCRIPTION
This fixes an error when the length of the cache is different from the current dimensions:
```
Traceback (most recent call last):                                                                                                             
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 85, in <module>                                                              
    script.cli()                                                                                                                               
  File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 562, in cli                                                                  
    self.run(args)                                                                                                                             
  File "/home/travis/wcEcoli/runscripts/manual/runParca.py", line 80, in run                                                                   
    task.run_task({})                                                                                                                          
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/parca.py", line 76, in run_task                                                     
    task.run_task(fw_spec)                                                                                                                     
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/fitSimData.py", line 63, in run_task                                                
    sim_data = fitSimData_1(                                                                                                                   
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 144, in fitSimData_1                                                
    sim_data.process.transcription.rnaData["KmEndoRNase"] = setKmCooperativeEndoRNonLinearRNAdecay(sim_data, cellSpecs["basal"]["bulkContainer"
])                                                                                                                                             
  File "/home/travis/wcEcoli/reconstruction/ecoli/fit_sim_data_1.py", line 3232, in setKmCooperativeEndoRNonLinearRNAdecay                     
    if np.sum(np.abs(R_aux(KmcountsCached))) > 1e-15:                                                                                          
  File "/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/theano/compile/function_module.py", line 914, in __call__            
    gof.link.raise_with_op(                                                                                                                    
  File "/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/theano/gof/link.py", line 325, in raise_with_op                      
    reraise(exc_type, exc_value, exc_trace)                                                                                                    
  File "/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/six.py", line 702, in reraise                                        
    raise value.with_traceback(tb)                                                                                                             
  File "/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/theano/compile/function_module.py", line 903, in __call__            
    self.fn() if output_subset is None else\                                                                                                   
ValueError: Input dimension mis-match. (input[0].shape[0] = 4558, input[1].shape[0] = 4546)
```