### PR TITLE
Specify units of RNA half life column in raw data

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -206,9 +206,8 @@ class Transcription(object):
 
 		# Get half life of each RNA - if the half life is not given, use the
 		# average reported half life of mRNAs
-		# TODO (ggsun): Handle units correctly
 		half_lives = np.array([
-			rna_id_to_half_life.get(rna['id'], average_mRNA_half_lives)
+			rna_id_to_half_life.get(rna['id'], average_mRNA_half_lives).asNumber(units.s)
 			for rna in raw_data.rnas])
 
 		# Convert to degradation rates

--- a/reconstruction/ecoli/flat/rna_half_lives.tsv
+++ b/reconstruction/ecoli/flat/rna_half_lives.tsv
@@ -1,5 +1,5 @@
-# Source: Bernstein et al., PNAS (2002), Units: seconds
-"id"	"half_life"
+# Source: Bernstein et al., PNAS (2002)
+"id"	"half_life (units.s)"
 "EG10002_RNA"	564
 "EG10003_RNA"	198
 "EG10004_RNA"	144


### PR DESCRIPTION
This PR specifies the units of the "half_life" column of the raw data file `rna_half_lives.tsv` in a correct way, such that the units would be imported along with the numbers in `raw_data`. This should not affect any of the actual half life values.