### PR TITLE
Correctly set max timestep at beginning of sims

### DIFF
--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -93,7 +93,6 @@ class Simulation():
 	# Attributes that may be optionally overwritten by a subclass
 	_listenerClasses = ()  # type: Tuple[Callable, ...]
 	_hookClasses = ()  # type: Sequence[Callable]
-	_timeStepSec = MAX_TIME_STEP
 	_shellColumnHeaders = ("Time (s)",)  # type: Sequence[str]
 
 	# Constructors
@@ -123,6 +122,7 @@ class Simulation():
 			print("Unknown keyword arguments: {}".format(unknownKeywords))
 
 		# Set time variables
+		self._timeStepSec = min(MAX_TIME_STEP, self._maxTimeStep)
 		self._simulationStep = 0
 		self.daughter_paths = []
 


### PR DESCRIPTION
This fixes a little bug involving the `--timestep-max` simulation flag.  If a value was supplied, the simulation would use the default `MAX_TIME_STEP` for the first few steps until the timestep is updated.  This update prevents the sim from going over the supplied max from the very beginning.