### PR TITLE
Remove all ribosomes bound to nonexisting mRNAs at each timestep

### DIFF
--- a/models/ecoli/processes/chromosome_structure.py
+++ b/models/ecoli/processes/chromosome_structure.py
@@ -333,9 +333,11 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 				self.fragmentBases.countsInc(base_counts)
 				self.ppi.countInc(n_initiated_sequences)
 
-		# Get mask for ribosomes that are bound to removed mRNA molecules
-		removed_ribosomes_mask = np.isin(
-			ribosome_mRNA_indexes, RNA_unique_indexes[removed_RNAs_mask])
+		# Get mask for ribosomes that are bound to nonexisting mRNAs
+		remaining_RNA_unique_indexes = RNA_unique_indexes[
+			np.logical_not(removed_RNAs_mask)]
+		removed_ribosomes_mask = np.logical_not(np.isin(
+			ribosome_mRNA_indexes, remaining_RNA_unique_indexes))
 		n_removed_ribosomes = np.count_nonzero(removed_ribosomes_mask)
 
 		# Remove ribosomes that are bound to removed mRNA molecules


### PR DESCRIPTION
@juliaschaepe pointed out that at the end of each timestep, there exists a certain number of ribosomes that are associated to nonexisting mRNA molecules, presumably because the corresponding mRNA molecule has been degraded by the `RnaDegradation` process. This PR makes changes to the `ChromosomeStructure` process such that it removes the entire set of ribosomes whose template mRNAs are missing, instead of accounting for mRNAs removed as a result of collisions between the replisome and the RNAPs.