### PR TITLE
Keep initial positions of ribosomes within range of full polypeptide lengths

### DIFF
--- a/models/ecoli/sim/initial_conditions.py
+++ b/models/ecoli/sim/initial_conditions.py
@@ -1046,6 +1046,7 @@ def initialize_translation(bulkMolCntr, uniqueMolCntr, sim_data, randomState):
 	currentNutrients = sim_data.conditions[sim_data.condition]['nutrients']
 	fracActiveRibosome = sim_data.process.translation.ribosomeFractionActiveDict[currentNutrients]
 	proteinSequences = sim_data.process.translation.translation_sequences
+	protein_lengths = sim_data.process.translation.monomer_data['length'].asNumber()
 	translationEfficiencies = normalize(
 		sim_data.process.translation.translation_efficiencies_by_monomer)
 	aaWeightsIncorporated = sim_data.process.translation.translation_monomer_weights
@@ -1121,9 +1122,16 @@ def initialize_translation(bulkMolCntr, uniqueMolCntr, sim_data, randomState):
 		mRNA_indexes[start_index:start_index+counts] = np.repeat(
 			unique_index_mRNAs[mask], n_ribosomes_per_RNA)
 
-		# Randomly place ribosomes along the length of each mRNA
+		# Get full length of this polypeptide
+		peptide_full_length = protein_lengths[protein_index]
+
+		# Randomly place ribosomes along the length of each mRNA, capped by the
+		# mRNA length expected from the full polypeptide length to prevent
+		# ribosomes from overshooting full peptide lengths
 		positions_on_mRNA[start_index:start_index+counts] = np.floor(
-			randomState.rand(counts)*np.repeat(lengths, n_ribosomes_per_RNA))
+			randomState.rand(counts)
+			* np.repeat(np.minimum(lengths, peptide_full_length*3), n_ribosomes_per_RNA)
+			)
 
 		start_index += counts
 


### PR DESCRIPTION
Fixes #979. The error in issue #979 was caused by some ribosomes being initialized with their `peptide_length` attributes set to be larger than the full length of the polypeptide that they were translating. This led to the `polymerize` function returning sequences with pad values (-1) that extend beyond a protein's length. The attribute was set this way because the lengths of the template mRNAs (which are sometimes longer than three times the full length of the polypeptide) were used to determine the positions of these ribosomes on the mRNAs first, and then this value was divided by three to yield the peptide length. As a temporary fix, I've capped the positions of these ribosomes to three times the full length of the polypeptide to make sure that the resulting `peptide_length` attribute falls within the correct range. The probability of a ribosome being assigned to an mRNA is still proportional to the full length of the RNA.

A lot of the positional attributes of active ribosomes were built assuming that three nucleotides on an mRNA always correspond to a single amino acid, which is something that would definitely be worth fixing with some good data on the coding sequences of mRNAs.