### PR TITLE
Sort molecule names for consistent ordering

### DIFF
--- a/reconstruction/ecoli/dataclasses/getter_functions.py
+++ b/reconstruction/ecoli/dataclasses/getter_functions.py
@@ -110,7 +110,7 @@ class GetterFunctions(object):
 		Returns a list of all molecule IDs with assigned submass arrays and
 		compartments.
 		"""
-		return list(self._all_submass_arrays.keys() & self._all_compartments.keys())
+		return sorted(self._all_submass_arrays.keys() & self._all_compartments.keys())
 
 	def _build_sequences(self, raw_data):
 		"""


### PR DESCRIPTION
This fixes #989.  Parca output is now identical between runs.  We should still update Jenkins build scripts to test for consistency as noted in #989 and #922.