### PR TITLE
Remove call to purge old Jenkins build directories

### DIFF
--- a/runscripts/jenkins/ecoli-anaerobic.sh
+++ b/runscripts/jenkins/ecoli-anaerobic.sh
@@ -5,8 +5,6 @@ PASSWORD=$4
 
 set -e
 
-runscripts/jenkins/purge.sh anaerobic 10
-
 source runscripts/jenkins/setup-environment.sh
 sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 

--- a/runscripts/jenkins/ecoli-glucose-minimal.sh
+++ b/runscripts/jenkins/ecoli-glucose-minimal.sh
@@ -5,8 +5,6 @@ PASSWORD=$4
 
 set -e
 
-runscripts/jenkins/purge.sh daily_build 10
-
 source runscripts/jenkins/setup-environment.sh
 sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 

--- a/runscripts/jenkins/ecoli-with-aa.sh
+++ b/runscripts/jenkins/ecoli-with-aa.sh
@@ -5,8 +5,6 @@ PASSWORD=$4
 
 set -e
 
-runscripts/jenkins/purge.sh with_aa 10
-
 source runscripts/jenkins/setup-environment.sh
 sh runscripts/jenkins/fireworks-config.sh $HOST $NAME $PORT $PASSWORD
 


### PR DESCRIPTION
This removes the Jenkins directory purge from 3 jobs to fix the build failures.  It is no longer needed since Sherlock automatically purges files now.  The Sherlock purge also changes the modification date when it empties the directories, which prevents the purge script from removing directories any way.