### PR TITLE
Check for finite positions before plotting text

### DIFF
--- a/models/ecoli/analysis/single/inter_rnap_distance.py
+++ b/models/ecoli/analysis/single/inter_rnap_distance.py
@@ -81,8 +81,9 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Add values to each bar
 		for i, v in enumerate(avg_inter_rnap_distance[:SAMPLE_SIZE]):
-			plt.text(v - 1, i, "{0:.1f}".format(v), color='white', fontsize=5,
-				horizontalalignment='right', verticalalignment='center')
+			if np.isfinite(v):
+				plt.text(v - 1, i, "{0:.1f}".format(v), color='white', fontsize=5,
+					horizontalalignment='right', verticalalignment='center')
 
 		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)


### PR DESCRIPTION
In troubleshooting the Jenkins builds failures (fix coming shortly), I came across a quick fix for many lines of `posx and posy should be finite values` that are getting printed.  This is certainly exceptional behavior when no chromosome is inherited (distance is nan) but cleaning this up makes it easier to see the error message in Jenkins emails.