### PR TITLE
Fix 976

### DIFF
--- a/models/ecoli/listeners/monomer_counts.py
+++ b/models/ecoli/listeners/monomer_counts.py
@@ -21,8 +21,6 @@ class MonomerCounts(wholecell.listeners.listener.Listener):
 	def initialize(self, sim, sim_data):
 		super(MonomerCounts, self).initialize(sim, sim_data)
 
-
-
 		# Get IDs of all bulk molecules
 		self.bulkMolecules = sim.internal_states["BulkMolecules"]
 		bulk_molecule_ids = self.bulkMolecules.container.objectNames()
@@ -37,7 +35,6 @@ class MonomerCounts(wholecell.listeners.listener.Listener):
 		# Get IDs of complexed molecules monomers involved in two component system
 		two_component_system_molecule_ids = list(sim_data.process.two_component_system.molecule_names)
 		two_component_system_complex_ids = list(sim_data.process.two_component_system.complex_to_monomer.keys())
-
 
 		# Get IDs of ribosome subunits
 		ribosome_50s_subunits = sim_data.process.complexation.get_monomers(
@@ -88,7 +85,6 @@ class MonomerCounts(wholecell.listeners.listener.Listener):
 		self.rnap_subunit_idx = get_molecule_indexes(rnap_subunit_ids)
 		self.replisome_subunit_idx = get_molecule_indexes(replisome_subunit_ids)
 
-
 		# Get indexes of all unique molecules that need to be accounted for
 		self.uniqueMolecules = sim.internal_states["UniqueMolecules"]
 		unique_molecule_ids = self.uniqueMolecules.container.objectNames()
@@ -120,13 +116,9 @@ class MonomerCounts(wholecell.listeners.listener.Listener):
 		two_component_monomer_counts = np.dot(self.two_component_system_stoich,
 			np.negative(bulkMoleculeCounts[self.two_component_system_complex_idx]))
 
-
-
 		bulkMoleculeCounts[self.complexation_molecule_idx] += complex_monomer_counts.astype(np.int)
 		bulkMoleculeCounts[self.equilibrium_molecule_idx] += equilibrium_monomer_counts.astype(np.int)
 		bulkMoleculeCounts[self.two_component_system_molecule_idx] += two_component_monomer_counts.astype(np.int)
-
-
 
 		# Account for monomers in unique molecule complexes
 		n_ribosome_subunit = n_active_ribosome * self.ribosome_stoich

--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -29,25 +29,24 @@ class TwoComponentSystem(object):
 		sim_data.molecule_groups.twoComponentSystems = raw_data.two_component_systems
 
 		# Build the abstractions needed for two component systems
-		molecules = [] # list of all molecules involved in two component system
-		moleculeTypes = [] # the type of each molecule (metabolite, protein monomer, protein complex, etc.)
+		molecules = []  # list of all molecules involved in two component system
+		moleculeTypes = []  # the type of each molecule (metabolite, protein monomer, protein complex, etc.)
 
-		ratesFwd = [] # rate of reaction fwd
-		ratesRev = [] # rate of reaction reverse (all 0, reverse reactions are
-		rxnIds = [] # ID tied to each rxn equation
+		ratesFwd = []  # rate of reaction fwd
+		ratesRev = []  # rate of reaction reverse (most/all are 0 in flat file)
+		rxnIds = []  # ID tied to each rxn equation
 
-		stoichMatrixI = [] # Molecule indices
-		stoichMatrixJ = [] # Reaction indices
-		stoichMatrixV = [] # Stoichometric coefficients
+		stoichMatrixI = []  # Molecule indices
+		stoichMatrixJ = []  # Reaction indices
+		stoichMatrixV = []  # Stoichometric coefficients
 
-		stoichMatrixMass = [] # molecular mass of molecules in stoichMatrixI
+		stoichMatrixMass = []  # molecular mass of molecules in stoichMatrixI
 
+		independentMolecules = []  # list of all specific independent molecule names
+		independent_molecule_indexes = []  # index of each of the independent molecules
+		independentToDependentMolecules = {}  # holds the phosphorylated version of the independent molecules
 
-		independentMolecules = [] # list of all specific independent molecule names
-		independent_molecule_indexes = [] # index of each of the independent molecules
-		independentToDependentMolecules = {} # holds the phosphorylated version of the independent molecules
-
-		activeToInactiveTF = {} #convention: active TF is the DNA-binding form (active form is phosphorylated version of RR)
+		activeToInactiveTF = {}  # convention: active TF is the DNA-binding form (active form is phosphorylated version of RR)
 
 		# Build template reactions
 		signalingTemplate = {
@@ -150,9 +149,9 @@ class TwoComponentSystem(object):
 					stoichMatrixMass.append(molecularMass)
 
 		# TODO(jerry): Move most of the rest to a subroutine for __init__ and __setstate__?
-		self._stoichMatrixI = np.array(stoichMatrixI) # array of molecule indices
-		self._stoichMatrixJ = np.array(stoichMatrixJ) # array of reaction indices
-		self._stoichMatrixV = np.array(stoichMatrixV) # arrary of stoichometric coefficients
+		self._stoichMatrixI = np.array(stoichMatrixI)  # array of molecule indices
+		self._stoichMatrixJ = np.array(stoichMatrixJ)  # array of reaction indices
+		self._stoichMatrixV = np.array(stoichMatrixV)  # arrary of stoichometric coefficients
 
 		self.molecule_names = np.array(molecules, dtype='U')
 		self.molecule_types = np.array(moleculeTypes, dtype='U')


### PR DESCRIPTION
This includes the complexed two component system monomers to the monomers count listiner. Also includes a fix to the process two_component_systems._buildComplexToMonomer in which the dictionary was not being properly created due to a a formatting issue when indexing through tcsMolecules.   