### PR TITLE
Fix compartment tag for CPLX0-7992 in outer membrane analysis plot

### DIFF
--- a/models/ecoli/analysis/single/outer_membrane_expression.py
+++ b/models/ecoli/analysis/single/outer_membrane_expression.py
@@ -68,7 +68,7 @@ outer_mem_proteins = {
 
 	# LPS transport
 	'CPLX0-7704[i]': 'LPS ABC transporter (lipid A-core flippase)',
-	'CPLX0-7992[s]': 'LPS transport system',
+	'CPLX0-7992[i]': 'LPS transport system',
 	'ABC-53-CPLX[i]': 'lptB2-F-G',
 	'CPLX0-7628[e]': 'lptE-D',
 	'YHBN-MONOMER[e]': 'lptA',


### PR DESCRIPTION
This PR changes the hard-coded compartment tag for 'CPLX0-7992' in the outer membrane analysis plot that was added with PR #983 from 's' to 'i'. This should address the build failures we had been seeing this week. 

We may want to consider moving away from using hard-coded full bulk molecule IDs with compartments, and making use of getter functions that can append compartment tags given a molecule ID. For molecules that are mapped to multiple compartments this might turn out to be tricky. 