### PR TITLE
Add total bound TF counts to fathom dynamics

### DIFF
--- a/models/ecoli/analysis/causality_network/build_network.py
+++ b/models/ecoli/analysis/causality_network/build_network.py
@@ -932,6 +932,20 @@ class BuildNetwork(object):
 
 		# Loop through all TFs
 		for tf_id in tf_ids:
+			# Add TF bound to DNA
+			bound_tf_id = f'{tf_id}-bound'
+			tf_node = Node()
+			attr = {
+				'node_class': 'Process',
+				'node_type': 'TF Binding',
+				'node_id': bound_tf_id,
+				'name': bound_tf_id,
+				'location': 'c',
+				}
+			tf_node.read_attributes(**attr)
+			self.node_list.append(tf_node)
+			self._append_edge("Regulation", tf_id + "[c]", bound_tf_id)
+
 			# Get IDs of RNAs that are regulated by the TF
 			regulated_rna_ids = rna_ids[TF_to_TU_idx[tf_id]]
 
@@ -957,7 +971,7 @@ class BuildNetwork(object):
 				self.node_list.append(regulation_node)
 
 				# Add edge from TF to this regulation node
-				self._append_edge("Regulation", tf_id + "[c]", reg_id)
+				self._append_edge("Regulation", bound_tf_id, reg_id)
 
 				# Add edge from this regulation node to the gene
 				self._append_edge("Regulation", reg_id, gene_id)

--- a/models/ecoli/analysis/causality_network/read_dynamics.py
+++ b/models/ecoli/analysis/causality_network/read_dynamics.py
@@ -404,6 +404,25 @@ def read_regulation_dynamics(sim_data, node, node_id, columns, indexes, volume):
 	node.read_dynamics(dynamics, dynamics_units)
 
 
+def read_tf_binding_dynamics(sim_data, node, node_id, columns, indexes, volume):
+	"""
+	Reads dynamics data for TF binding nodes from a simulation output.
+	"""
+
+	tf_id, _ = node_id.split("-bound")
+	tf_idx = indexes["TranscriptionFactors"][tf_id]
+
+	dynamics = {
+		'bound TFs': columns[("RnaSynthProb", "n_bound_TF_per_TU")][
+			:, :, tf_idx].sum(axis=1),
+		}
+	dynamics_units = {
+		'bound TFs': COUNT_UNITS,
+		}
+
+	node.read_dynamics(dynamics, dynamics_units)
+
+
 def read_charging_dynamics(sim_data, node, node_id, columns, indexes, volume):
 	"""
 	Reads dynamics data for charging nodes from a simulation output.
@@ -436,5 +455,6 @@ TYPE_TO_READER_FUNCTION = {
 	"Metabolism": read_metabolism_dynamics,
 	"Transport": read_metabolism_dynamics,
 	"Regulation": read_regulation_dynamics,
+	"TF Binding": read_tf_binding_dynamics,
 	"Charging": read_charging_dynamics,
 	}


### PR DESCRIPTION
This adds a total TF bound count to fathom.  Previously, bound counts were only shown for individual TF-gene promoters.  Since the active TF counts do not include bound counts, it was hard to get a sense for the total number of TF (free and bound) in a sim.

The image below demonstrates this (LeuO counts are nearly always 0 but bound counts remain at 13 throughout the sim).  `PD00519-bound` (along with other bound TFs) is added in this PR with that labeling notation.
![image](https://user-images.githubusercontent.com/18123227/105087477-60ed1b00-5a4f-11eb-9318-cc78e3b94b8c.png)

I will also update the Causality repo to include an abbreviation for TF Binding (TFB) so that the "?" doesn't show up.