### PR TITLE
Interactive analysis updates

### DIFF
--- a/runscripts/manual/analysis_interactive.py
+++ b/runscripts/manual/analysis_interactive.py
@@ -363,6 +363,10 @@ def create_app(data_structure: Dict) -> dash.Dash:
 				two values (all separated by SEPARATOR) for x data
 			y_input: directory path to simOut with listener and column as last
 				two values (all separated by SEPARATOR) for y data
+			x_options: options from check boxes to apply transformations to the
+				x data
+			y_options: options from check boxes to apply transformations to the
+				y data
 
 		Returns:
 			plotly figure dict


### PR DESCRIPTION
This makes several adjustments to the interactive analysis framework to make it even more useful.  It adds the ability to transform datasets (see options below), simplified the data selection process by having one drop down list and buttons to select x or y data, and scatter plots are now a useful plotting option (they can actually be done with `line` so no need for a separate `scatter` option).

Data options:
- normalized: normalize to an initial value
- mean: reduce time series to a mean for the cell cycle
- log: scale the data with a log function

A screenshot demonstrating some of the changes by showing the ability to compare counts of monomers across any simulation:
![image](https://user-images.githubusercontent.com/18123227/105425525-68065b80-5bfe-11eb-9574-729683438277.png)
