### PR TITLE
Use cell cycle length instead of final time for correct mRNA half life plot

### DIFF
--- a/models/ecoli/analysis/single/mRnaHalfLives.py
+++ b/models/ecoli/analysis/single/mRnaHalfLives.py
@@ -23,7 +23,6 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get the expected degradation rates from KB
 		sim_data = cPickle.load(open(simDataFile, 'rb'))
-		mRNA_ids = sim_data.process.transcription.rna_data['id']
 		isMRna = sim_data.process.transcription.rna_data['is_mRNA']
 		expected_degradation_rate_constants = np.array(
 			sim_data.process.transcription.rna_data['deg_rate'][isMRna].asNumber()
@@ -31,7 +30,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Get length of simulation
 		main_reader = TableReader(os.path.join(simOutDir, 'Main'))
-		sim_length = main_reader.readColumn('time')[-1]
+		sim_time = main_reader.readColumn('time')
+		sim_length = sim_time[-1] - sim_time[0]
 
 		# Read counts of mRNAs
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))


### PR DESCRIPTION
This fixes an issue in the mRNA half lives plot that was using total sim time instead of cell cycle time to calculate half lives.  This led to decreasing calculated deg rates with each generation.

Old plot for second gen:
![image](https://user-images.githubusercontent.com/18123227/105557700-b0d31880-5cc1-11eb-9f17-50c4ccc9758f.png)

Corrected plot for second gen:
![image](https://user-images.githubusercontent.com/18123227/105557739-c5afac00-5cc1-11eb-9119-f4bd37b39c62.png)
