### PR TITLE
Increase dnaB expression

### DIFF
--- a/reconstruction/ecoli/flat/adjustments/rna_expression_adjustments.tsv
+++ b/reconstruction/ecoli/flat/adjustments/rna_expression_adjustments.tsv
@@ -1,9 +1,10 @@
-# Adjustments to get protein expression for certain enzymes required for metabolism				
+# Adjustments to get protein expression for certain enzymes required for metabolism
 "name"	"value"	"units"	"_source"	"_comments"
 "EG11493_RNA[c]"	10		"fit_sim_data_1.py"	"pabC, aminodeoxychorismate lyase"
 "EG12438_RNA[c]"	10		"fit_sim_data_1.py"	"menH, 2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate synthetase"
 "EG12298_RNA[c]"	10		"fit_sim_data_1.py"	"yibQ, Predicted polysaccharide deacetylase; This RNA is fit for the anaerobic condition viability"
 "EG11672_RNA[c]"	10		"fit_sim_data_1.py"	"atoB, acetyl-CoA acetyltransferase; This RNA is fit for the anaerobic condition viability"
+"EG10236_RNA[c]"	10		"fit_sim_data_1.py"	"dnaB, replicative DNA helicase; This RNA is fit for the sims to produce enough DNAPs for timely replication in anaerobic condition"
 "EG10238_RNA[c]"	10		"fit_sim_data_1.py"	"dnaE, DNA polymerase III subunit alpha; This RNA is fit for the sims to produce enough DNAPs for timely replication"
 "EG11673_RNA[c]"	10		"fit_sim_data_1.py"	"folB, dihydroneopterin aldolase; needed for growth (METHYLENE-THF) in acetate condition"
 "EG10808_RNA[c]"	4		"fit_sim_data_1.py"	"pyrE, orotate phosphoribosyltransferase; Needed for UTP synthesis, transcriptional regulation by UTP is not included in the model"


### PR DESCRIPTION
This increases expression of dnaB so that DNA replication always begins in a timely manner in anaerobic conditions.  The daily anaerobic build was failing because DNA replication did not complete before division so RNA was not produced in later generations that did not receive a copy of the chromosome.

@ggsun, do you know if there is any regulation of these replisome proteins?  EcoCyc doesn't list any for dnaB or dnaE (another adjustment in this file) but it seems like something that should be tightly regulated.  Maybe regulated by supercoiling?