### PR TITLE
Remove fnr -> arcA regulation

### DIFF
--- a/reconstruction/ecoli/flat/fold_changes_removed.tsv
+++ b/reconstruction/ecoli/flat/fold_changes_removed.tsv
@@ -2,3 +2,4 @@
 "crp"	"cyaA"	"Disabled because of negative feedback in acetate - cyaA -> cAMP -> cAMP-crp"
 "bglJ"	"leuO"	"Remove feedback loop between bglJ <-> leuO"
 "leuO"	"bglJ"	"Remove feedback loop between bglJ <-> leuO"
+"fnr"	"arcA"	"Remove to get expression of arcA"


### PR DESCRIPTION
This removes fnr -> arcA regulation form fold changes in order to get expression of arcA.  With the regulation in place, the basal probability and delta probability for arcA was 0 so it was never produced in simulations.  The plot and spreadsheet output added with #1015 identified several genes that are at 0 basal probability (most of these are expected with no measured expression).  After this change, arcA has a basal probability.

From tf_binding multigen plot:
Before (no expression throughout sim):
![image](https://user-images.githubusercontent.com/18123227/105798472-0ec46200-5f47-11eb-9240-2b11252fe873.png)

After:
![image](https://user-images.githubusercontent.com/18123227/105798388-e63c6800-5f46-11eb-9535-65d87943f068.png)
