### PR TITLE
Remove Arg binding to single ArgR to allow binding to hexamer

### DIFF
--- a/reconstruction/ecoli/flat/equilibrium_reactions_removed.tsv
+++ b/reconstruction/ecoli/flat/equilibrium_reactions_removed.tsv
@@ -3,6 +3,6 @@
 "CPLX0-7670_RXN"
 "CPLX0-8026_RXN"
 "CPLX0-8027_RXN"
+"CPLX0-8076_RXN"	"ArgR-Arg complex. Not included in EcoCyc. Prevents formation of 6ArgR-Arg complex which is a TF"
 "MONOMER-51-PROPIONYL-COA_RXN"
 "MONOMER0-163_RXN"
-"CPLX0-8076_RXN"	"ArgR-Arg complex. Not included in EcoCyc. Prevents formation of 6ArgR-Arg complex which is a TF"


### PR DESCRIPTION
This fixes an issue where the number of ArgR transcription factors would deplete over time.  The issue was coming from two equilibrium reaction with ArgR and Arg.  One involved the ArgR monomer and formed a complex (CPLX0-8076) that is no longer on EcoCyc and the other involved an ArgR hexamer to form the active TF.  Removing the equilibrium reaction for CPLX0-8076 now allows the hexamer and active TF to form.

The issue was demonstrated in the `tf_binding.py` multigen plot:
Before:
![image](https://user-images.githubusercontent.com/18123227/105888656-1a08a380-5fc2-11eb-8531-06aab85f3133.png)

After:
![image](https://user-images.githubusercontent.com/18123227/105888886-681da700-5fc2-11eb-869b-f3d99cf684b6.png)
