### PR TITLE
Turn on negative autoregulation of TFs

### DIFF
--- a/reconstruction/ecoli/simulation_data.py
+++ b/reconstruction/ecoli/simulation_data.py
@@ -126,6 +126,8 @@ class SimulationDataEcoli(object):
 			gene_not_found = set()
 			tf_not_found = set()
 			for row in getattr(raw_data, fc_file):
+				FC = row['log2 FC mean']
+
 				# Skip fold changes that have been removed
 				if (row['TF'], row['Target']) in removed_fcs:
 					continue
@@ -134,8 +136,8 @@ class SimulationDataEcoli(object):
 				if row['Regulation_direct'] != '' and row['Regulation_direct'] > 2:
 					continue
 
-				# Skip autoregulation
-				if row['TF'] == row['Target']:
+				# Skip positive autoregulation
+				if row['TF'] == row['Target'] and FC > 0:
 					continue
 
 				try:
@@ -154,7 +156,6 @@ class SimulationDataEcoli(object):
 					self.tf_to_fold_change[tf] = {}
 					self.tf_to_direction[tf] = {}
 
-				FC = row['log2 FC mean']
 				self.tf_to_direction[tf][target] = np.sign(FC)
 				self.tf_to_fold_change[tf][target] = 2**FC
 


### PR DESCRIPTION
This turns on negative autoregulation of transcription factors.  It still excludes positive autoregulation, which could be unstable within other feedback mechanisms.  This will help with some sims that could experience high ArgR activation when certain amino acids spiked. This activation would repress lrp and reduces the amount of synthetases that are produced, which would lead to even higher amino acids through less charging.  It appears to have minimal impact on other basal probabilities and delta probabilities.  Currently, it looks like only ArgR, TrpR, TyrR and PutA have a high enough delta probability to have a significant effect on their own expression.