### PR TITLE
Set interactive analysis hover to closest

### DIFF
--- a/runscripts/manual/analysis_interactive.py
+++ b/runscripts/manual/analysis_interactive.py
@@ -411,6 +411,7 @@ def create_app(data_structure: Dict) -> dash.Dash:
 			'layout': go.Layout(
 				xaxis_title=x_input.split(SEPARATOR)[-1],
 				yaxis_title=y_input.split(SEPARATOR)[-1],
+				hovermode='closest',
 				**layout_options),
 			}
 


### PR DESCRIPTION
This makes a small configuration change to the interactive analysis to show the name of the closest trace and make the hover much more useful for identifying traces/outliers.

Before:
![image](https://user-images.githubusercontent.com/18123227/106194356-8f5faa00-6163-11eb-84d2-0fcc70d18c95.png)

After:
![image](https://user-images.githubusercontent.com/18123227/106194290-76ef8f80-6163-11eb-8fd2-1e800554a35e.png)
