### PR TITLE
Handle ValueError in equilibrium solve_ivp

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/equilibrium.py
+++ b/reconstruction/ecoli/dataclasses/process/equilibrium.py
@@ -346,8 +346,8 @@ class Equilibrium(object):
 					method=method, t_eval=[0, time_limit],
 					jac=derivatives_jacobian)
 				break
-			except ValueError:
-				print('Warning: switching solver method in equilibrium')
+			except ValueError as e:
+				print(f'Warning: switching solver method in equilibrium, {e!r}')
 		else:
 			raise RuntimeError('Could not solve ODEs in equilibrium to SS.'
 				' Try adjusting time step or changing methods.')


### PR DESCRIPTION
This handles an error that can pop up at times in equilibrium:
```
 lsoda--  at t (=r1) and step size h (=r2), the            
       corrector convergence failed repeatedly                                                                                 
       or with abs(h) = hmin  
      in above,  r1 =  0.0000000000000D+00   r2 =  0.4815346759737D+03                                                        
/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/scipy/integrate/_ode.py:1350: UserWarning: lsoda: Repeated convergence failur
es (perhaps bad Jacobian or tolerances).                  
  warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,

Traceback (most recent call last):                                                                                 
  File "/home/travis/wcEcoli3/runscripts/manual/runDaughter.py", line 105, in <module>
    script.cli()
  File "/home/travis/wcEcoli3/wholecell/utils/scriptBase.py", line 589, in cli
    self.run(args)
  File "/home/travis/wcEcoli3/runscripts/manual/runDaughter.py", line 100, in run
    task.run_task({})
  File "/home/travis/wcEcoli3/wholecell/fireworks/firetasks/simulationDaughter.py", line 83, in run_task
    sim.run()
  File "/home/travis/wcEcoli3/wholecell/sim/simulation.py", line 241, in run
    self.run_incremental(self._lengthSec + self.initialTime())
  File "/home/travis/wcEcoli3/wholecell/sim/simulation.py", line 273, in run_incremental
    self._evolveState(processes)
  File "/home/travis/wcEcoli3/wholecell/sim/simulation.py", line 329, in _evolveState
    process.calculateRequest()
  File "/home/travis/wcEcoli3/models/ecoli/processes/equilibrium.py", line 57, in calculateRequest
    self.rxnFluxes, self.req = self.fluxesAndMoleculesToSS(
  File "/home/travis/wcEcoli3/reconstruction/ecoli/dataclasses/process/equilibrium.py", line 342, in fluxes_and_molecules_to_SS
    sol = integrate.solve_ivp(
  File "/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/scipy/integrate/_ivp/ivp.py", line 650, in solve_ivp
    ts = np.hstack(ts)
  File "<__array_function__ internals>", line 5, in hstack
  File "/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/numpy/core/shape_base.py", line 346, in hstack
    return _nx.concatenate(arrs, 1)
  File "<__array_function__ internals>", line 5, in concatenate
ValueError: need at least one array to concatenate
```

Switching from LSODA to BDF at problem time steps can provide a solution that is nearly identical to a solution from LSODA with a shorter time step that does not produce this error.

Handling the error now just produces warnings with insights into where the problem might be coming from (singular matrix that is obviously handled properly with BDF):
```
 lsoda--  at t (=r1) and step size h (=r2), the                                                        
       corrector convergence failed repeatedly                                                              
       or with abs(h) = hmin                                                                    
      in above,  r1 =  0.0000000000000D+00   r2 =  0.4815346759737D+03             
/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/scipy/integrate/_ode.py:1350: UserWarning: lsoda: Repeated convergence failur
es (perhaps bad Jacobian or tolerances).                                           
  warnings.warn('{:s}: {:s}'.format(self.__class__.__name__,                       
Warning: switching solver method in equilibrium                                    
/home/travis/.pyenv/versions/wcEcoli3/lib/python3.8/site-packages/scipy/integrate/_ivp/bdf.py:218: LinAlgWarning: Diagonal number 53 is exactly
 zero. Singular matrix.                                                            
  return lu_factor(A, overwrite_a=True)
```

It appears that if a certain combination of molecules have 0 counts in a time step, then this problem can occur.  I did a little troubleshooting and found that if you would add 1 count to any of the molecules below then the original code would produce a result for the trouble time step.  Not sure if they have anything in common or if the same molecules were causing problems in other sims where I ran into this problem (other combinations might cause the same issue).
```
'PC00061[c]'
'PD04099[c]'
'CPLX0-7733[c]'
'PD00339[c]'
'EG11088-MONOMER[c]'
'PD00353[c]'
'PD03831[c]'
'PD00413[c]'
'EG11149-MONOMER[c]'
```
