### PR TITLE
Include next amino acid position for f calculation to avoid NaN

### DIFF
--- a/models/ecoli/processes/polypeptide_elongation.py
+++ b/models/ecoli/processes/polypeptide_elongation.py
@@ -48,6 +48,7 @@ class PolypeptideElongation(wholecell.processes.process.Process):
 		self.endWeight = translation.translation_end_weight
 		self.variable_elongation = sim._variable_elongation_translation
 		self.make_elongation_rates = translation.make_elongation_rates
+		self.next_aa_pad = translation.next_aa_pad
 
 		self.ribosomeElongationRate = float(sim_data.growth_rate_parameters.ribosomeElongationRate.asNumber(units.aa / units.s))
 
@@ -169,13 +170,12 @@ class PolypeptideElongation(wholecell.processes.process.Process):
 			'protein_index', 'peptide_length', 'pos_on_mRNA'
 			)
 
-		next_aa_pad = 1  # Need an extra amino acid to find out the next one if fully elongated
 		all_sequences = buildSequences(
 			self.proteinSequences,
 			protein_indexes,
 			peptide_lengths,
-			self.elongation_rates + next_aa_pad)
-		sequences = all_sequences[:, :-next_aa_pad].copy()
+			self.elongation_rates + self.next_aa_pad)
+		sequences = all_sequences[:, :-self.next_aa_pad].copy()
 
 		if sequences.size == 0:
 			return

--- a/reconstruction/ecoli/dataclasses/process/translation.py
+++ b/reconstruction/ecoli/dataclasses/process/translation.py
@@ -22,6 +22,7 @@ class Translation(object):
 
 	def __init__(self, raw_data, sim_data):
 		self.max_time_step = min(MAX_TIME_STEP, PROCESS_MAX_TIME_STEP)
+		self.next_aa_pad = 1  # Need an extra amino acid in sequences lengths to find next one
 
 		self._build_monomer_data(raw_data, sim_data)
 		self._build_translation(raw_data, sim_data)
@@ -156,7 +157,7 @@ class Translation(object):
 		max_len = np.int64(
 			self.monomer_data["length"].asNumber().max()
 			+ self.max_time_step * sim_data.constants.ribosome_elongation_rate_max.asNumber(units.aa / units.s)
-			)
+			) + self.next_aa_pad
 
 		self.translation_sequences = np.full((len(sequences), max_len), polymerize.PAD_VALUE, dtype=np.int8)
 		aa_ids_single_letter = six.viewkeys(sim_data.amino_acid_code_to_id_ordered)


### PR DESCRIPTION
This makes a slight change to the calculation of `f` when looking at amino acid charging related to ppGpp.  `f` is used to calculate the fraction of amino acids at the A position of ribosomes.  This should include the next up amino acid after all elongations so it makes sense to add the number of amino acids in this position in addition to all of the `aas_used` to calculate an average `f` over the time step.

It also has the benefit of fixing an error that could pop up in certain time steps when `aas_used` could be 0.  This comes from charging issues where there are no charged tRNAs of a certain species in a given time step (largely due to instability in amino acid concentrations and the charged state of certain species) which leads to no translation in that time step.
```
Traceback (most recent call last):                                                                                                             
  File "/home/travis/.pyenv/versions/3.8.3/envs/wcEcoli3/lib/python3.8/site-packages/fireworks/core/rocket.py", line 262, in run               
    m_action = t.run_task(my_spec)                                                                                                             
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/simulation.py", line 80, in run_task                                                
    sim.run()                                                                                                                                  
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 241, in run                                                                    
    self.run_incremental(self._lengthSec + self.initialTime())                                                                                 
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 273, in run_incremental                                                        
    self._evolveState(processes)                                                                                                               
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 342, in _evolveState                                                           
    process.evolveState()                                                                                                                      
  File "/home/travis/wcEcoli/models/ecoli/processes/polypeptide_elongation.py", line 251, in evolveState                                       
    net_charged, self.aa_count_diff = self.elongation_model.evolve(total_aa_counts, aas_used, nElongations, nInitialized)                      
  File "/home/travis/wcEcoli/models/ecoli/processes/polypeptide_elongation.py", line 546, in evolve                                            
    delta_metabolites, ppgpp_syn, ppgpp_deg, rela_syn, spot_syn, spot_deg = self.ppgpp_metabolite_changes(                                     
  File "/home/travis/wcEcoli/models/ecoli/processes/polypeptide_elongation.py", line 815, in ppgpp_metabolite_changes                          
    max_iterations = int(n_deg_reactions + n_syn_reactions + 1)                                                                                
ValueError: cannot convert float NaN to integer 
```