### PR TITLE
Check homeostatic target for nonnegativity

### DIFF
--- a/wholecell/utils/modular_fba.py
+++ b/wholecell/utils/modular_fba.py
@@ -1155,7 +1155,7 @@ class FluxBalanceAnalysis(object):
 
 		for molecule_id, coeff in objective.items():
 			if coeff < 0:
-				raise ValueError('Homeostatic target must be non-negative.')
+				raise ValueError(f'Homeostatic target must be non-negative. It is {coeff} for {molecule_id}.')
 
 			if molecule_id not in self._outputMoleculeIDs:
 				raise FBAError(


### PR DESCRIPTION
This adds a check to make sure homeostatic targets are not negative.  This problem previously led to the FBA problem being infeasible and an error message like:
```
Warning: GLP_NOFEAS: no feasible error while solving FBA - repeating FBA solve
Warning: GLP_NOFEAS: no feasible error while solving FBA - repeating FBA solve
Warning: GLP_NOFEAS: no feasible error while solving FBA - repeating FBA solve

Simulation finished:
 - Sim length: 0:00:08
 - Sim end time: 2:26:18
 - Runtime: 0:00:13

Traceback (most recent call last):
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1472, in solve
    self._solver._solve()
  File "/home/travis/wcEcoli/wholecell/utils/_netflow/nf_glpk.py", line 478, in _solve
    raise RuntimeError(self.status_string)
RuntimeError: GLP_NOFEAS: no feasible

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1472, in solve
    self._solver._solve()
  File "/home/travis/wcEcoli/wholecell/utils/_netflow/nf_glpk.py", line 478, in _solve
    raise RuntimeError(self.status_string)
RuntimeError: GLP_NOFEAS: no feasible

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1472, in solve
    self._solver._solve()
  File "/home/travis/wcEcoli/wholecell/utils/_netflow/nf_glpk.py", line 478, in _solve
    raise RuntimeError(self.status_string)
RuntimeError: GLP_NOFEAS: no feasible

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/travis/.pyenv/versions/3.8.3/envs/wcEcoli3/lib/python3.8/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/simulationDaughter.py", line 83, in run_task
    sim.run()
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 241, in run
    self.run_incremental(self._lengthSec + self.initialTime())
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 273, in run_incremental
    self._evolveState(processes)
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 342, in _evolveState
    process.evolveState()
  File "/home/travis/wcEcoli/models/ecoli/processes/metabolism.py", line 161, in evolveState
    fba.solve(n_retries)
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1475, in solve
    self.solve(iterations - 1)
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1475, in solve
    self.solve(iterations - 1)
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1475, in solve
    self.solve(iterations - 1)
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1469, in solve
    self._solver._solve()
  File "/home/travis/wcEcoli/wholecell/utils/_netflow/nf_glpk.py", line 478, in _solve
    raise RuntimeError(self.status_string)
RuntimeError: GLP_NOFEAS: no feasible
```

Now an error will be raised that should be more helpful in identifying the problem by showing the target for the molecule that is negative.  This error appears to mostly be a result of the instability in amino acid charging that was fixed with #1037 but I wanted to include this update in case it happens again.

I also made a small change to move multiple solve tries out of an except block so there aren't multiple stack traces with `During handling of the above exception, another exception occurred` like shown above.