### PR TITLE
Add check for sim_data is None when saving sim_data intermediates

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -152,7 +152,7 @@ def save_state(func):
 			cell_specs = {}
 
 		# Save the current state of the parameter calculator after the function to disk
-		if kwargs.get('save_intermediates', False) and intermediates_dir != '':
+		if kwargs.get('save_intermediates', False) and intermediates_dir != '' and sim_data is not None:
 			os.makedirs(intermediates_dir, exist_ok=True)
 			with open(sim_data_file, 'wb') as f:
 				cPickle.dump(sim_data, f, protocol=cPickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
This adds a check to make sure we don't save `None` as an intermediate for `sim_data`.  This was an issue if using `--load` and `--save` options at the same time since functions before the loaded function would not be loaded or run so the saved intermediate `sim_data` was being overwritten by `None` and could not be loaded in the future.