### PR TITLE
Add squeezing of readColumn() as optional argument in readColumn2D()

### DIFF
--- a/models/ecoli/analysis/multigen/ppgpp_regulation.py
+++ b/models/ecoli/analysis/multigen/ppgpp_regulation.py
@@ -28,7 +28,7 @@ def read_data(cell_paths, table, column):
 	for sim_dir in cell_paths:
 		sim_out_dir = os.path.join(sim_dir, 'simOut')
 		reader = TableReader(os.path.join(sim_out_dir, table))
-		sim_columns.append(reader.readColumn2D(column))
+		sim_columns.append(reader.readColumn(column, squeeze=False))
 
 	return np.vstack(sim_columns)
 

--- a/models/ecoli/analysis/single/evaluationTime.py
+++ b/models/ecoli/analysis/single/evaluationTime.py
@@ -48,14 +48,14 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		logger_names = evaluationTime.readAttribute("logger_names")
 
 		clock_times = evaluationTime.readColumn("clock_time")
-		update_queries = evaluationTime.readColumn2D("update_queries_times")
-		partition = evaluationTime.readColumn2D("partition_times")
-		merge = evaluationTime.readColumn2D("merge_times")
-		calculate_mass = evaluationTime.readColumn2D("calculate_mass_times")
-		calculate_request = evaluationTime.readColumn2D("calculate_request_times")
-		evolve_state = evaluationTime.readColumn2D("evolve_state_times")
-		update = evaluationTime.readColumn2D("update_times")
-		append = evaluationTime.readColumn2D("append_times")
+		update_queries = evaluationTime.readColumn("update_queries_times")
+		partition = evaluationTime.readColumn("partition_times")
+		merge = evaluationTime.readColumn("merge_times")
+		calculate_mass = evaluationTime.readColumn("calculate_mass_times")
+		calculate_request = evaluationTime.readColumn("calculate_request_times")
+		evolve_state = evaluationTime.readColumn("evolve_state_times")
+		update = evaluationTime.readColumn("update_times")
+		append = evaluationTime.readColumn("append_times")
 
 		initialTime = mainReader.readAttribute("initialTime")
 		time = (mainReader.readColumn("time") - initialTime) / 60  # min

--- a/runscripts/debug/diff_simouts.py
+++ b/runscripts/debug/diff_simouts.py
@@ -117,8 +117,8 @@ def diff_subdirs(subdir, simout_dir1, simout_dir2):
 
 	# Diff the Table Columns.
 	for key in column_names1 | column_names2:
-		column1 = table1.readColumn2D(key) if key in column_names1 else Repr('<absent column>')
-		column2 = table2.readColumn2D(key) if key in column_names2 else Repr('<absent column>')
+		column1 = table1.readColumn(key, squeeze=False) if key in column_names1 else Repr('<absent column>')
+		column2 = table2.readColumn(key, squeeze=False) if key in column_names2 else Repr('<absent column>')
 		if is_repr(column1) or is_repr(column2):
 			description = (column1, column2)
 		else:

--- a/runscripts/manual/analysis_interactive.py
+++ b/runscripts/manual/analysis_interactive.py
@@ -85,7 +85,7 @@ def load_listener(selection: str) -> Tuple[np.ndarray, List[str]]:
 	column = split[-1]
 
 	reader = TableReader(os.path.join(path, listener))
-	data = reader.readColumn2D(column)
+	data = reader.readColumn(column, squeeze=False)
 
 	# Read subcolumn attributes
 	try:

--- a/wholecell/analysis/analysis_tools.py
+++ b/wholecell/analysis/analysis_tools.py
@@ -176,7 +176,7 @@ def read_bulk_molecule_counts(sim_out_dir, mol_names):
 
 	lengths = [len(names) for names in mol_names]
 	indices = np.hstack([[mol_indices[mol] for mol in names] for names in mol_names])
-	bulk_counts = bulk_reader.readColumn2D('counts', indices)
+	bulk_counts = bulk_reader.readColumn('counts', indices, squeeze=False)
 
 	start_slice = 0
 	for length in lengths:
@@ -242,6 +242,6 @@ def read_stacked_columns(cell_paths: np.ndarray, table: str, column: str) -> np.
 	for sim_dir in cell_paths:
 		sim_out_dir = os.path.join(sim_dir, 'simOut')
 		reader = TableReader(os.path.join(sim_out_dir, table))
-		data.append(reader.readColumn2D(column))
+		data.append(reader.readColumn(column, squeeze=False))
 
 	return np.vstack(data)

--- a/wholecell/io/tablereader.py
+++ b/wholecell/io/tablereader.py
@@ -153,15 +153,16 @@ class TableReader(object):
 		return self._attributes[name]
 
 
-	def readColumn2D(self, name, indices=None):
-		# type: (str, Any) -> np.ndarray
+	def readColumn(self, name, indices=None, squeeze=True):
+		# type: (str, Any, bool) -> np.ndarray
 		"""
 		Load a full column (all rows). Each row entry is a 1-D NumPy array of
-		subcolumns, so the result is a 2-D array row x subcolumn. In the case
-		of fixed-length columns, this method can optionally read just a
-		vertical slice of all those arrays -- the subcolumns at the given
-		`indices`. For variable-length columns, np.nan is used as a filler
-		value for the empty entries of each row.
+		subcolumns, so the initial result is a 2-D array row x subcolumn, which
+		is optionally squeezed to arrays with lower dimensions if squeeze=True.
+		In the case of fixed-length columns, this method can optionally read
+		just a vertical slice of all those arrays -- the subcolumns at the
+		given `indices`. For variable-length columns, np.nan is used as a
+		filler value for the empty entries of each row.
 
 		The current approach collects up the compressed blocks, allocates the
 		result array, then unpacks entries into it, keeping each decompressed
@@ -185,9 +186,15 @@ class TableReader(object):
 				NOTE: The speed benefit might only be realized if the file is
 				in the disk cache (i.e. the file has been recently read), which
 				should typically be the case. This will still save RAM.
+			squeeze: If True, the resulting NumPy array is squeezed into a 0D,
+				1D, or 2D array, depending on the number of rows and subcolumns
+				it has.
+				1 row x 1 subcolumn => 0D.
+				n rows x 1 subcolumn or 1 row x m subcolumns => 1D.
+				n rows x m subcolumns => 2D.
 
 		Returns:
-			ndarray: a writable 2-D NumPy array (row x subcolumn).
+			ndarray: A writable 0D, 1D, or 2D array.
 
 		TODO (jerry): Bring back the code to block-read `indices` of the data
 			from uncompressed tables or after decompression, via seek + read or
@@ -233,6 +240,10 @@ class TableReader(object):
 				raise VariableLengthColumnError(
 					'Attempted to access subcolumns of a variable-length column {}.'.format(name))
 
+			# Variable-length columns should not be squeezed.
+			if variable_length:
+				squeeze = False
+
 			if header.compression_type == tw.COMPRESSION_TYPE_ZLIB:
 				decompressor = lambda data_bytes: zlib.decompress(data_bytes)  # type: Callable[[bytes], bytes]
 			else:
@@ -274,13 +285,8 @@ class TableReader(object):
 				for block in row_size_blocks]  # type: List[Iterable[int]]
 			all_row_sizes = np.concatenate(row_sizes_list)
 
-			# Initialize results array to NaNs (Number of columns is set to be
-			# 2 if the maximum row size is 1 to ensure the array is not
-			# flattened to a 1D array by readColumn())
-			if all_row_sizes.max() == 1:
-				result = np.full((len(all_row_sizes), 2), np.nan)
-			else:
-				result = np.full((len(all_row_sizes), all_row_sizes.max()), np.nan)
+			# Initialize results array to NaNs
+			result = np.full((len(all_row_sizes), all_row_sizes.max()), np.nan)
 
 			row = 0
 			for raw_entry, row_sizes_ in zip(entry_blocks, row_sizes_list):
@@ -311,31 +317,11 @@ class TableReader(object):
 
 			result[row : (row + last_num_rows)] = last_entries
 
+		# Squeeze if flag is set to True
+		if squeeze:
+			result = result.squeeze()
+
 		return result
-
-
-	def readColumn(self, name, indices=None):
-		# type: (str, Any) -> np.ndarray
-		'''
-		Read a column via readColumn2D() then squeeze() the resulting
-		NumPy array into a 0D, 1D, or 2D array, depending on the number
-		of rows and subcolumns it has.
-
-		1 row x 1 subcolumn => 0D.
-
-		n rows x 1 subcolumn or 1 row x m subcolumns => 1D.
-
-		n rows x m subcolumns => 2D.
-
-		Args:
-			name: the column name.
-			indices: The subcolumn indices to select from each
-				entry, or None to read in all data. See readColumn2D().
-
-		Returns:
-			ndarray: A writable 0D, 1D, or 2D array.
-		'''
-		return self.readColumn2D(name, indices).squeeze()
 
 
 	def readSubcolumn(self, column, subcolumn_name):
@@ -358,7 +344,7 @@ class TableReader(object):
 		subcol_name_map = self.readAttribute(SUBCOLUMNS_KEY)
 		subcols = self.readAttribute(subcol_name_map[column])
 		index = subcols.index(subcolumn_name)
-		return self.readColumn2D(column, [index])[:, 0]
+		return self.readColumn(column, [index], squeeze=False)[:, 0]
 
 
 	def allAttributeNames(self):

--- a/wholecell/tests/io/measure_bulk_reader.py
+++ b/wholecell/tests/io/measure_bulk_reader.py
@@ -58,7 +58,7 @@ def test_old(reader, column, indices):
 	'''
 
 	return test_method(
-		lambda : reader.readColumn2D(column)[:, indices],
+		lambda : reader.readColumn(column, squeeze=False)[:, indices],
 		'Old method, read all + select subcolumns')
 
 def test_old_full(reader, column, indices):
@@ -73,7 +73,7 @@ def test_old_full(reader, column, indices):
 	'''
 
 	return test_method(
-		lambda : reader.readColumn2D(column),
+		lambda : reader.readColumn(column, squeeze=False),
 		'Old method, read all')
 
 def test_new_block(reader, column, indices):
@@ -88,7 +88,7 @@ def test_new_block(reader, column, indices):
 	'''
 
 	return test_method(
-		lambda : reader.readColumn2D(column, indices),
+		lambda : reader.readColumn(column, indices, squeeze=False),
 		'New method, read subcolumns')
 
 def test_functions(functions, text, reader, column, indices):

--- a/wholecell/tests/io/measure_zlib.py
+++ b/wholecell/tests/io/measure_zlib.py
@@ -184,7 +184,7 @@ def measure_tables(basepath, table_columns):
 	for table, columns in table_columns:
 		reader = TableReader(os.path.join(basepath, table))
 		for column in columns:
-			array = reader.readColumn2D(column)
+			array = reader.readColumn(column, squeeze=False)
 			# TODO(jerry): ...
 
 def time_decompressor(bytestrings, level):
@@ -217,7 +217,7 @@ def measure_block_subranges(array, table_name='', column_name=''):
 
 def measure_performance_metrics(sim_out_dir, table_name, column_name):
 	reader = TableReader(os.path.join(sim_out_dir, table_name))
-	array = reader.readColumn2D(column_name)
+	array = reader.readColumn(column_name, squeeze=False)
 	print('')
 	array2 = measure_block_subranges(array, table_name, column_name)
 	print('')

--- a/wholecell/tests/io/test_tablereader_writer.py
+++ b/wholecell/tests/io/test_tablereader_writer.py
@@ -100,10 +100,11 @@ class Test_TableReader_Writer(unittest.TestCase):
 
 		reader.close()
 
-	def test_readColumn2D(self):
-		'''Test readColumn2D() vs. readColumn() array squeezing.
-		readColumn2D() should always return a 2D array.
-		readColumn() may return a 0D, 1D, or 2D array, depending on the data.
+	def test_readColumn_squeeze(self):
+		'''Test the squeeze option of readColumn().
+		If squeeze=False, readColumn() should always return a 2D array.
+		If squeeze=True, readColumn() may return a 0D, 1D, or 2D array,
+		depending on the data.
 		Cases: {1, 2} rows x {scalar, 1-element, 1D, 2D} x {None, 1, 2} indices.
 		TODO(jerry): Test 0 rows?
 		'''
@@ -123,26 +124,26 @@ class Test_TableReader_Writer(unittest.TestCase):
 		writer.append(**data)
 		writer.close()
 
-		# --- Read 1 row with readColumn2D() ---
+		# --- Read 1 row with squeeze=False ---
 		reader = TableReader(self.table_path)
-		self.assertEqual(2, reader.readColumn2D('scalar').ndim)
-		self.assertEqual(2, reader.readColumn2D('1_element').ndim)
-		self.assertEqual(2, reader.readColumn2D('1D').ndim)
-		self.assertEqual(2, reader.readColumn2D('2D').ndim)
+		self.assertEqual(2, reader.readColumn('scalar', squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1_element', squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1D', squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('2D', squeeze=False).ndim)
 
-		self.assertEqual(2, reader.readColumn2D('scalar', index1).ndim)
-		self.assertEqual(2, reader.readColumn2D('1_element', index1).ndim)
-		self.assertEqual(2, reader.readColumn2D('1D', index1).ndim)
-		self.assertEqual(2, reader.readColumn2D('2D', index1).ndim)
+		self.assertEqual(2, reader.readColumn('scalar', index1, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1_element', index1, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1D', index1, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('2D', index1, squeeze=False).ndim)
 
 		with self.assertRaises(IndexError):
-			self.assertEqual(2, reader.readColumn2D('scalar', index2).ndim)
+			self.assertEqual(2, reader.readColumn('scalar', index2, squeeze=False).ndim)
 		with self.assertRaises(IndexError):
-			self.assertEqual(2, reader.readColumn2D('1_element', index2).ndim)
-		self.assertEqual(2, reader.readColumn2D('1D', index2).ndim)
-		self.assertEqual(2, reader.readColumn2D('2D', index2).ndim)
+			self.assertEqual(2, reader.readColumn('1_element', index2, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1D', index2, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('2D', index2, squeeze=False).ndim)
 
-		# --- Read 1 row with readColumn() ---
+		# --- Read 1 row with squeeze=True ---
 		self.assertEqual(0, reader.readColumn('scalar').ndim)
 		self.assertEqual(0, reader.readColumn('1_element').ndim)
 		self.assertEqual(1, reader.readColumn('1D').ndim)
@@ -157,8 +158,8 @@ class Test_TableReader_Writer(unittest.TestCase):
 		self.assertEqual(1, reader.readColumn('2D', index2).ndim)
 
 		# Test that the reader returns writeable arrays.
-		reader.readColumn2D('2D')[0, 0] = 0
-		reader.readColumn2D('2D', index2)[0, 0] = 0
+		reader.readColumn('2D', squeeze=False)[0, 0] = 0
+		reader.readColumn('2D', index2, squeeze=False)[0, 0] = 0
 
 		# === Write 2 rows ===
 		table2_path = os.path.join(self.test_dir, 'Segundo')
@@ -167,22 +168,22 @@ class Test_TableReader_Writer(unittest.TestCase):
 		writer.append(**data)
 		writer.close()
 
-		# --- Read 2 rows with readColumn2D() ---
+		# --- Read 2 rows with squeeze=False ---
 		reader = TableReader(table2_path)
-		self.assertEqual(2, reader.readColumn2D('scalar').ndim)
-		self.assertEqual(2, reader.readColumn2D('1_element').ndim)
-		self.assertEqual(2, reader.readColumn2D('1D').ndim)
-		self.assertEqual(2, reader.readColumn2D('2D').ndim)
+		self.assertEqual(2, reader.readColumn('scalar', squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1_element', squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1D', squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('2D', squeeze=False).ndim)
 
-		self.assertEqual(2, reader.readColumn2D('scalar', index1).ndim)
-		self.assertEqual(2, reader.readColumn2D('1_element', index1).ndim)
-		self.assertEqual(2, reader.readColumn2D('1D', index1).ndim)
-		self.assertEqual(2, reader.readColumn2D('2D', index1).ndim)
+		self.assertEqual(2, reader.readColumn('scalar', index1, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1_element', index1, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('1D', index1, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('2D', index1, squeeze=False).ndim)
 
-		self.assertEqual(2, reader.readColumn2D('1D', index2).ndim)
-		self.assertEqual(2, reader.readColumn2D('2D', index2).ndim)
+		self.assertEqual(2, reader.readColumn('1D', index2, squeeze=False).ndim)
+		self.assertEqual(2, reader.readColumn('2D', index2, squeeze=False).ndim)
 
-		# --- Read 2 rows with readColumn() ---
+		# --- Read 2 rows with squeeze=True ---
 		self.assertEqual(1, reader.readColumn('scalar').ndim)
 		self.assertEqual(1, reader.readColumn('1_element').ndim)
 		self.assertEqual(2, reader.readColumn('1D').ndim)
@@ -319,7 +320,7 @@ class Test_TableReader_Writer(unittest.TestCase):
 
 		# --- Read ---
 		reader = TableReader(self.table_path)
-		actual = reader.readColumn2D('val')
+		actual = reader.readColumn('val', squeeze=False)
 		self.assertEqual(2, actual.ndim)
 		self.assertEqual((3, 1), actual.shape)
 		npt.assert_array_equal(np.zeros((3, 1)), actual)
@@ -342,8 +343,8 @@ class Test_TableReader_Writer(unittest.TestCase):
 
 		# --- Read ---
 		reader = TableReader(self.table_path)
-		actual_ints = reader.readColumn2D('ManyInts')
-		actual_floats = reader.readColumn2D('ManyFloats')
+		actual_ints = reader.readColumn('ManyInts', squeeze=False)
+		actual_floats = reader.readColumn('ManyFloats', squeeze=False)
 		npt.assert_array_equal(np.vstack(5 * [ints]), actual_ints)
 		npt.assert_array_equal(np.vstack(5 * [floats]), actual_floats)
 
@@ -364,8 +365,8 @@ class Test_TableReader_Writer(unittest.TestCase):
 
 		# --- Read ---
 		reader = TableReader(self.table_path)
-		actual_ints = reader.readColumn2D('ManyInts')
-		actual_floats = reader.readColumn2D('ManyFloats')
+		actual_ints = reader.readColumn('ManyInts', squeeze=False)
+		actual_floats = reader.readColumn('ManyFloats', squeeze=False)
 		npt.assert_array_equal(np.vstack(rows * [ints]), actual_ints)
 		npt.assert_array_equal(np.vstack(rows * [floats]), actual_floats)
 
@@ -392,6 +393,30 @@ class Test_TableReader_Writer(unittest.TestCase):
 		# Subcolumns cannot be accessed for variable-length columns
 		with self.assertRaises(VariableLengthColumnError):
 			reader.readColumn(VARIABLE_LENGTH_COLUMN_NAME, indices=1)
+
+	def test_variable_length_columns_with_max_row_length_one(self):
+		'''
+		Test variable-length columns with a maximum row length of one. The
+		returned array should not be squeezed and should be 2-dimensional.
+		'''
+		self.make_test_dir()
+
+		# --- Write ---
+		writer = TableWriter(self.table_path)
+		writer.set_variable_length_columns(VARIABLE_LENGTH_COLUMN_NAME)
+		writer.append(**{VARIABLE_LENGTH_COLUMN_NAME: np.arange(1, dtype=np.int32)})
+		writer.append(**{VARIABLE_LENGTH_COLUMN_NAME: []})
+		writer.append(**{VARIABLE_LENGTH_COLUMN_NAME: np.arange(1, dtype=np.int32)})
+		writer.close()
+
+		# --- Read ---
+		reader = TableReader(self.table_path)
+		variable_column = reader.readColumn(VARIABLE_LENGTH_COLUMN_NAME)
+
+		npt.assert_array_equal(
+			np.array([[0], [np.nan], [0]]),
+			variable_column)
+		self.assertEqual(2, variable_column.ndim)
 
 	def test_long_variable_length_columns(self):
 		'''Test long variable-length columns that span multiple blocks.'''


### PR DESCRIPTION
This fixes a bug in our `TableReader` class that shows up when the reader tries to read a variable-length table that has most one entry per timestep. Since the number of columns in the initialized array gets set to one, this array is later flattened to return a 1-dimensional array to the analysis scripts, which leads to errors if the script assumes the arrays are two-dimensional. This fix will set the minimum number of columns in this array to 2 such that this does not happen downstream.

This should fix the anaerobic build failures we've been getting since February 6th.