### PR TITLE
Fix charging counts

### DIFF
--- a/models/ecoli/processes/polypeptide_elongation.py
+++ b/models/ecoli/processes/polypeptide_elongation.py
@@ -523,7 +523,8 @@ class SteadyStateElongationModel(TranslationSupplyElongationModel):
 
 		## Reactions that are charged and elongated in same time step
 		total_uncharging_reactions = self.distribution_from_aa(aas_used, total_trna)
-		charged_and_elongated = total_uncharging_reactions - charged_trna
+		trna_to_uncharge = np.fmin(charged_trna, total_uncharging_reactions)
+		charged_and_elongated = total_uncharging_reactions - trna_to_uncharge
 		total_charging_reactions = charged_and_elongated + n_trna_charged
 		net_charged = total_charging_reactions - total_uncharging_reactions
 		self.charging_molecules.countsInc(np.dot(self.charging_stoich_matrix, total_charging_reactions))


### PR DESCRIPTION
This updates the calculation for charging and uncharging reactions to more accurately update counts of molecules involved.  This is mostly to fix an error that pops up sporadically:
```
Traceback (most recent call last):                      
  File "/home/travis/wcEcoli/runscripts/manual/runDaughter.py", line 105, in <module>
    script.cli()                                                 
  File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 584, in cli
    self.run(args)                                                          
  File "/home/travis/wcEcoli/runscripts/manual/runDaughter.py", line 100, in run      
    task.run_task({})                                                                                                                          
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/simulationDaughter.py", line 83, in run_task
    sim.run()                                                                                                                              
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 241, in run 
    self.run_incremental(self._lengthSec + self.initialTime())        
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 273, in run_incremental
    self._evolveState(processes)                                                       
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 353, in _evolveState    
    state.merge(processes)                                                                
  File "/home/travis/wcEcoli/wholecell/states/bulk_molecules.py", line 199, in merge
    raise NegativeCountsError(                                                     
wholecell.states.bulk_molecules.NegativeCountsError: Negative value(s) in self._countsAllocatedFinal:
AMP[c] in PolypeptideElongation (-1855)                                 
PPI[c] in PolypeptideElongation (-1958)
```

Some uncharging events were actually consuming AMP/PPI to produce ATP instead of just going from charged tRNA to uncharged tRNA.  This more clearly separates the calculations for uncharging and charging reactions and limits the number of uncharging reactions to the number of amino acids polymerized - the number of `charged_trna` allocated is the number expected to be uncharged through elongation within the time step but sometimes this number was greater than actual number of elongations.  This appears to have minimal effects on sims since there were typically only a few reactions that were accounted for this way, which is why the error was sporadic.