### PR TITLE
Refactor TF adjustments

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -3123,7 +3123,7 @@ def calculateRnapRecruitment(sim_data, cell_specs):
 		- ['r_vector']: Fit parameters on how the recruitment of a TF affects the expression
 		of a gene. High (positive) values of r indicate that the TF binding
 		increases the probability that the gene is expressed.
-		- ['col_names_to_index']: mapping of column name to index in r
+		- ['r_columns']: mapping of column name to index in r
 
 	Modifies
 	--------


### PR DESCRIPTION
This does some refactoring for transcription factor adjustments that I thought I was going to need in another PR but is no longer needed.  I think it has some improvements that are still useful so I've broken it out into a separate PR for clarity.

Changes:
- `fitPromoterBoundProbability` now runs in its own function that can be saved/loaded and its output is saved in `cell_specs` to update probabilities in `adjust_promoters`.  Since `fitPromoterBoundProbability` takes a long time to solve, this allows the result to be cached to jump straight to `adjust_promoters` if tweaking that function.
- `r_vector` (previously a returned value) and `r_columns` (previously recomputed in multiple locations) are now stored in `cell_specs` to be able to cache to disk and use in later parca functions.
- `calculateRnapRecruitment` uses a dictionary lookup instead of `.index` and does not need to rebuild column names for the r vector which could have led to issues if column names where updated in one location but not the other.

This produces the same parca output as before.