### PR TITLE
Add MetJ to amino acid condition active TFs

### DIFF
--- a/reconstruction/ecoli/flat/condition/condition_defs.tsv
+++ b/reconstruction/ecoli/flat/condition/condition_defs.tsv
@@ -5,6 +5,6 @@
 "condition"	"nutrients"	"genotype perturbations"	"doubling time (units.min)"	"active TFs"	"inactive TFs"
 "basal"	"minimal"	{}	44.0	[]	[]
 "no_oxygen"	"minimal_minus_oxygen"	{}	100.0	["FNR-4FE-4S-CPLX", "PHOSPHO-ARCA", "CPLX0-226"]	[]
-"with_aa"	"minimal_plus_amino_acids"	{}	25.0	["CPLX-125", "MONOMER0-162", "CPLX0-228", "MONOMER0-155"]	["CPLX0-7669", "PUTA-CPLX", "EG12123-MONOMER"]
+"with_aa"	"minimal_plus_amino_acids"	{}	25.0	["CPLX-125", "MONOMER0-162", "CPLX0-228", "MONOMER0-155", "CPLX0-7796"]	["CPLX0-7669", "PUTA-CPLX", "EG12123-MONOMER"]
 "acetate"	"minimal_acetate"	{}	136.0	["CPLX0-226"]	[]
 "succinate"	"minimal_succinate"	{}	82.0	["CPLX0-226", "PHOSPHO-DCUR"]	[]


### PR DESCRIPTION
This adds MetJ (CPLX0-7796) as an active TF in with_aa conditions for better fitting in the parca.  MetJ is active when bound to SAM which will be higher in simulations with amino acids because Met will also be higher.  This leads to better predictions for protein counts in the parca in the `with_aa` condition.  For example, MetA, which is used to calculate parameters related to amino acid synthesis and import, matches much better to data from Li et al listed on EcoCyc when considering the direction of the change (direction of change is more important than quantity for these calculations).

MetA counts/cell:
Parca minimal (before change): 167
Parca with_aa (before change): 311
Parca minimal (after change): 167
Parca with_aa (after change): 64
Li et al minimal: 1711
Li et al rich: 318