### PR TITLE
Fix handling of str args

### DIFF
--- a/wholecell/utils/modular_fba.py
+++ b/wholecell/utils/modular_fba.py
@@ -1106,8 +1106,10 @@ class FluxBalanceAnalysis(object):
 
 		if isinstance(reactionIDs, six.string_types):
 			reactionIDs = [reactionIDs]
-			lowerBounds = [lowerBounds]
-			upperBounds = [upperBounds]
+			if lowerBounds is not None:
+				lowerBounds = [lowerBounds]
+			if upperBounds is not None:
+				upperBounds = [upperBounds]
 
 		nReactions = len(reactionIDs)
 		if lowerBounds is None:


### PR DESCRIPTION
This fixes a edge case of args in `setReactionFluxBounds()`.  The function can take lists/arrays or str and float args but default `None` args were not handled properly when a str reaction ID was passed.

```
Traceback (most recent call last):                                                                                                           
  File "/home/travis/wcEcoli/runscripts/manual/runSim.py", line 171, in <module>                                                             
    script.cli()                                                                                                                             
  File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 601, in cli                                                                
    self.run(args)                                                                                                                           
  File "/home/travis/wcEcoli/runscripts/manual/runSim.py", line 166, in run                                                                  
    task.run_task({})                                                                                                                        
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/simulation.py", line 86, in run_task                                              
    sim.run()                                                                                                                                
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 244, in run                                                                  
    self.run_incremental(self._lengthSec + self.initialTime())                                                                               
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 276, in run_incremental                                                      
    self._evolveState(processes)                                                                                                             
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 345, in _evolveState
    process.evolveState()
  File "/home/travis/wcEcoli/models/ecoli/processes/metabolism.py", line 153, in evolveState
    targets, upper_targets, lower_targets = self.model.set_reaction_targets(kinetic_enzyme_counts,
  File "/home/travis/wcEcoli/models/ecoli/processes/metabolism.py", line 561, in set_reaction_targets
    self.fba.setReactionFluxBounds(self.kinetics_constrained_reactions[atp_rxn], upperBounds=upper_targets[atp_rxn])
  File "/home/travis/wcEcoli/wholecell/utils/modular_fba.py", line 1115, in setReactionFluxBounds
    elif np.any(np.array(lowerBounds) < 0):
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```