### PR TITLE
Use all exchange molecules in metabolism

### DIFF
--- a/models/ecoli/processes/metabolism.py
+++ b/models/ecoli/processes/metabolism.py
@@ -293,7 +293,6 @@ class FluxBalanceAnalysisModel(object):
 
 		# go through all media in the timeline and add to metaboliteNames
 		metaboliteNamesFromNutrients = set()
-		exchange_molecules = set(imports)
 		if include_ppgpp:
 			metaboliteNamesFromNutrients.add(self.ppgpp_id)
 		for time, media_id in timeline:
@@ -302,9 +301,8 @@ class FluxBalanceAnalysisModel(object):
 				metabolism.concentration_updates.concentrations_based_on_nutrients(
 					imports=exchanges['importExchangeMolecules'])
 				)
-			exchange_molecules.update(exchanges['externalExchangeMolecules'])
 		self.metaboliteNamesFromNutrients = list(sorted(metaboliteNamesFromNutrients))
-		exchange_molecules = list(sorted(exchange_molecules))
+		exchange_molecules = sorted(sim_data.external_state.all_external_exchange_molecules)
 		molecule_masses = dict(zip(exchange_molecules,
 			sim_data.getter.get_masses(exchange_molecules).asNumber(MASS_UNITS / COUNTS_UNITS)))
 


### PR DESCRIPTION
This makes a small change to metabolism to include all possible exchange molecules in the FBA problem.  This leads to slight floating point differences in the FBA solution because the solver has a few more reactions to handle.  This fixes a problem with the single AA shift variants (#1096) where adding a single amino acid to an environment would lead to different simulation results even before the shift occurred because the extra exchange flux reaction was in the FBA problem even if it wasn't being used until amino acid was present in the media.  Consistent simulation results between those shift variants is necessary for being able to do direct comparisons between them.