### PR TITLE
Adjust expression for attenuation in initial_conditions

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -714,6 +714,11 @@ class Transcription(object):
 		basal_synth_prob = (basal_prob + delta)[self.attenuated_rna_indices]
 		self.attenuation_basal_prob_adjustments = basal_synth_prob * (1 / (1 - basal_stop_prob) - 1)
 
+		# Store expected readthrough fraction for each condition to use in initial conditions
+		self.attenuation_readthrough = {}
+		for condition in sim_data.conditions:
+			self.attenuation_readthrough[condition] = 1 - self.get_attenuation_stop_probabilities(get_aa_conc(condition))
+
 	def get_attenuation_stop_probabilities(self, aa_conc):
 		"""
 		Calculate the probability of a transcript stopping early due to attenuation.


### PR DESCRIPTION
This makes adjustments to the expected amount of transcription in initial_conditions to account for transcriptional attenuation.  This should more accurately initialize cells when the `--trna-attenuation` option is set.

Plots below show some issues that are fixed with these changes from sims run with `-v condition 2 2 --trna-attenuation --length-sec 600` options.

Some attenuated genes were getting a burst of expression at the beginning of sims (orange trace) because of RNAPs initialized with partial transcripts (before change):
![image](https://user-images.githubusercontent.com/18123227/124139433-9ada3880-da55-11eb-958b-ac6df856596a.png)

But this should be more constant throughout the simulation (after change):
![image](https://user-images.githubusercontent.com/18123227/124139249-6f574e00-da55-11eb-87a3-f70153c6a372.png)

Attenuated proteins also were being initialized too high and dropping in concentration throughout the sim (plot shows enzyme concentration for His synthesis before change):
![image](https://user-images.githubusercontent.com/18123227/124139849-f9071b80-da55-11eb-8374-7ea406e5bf1f.png)

Now they start lower and should be more stable throughout sims (after change):
![image](https://user-images.githubusercontent.com/18123227/124139975-1936da80-da56-11eb-8e07-6e463c03065c.png)
