### PR TITLE
Fix #1113 by reverting to distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup
+#from setuptools import setup
+from distutils.core import setup
 
 from Cython.Build import cythonize
 
@@ -15,7 +16,7 @@ setup(
 	name = "Build sequences",
 	ext_modules = build_sequences_module,
 	include_dirs = [np.get_include()],
-	zip_safe = False
+	# zip_safe = False  # see Cython docs, but it seems to need setuptools
 	)
 
 complexation_module = cythonize(
@@ -27,7 +28,7 @@ setup(
 	name = "Monte-carlo complexation",
 	ext_modules = complexation_module,
 	include_dirs = [np.get_include()],
-	zip_safe = False
+	# zip_safe = False  # see Cython docs, but it seems to need setuptools
 	)
 
 fast_polymerize_sums_module = cythonize(
@@ -40,5 +41,5 @@ setup(
 	name = "Fast polymerize sums",
 	ext_modules = fast_polymerize_sums_module,
 	include_dirs = [np.get_include()],
-	zip_safe = False
+	# zip_safe = False  # see Cython docs, but it seems to need setuptools
 	)


### PR DESCRIPTION
Python 3.10 will deprecate distutils. By then we should figure out whether to use setuptools, Bento, or something else, and still get fast `make compile` when it needn't recompile.