### PR TITLE
Updates to cell_growth variant plot

### DIFF
--- a/models/ecoli/analysis/variant/cell_growth.py
+++ b/models/ecoli/analysis/variant/cell_growth.py
@@ -60,6 +60,10 @@ def plot_validation(mean, std, labels, val_rates, val_std, val_aa_ids, label, te
 	if text_highlight:
 		for aa, x, y in zip(val_aa_ids, val_rates, wcm_normalized_growth_rates):
 			color = 'r' if text_highlight.get(aa, False) else 'k'
+			if y < AXIS_LIMITS[0]:
+				y = AXIS_LIMITS[0]
+			elif y > AXIS_LIMITS[1]:
+				y = AXIS_LIMITS[1]
 			plt.text(x, 0.01 + y, aa, ha='center', fontsize=6, color=color)
 
 def remove_border(ax, bottom=False):


### PR DESCRIPTION
This makes some changes to help with comparisons on the cell_growth variant plot.  Some dashed reference lines are added and the axes limits are improved.  It also uses a time weighted average for calculating the rates since some short time steps can often have very different rates that would be disproportionately represented in a normal mean.

Before:
![master-cell_growth](https://user-images.githubusercontent.com/18123227/126201719-83d230d5-9fea-440f-8b65-779c98987d6a.png)

After:
![updated-cell_growth](https://user-images.githubusercontent.com/18123227/126201744-480d1b82-670b-43b4-8c48-6e98c0881f74.png)
