### PR TITLE
Update pPromoterBound for combined conditions

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -2615,18 +2615,14 @@ def fitPromoterBoundProbability(sim_data, cell_specs):
 				pInitI.append(H_col_name_to_index[col_name])
 				pInitV.append(1.)
 
+		# Save indices to update promoter binding for active TFs in combined conditions
 		for condition, tfs in sim_data.condition_active_tfs.items():
-			if condition == 'basal':
-				continue
-
 			for tf in tfs:
 				col_name = f'{tf}__{tf}__active'
 				pPromoterBoundIdxs[condition][tf] = H_col_name_to_index[col_name]
 
+		# Save indices to update promoter binding for inactive TFs in combined conditions
 		for condition, tfs in sim_data.condition_inactive_tfs.items():
-			if condition == 'basal':
-				continue
-
 			for tf in tfs:
 				col_name = f'{tf}__{tf}__inactive'
 				pPromoterBoundIdxs[condition][tf] = H_col_name_to_index[col_name]


### PR DESCRIPTION
This makes a change to the promoter fitting problem so that combined conditions (eg `'with_aa'`, etc.) have updated pPromoterBound probabilities.  They were not being updated before but this change adds a mapping so that they now get updated with the `fromArray` function.  This greatly improves the integration of ppGpp regulation and transcription factors since `pPromoterBound` is used to calculate the effect of TF binding with ppGpp regulation and should make predicted counts of enzymes in the parca much more accurate with ppGpp and attenuation calculations.  For example, without ppGpp regulation Glt synthesis enzymes are expected to drop from 1524 -> 727 counts going from basal to with_aa due to ArgR and ArgP regulation.  With ppGpp regulation before, this actually increased from 496 -> 725 but now it decreases from 1573 -> 969.  This had significant impacts on the calculation of kcat and import parameters for AA supply, which will be improved with this PR.

This change does not affect the solution of the problem since you can see the probabilities of the active/inactive conditions are the same before and after.

A few considerations that might need to be addressed (feedback would be welcome since this is a complicated part of the parca but I might turn these into a new issue to be addressed in the future):
- Should we also update the probabilities for the basal condition?  It does not have any TFs in `sim_data.condition_active_tfs` or `sim_data.condition_inactive_tfs` because it is considered the reference condition but will have active or inactive TFs that might have different fit probabilities.
- Should we integrate all of the inactive/active conditions?  These updates only apply to the combined conditions with multiple TFs but should something like `CPLX-125__active` have the `CPLX0-228` probability updated since they are both in with_aa conditions.  I don't quite know the implications of this in the solver but don't think it would have as significant an effect as the combined conditions not being updated elsewhere in the parca or model.
- Should we change the problem setup at all to include these links when solving for p or is it ok updating after?  I'm not sure what all would need to be updated or if the problem could be solved if p is fit for multiple conditions.

A selection of pPromoterBound values from before
```
> pprint.pprint(sim_data.pPromoterBound)  
{'CPLX-125__active': {'CPLX-125': 0.9103080370624681,                 
                      'CPLX-172': 0.0,                             
                      'CPLX0-226': 0.10271396305869655,                                                                                      
                      'CPLX0-228': 0.3988577771570601,           
                      'CPLX0-7669': 0.23536302387400865,           
                      ...},
 'CPLX-125__inactive': {'CPLX-125': 0.11160538792908772,
                        'CPLX-172': 0.0,
                        'CPLX0-226': 0.09414080796472803,
                        'CPLX0-228': 0.15994376788398604,
                        'CPLX0-7669': 0.3810427088571887,
                        ...},
...
 'basal': {'CPLX-125': 0.11160538793006772,
           'CPLX-172': 0.0,                                           
           'CPLX0-226': 0.09414080796472803,       
           'CPLX0-228': 0.15994376788398604,    
           'CPLX0-7669': 0.3810427088571887,                          
           ...},
 'with_aa': {'CPLX-125': 0.11636928514862668,  # not updated to match CPLX-125__active and way too low
             'CPLX-172': 0.0,
             'CPLX0-226': 0.10414417955908936,
             'CPLX0-228': 0.26035498167367865,
             'CPLX0-7669': 0.23536302387400865,
             ...}
```

With these changes:
```
> pprint.pprint(sim_data.pPromoterBound)                                                                                                 
{'CPLX-125__active': {'CPLX-125': 0.9103080370624681,                                                                                        
                      'CPLX-172': 0.0,                                                                                                       
                      'CPLX0-226': 0.10271396305869655,                                                                                      
                      'CPLX0-228': 0.3988577771570601,  # Should this also update to match CPLX0-228__active since this is with_aa condition?
                      'CPLX0-7669': 0.23536302387400865,  # Should this also update to match CPLX0-7669__inactive since this is with_aa condition?
                      ...},
 'CPLX-125__inactive': {'CPLX-125': 0.11160538792908772,                                                                                     
                        'CPLX-172': 0.0,                                                                                                     
                        'CPLX0-226': 0.09414080796472803,                                                                                    
                        'CPLX0-228': 0.15994376788398604,                                                                                    
                        'CPLX0-7669': 0.3810427088571887,                                                                                    
                        ...}, 
...
 'CPLX0-226__inactive': {'CPLX-125': 0.11160538793006772,                                                                                    
                         'CPLX-172': 6.733906321216249e-11,                                                                                  
                         'CPLX0-226': 0.07706060714936681,  # Should basal be updated to match this value?                                                                                   
                         'CPLX0-228': 0.15994376787119896,                                                                                   
                         'CPLX0-7669': 0.3810427088571887,                                                                                   
                         ...},
...
 'basal': {'CPLX-125': 0.11160538793006772,      
           'CPLX-172': 0.0,                                           
           'CPLX0-226': 0.09414080796472803,                          
           'CPLX0-228': 0.15994376788398604,
           'CPLX0-7669': 0.3810427088571887,  
           ...},
 'with_aa': {'CPLX-125': 0.9103080370624681,  # Updated to match CPLX-125__active and sim probabilities
             'CPLX-172': 0.0,
             'CPLX0-226': 0.10414417955908936,
             'CPLX0-228': 0.8972982638046005,  # Updated to match CPLX0-228__active and sim probabilities
             'CPLX0-7669': 0.050402666352644246,  # Updated to match CPLX0-7669__inactive and sim probabilities
             ...}
```

From a with_aa simulation you can see the simulation probabilities match more closely to the newly updated values for `sim_data.pPromoterBound['with_aa']` (blue trace on right side):
TrpR (CPLX-125) ~ 0.9
ArgR (CPLX0-228) ~ 0.9
ArgP (CPLX0-7669) ~ 0.05
![image](https://user-images.githubusercontent.com/18123227/126800443-fbb82943-e188-4cdd-babb-bafeda7b5582.png)
