### PR TITLE
Revert to tRNA for attenuation instead of amino acids

### DIFF
--- a/models/ecoli/processes/transcript_elongation.py
+++ b/models/ecoli/processes/transcript_elongation.py
@@ -70,7 +70,7 @@ class TranscriptElongation(wholecell.processes.process.Process):
 		self.trna_attenuation = sim._trna_attenuation
 		self.cell_density = sim_data.constants.cell_density
 		self.n_avogadro = sim_data.constants.n_avogadro
-		self.charged_trna = self.bulkMoleculesView(sim_data.molecule_groups.amino_acids)
+		self.charged_trna = self.bulkMoleculesView(sim_data.process.transcription.charged_trna_names)
 		self.stop_probabilities = sim_data.process.transcription.get_attenuation_stop_probabilities
 		self.attenuated_rna_indices = sim_data.process.transcription.attenuated_rna_indices
 		self.attenuated_rna_indices_lookup = {idx: i for i, idx in enumerate(self.attenuated_rna_indices)}


### PR DESCRIPTION
This reverts some of the changes made in #1078 that used amino acid concentrations instead of tRNA concentrations to determine the amount of attenuation.  The previous change was done to allow for greater impact from attenuation to match data when remove allosteric inhibition on pathways.  This was because the dynamic range of tRNA attenuation was small and certain amino acid concentrations could continually increase (particularly Thr).  With the expanded synthesis network from #1122, there are now mechanisms (KM values) that limit increasing amino acid concentrations.

![remove_aa_inhibition](https://user-images.githubusercontent.com/18123227/128875643-05505c71-282d-46c3-b331-589d0012e357.png)

The new change allows tRNA attenuation to be much more sensitive when charging and amino acids become limiting.  This provides stability in growth in certain single amino acid media addition environments (Ile, Leu, Phe) where charged tRNA were going to 0 but amino acid concentrations were continuing to increase.

Growth rates before:
![growth_rate_time_series](https://user-images.githubusercontent.com/18123227/128876523-36bbf5ce-e297-4c30-88c3-97f29d394b15.png)

Growth rates after:
![growth_rate_time_series](https://user-images.githubusercontent.com/18123227/128876396-93df9098-2d99-402b-a268-1de395007c35.png)
