### PR TITLE
Update ribosomeElongationRateDict in one amino acid shift variants

### DIFF
--- a/models/ecoli/sim/variants/add_one_aa_shift.py
+++ b/models/ecoli/sim/variants/add_one_aa_shift.py
@@ -8,6 +8,7 @@ Modifies:
 	sim_data.expectedDryMassIncreaseDict
 	sim_data.nutrient_to_doubling_time
 	sim_data.translation_supply_rate
+	sim_data.process.translation.ribosomeElongationRateDict
 	sim_data.process.translation.ribosomeFractionActiveDict
 	sim_data.process.transcription.rnaPolymeraseElongationRateDict
 	sim_data.process.transcription.rnaSynthProbFraction
@@ -46,6 +47,7 @@ def add_one_aa_shift(sim_data, index):
 		sim_data.expectedDryMassIncreaseDict,
 		sim_data.nutrient_to_doubling_time,
 		sim_data.translation_supply_rate,
+		sim_data.process.translation.ribosomeElongationRateDict,
 		sim_data.process.translation.ribosomeFractionActiveDict,
 		sim_data.process.transcription.rnaPolymeraseElongationRateDict,
 		sim_data.process.transcription.rnaSynthProbFraction,

--- a/models/ecoli/sim/variants/remove_one_aa_shift.py
+++ b/models/ecoli/sim/variants/remove_one_aa_shift.py
@@ -9,6 +9,7 @@ Modifies:
 	sim_data.expectedDryMassIncreaseDict
 	sim_data.nutrient_to_doubling_time
 	sim_data.translation_supply_rate
+	sim_data.process.translation.ribosomeElongationRateDict
 	sim_data.process.translation.ribosomeFractionActiveDict
 	sim_data.process.transcription.rnaPolymeraseElongationRateDict
 	sim_data.process.transcription.rnaSynthProbFraction
@@ -57,6 +58,7 @@ def remove_one_aa_shift(sim_data, index):
 			sim_data.expectedDryMassIncreaseDict,
 			sim_data.nutrient_to_doubling_time,
 			sim_data.translation_supply_rate,
+			sim_data.process.translation.ribosomeElongationRateDict,
 			sim_data.process.translation.ribosomeFractionActiveDict,
 			sim_data.process.transcription.rnaPolymeraseElongationRateDict,
 			sim_data.process.transcription.rnaSynthProbFraction,


### PR DESCRIPTION
This adds the newly created media for single amino acid additions or removal to `ribosomeElongationRateDict` to prevent errors that would occur at the start of a new generation after the shift had occurred.

```
Traceback (most recent call last):                                                                                                           
  File "/home/travis/wcEcoli/runscripts/manual/runDaughter.py", line 105, in <module>                                                        
    script.cli()                                                                                                                             
  File "/home/travis/wcEcoli/wholecell/utils/scriptBase.py", line 621, in cli                                                                
    self.run(args)                                                                                                                           
  File "/home/travis/wcEcoli/runscripts/manual/runDaughter.py", line 100, in run                                                             
    task.run_task({})                                                                                                                        
  File "/home/travis/wcEcoli/wholecell/fireworks/firetasks/simulationDaughter.py", line 95, in run_task                                      
    sim.run()                                                                                                                                
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 259, in run                                                                  
    self.run_incremental(self._lengthSec + self.initialTime())                                                                               
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 291, in run_incremental                                                      
    self._evolveState(processes)                                                                                                             
  File "/home/travis/wcEcoli/wholecell/sim/simulation.py", line 347, in _evolveState                                                         
    process.calculateRequest()                                                                                                               
  File "/home/travis/wcEcoli/models/ecoli/processes/polypeptide_initiation.py", line 86, in calculateRequest                                 
    self.ribosomeElongationRate = self.ribosomeElongationRateDict[                                                                           
KeyError: 'minimal_plus_GLT'
```