### PR TITLE
Use faster rate for transcription sequence padding

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -454,7 +454,7 @@ class Transcription(object):
 		# Construct transcription sequence matrix
 		maxLen = np.int64(
 			self.rna_data["length"].asNumber().max()
-			+ self.max_time_step * sim_data.growth_rate_parameters.rnaPolymeraseElongationRate.asNumber(units.nt / units.s)
+			+ self.max_time_step * sim_data.constants.RNAP_elongation_rate_for_stable_RNA.asNumber(units.nt / units.s)
 			)
 
 		self.transcription_sequences = np.full((len(rna_seqs), maxLen), polymerize.PAD_VALUE, dtype=np.int8)


### PR DESCRIPTION
This should fix the issue in the anaerobic daily build:
```
Traceback (most recent call last):
  File "/home/groups/mcovert/pyenv/versions/wcEcoli3/lib/python3.8/site-packages/fireworks/core/rocket.py", line 262, in run
    m_action = t.run_task(my_spec)
  File "/scratch/groups/mcovert/jenkins/workspace@4/wholecell/fireworks/firetasks/simulation.py", line 92, in run_task
    sim.run()
  File "/scratch/groups/mcovert/jenkins/workspace@4/wholecell/sim/simulation.py", line 259, in run
    self.run_incremental(self._lengthSec + self.initialTime())
  File "/scratch/groups/mcovert/jenkins/workspace@4/wholecell/sim/simulation.py", line 291, in run_incremental
    self._evolveState(processes)
  File "/scratch/groups/mcovert/jenkins/workspace@4/wholecell/sim/simulation.py", line 347, in _evolveState
    process.calculateRequest()
  File "/scratch/groups/mcovert/jenkins/workspace@4/models/ecoli/processes/transcript_elongation.py", line 103, in calculateRequest
    sequences = buildSequences(
  File "wholecell/utils/_build_sequences.pyx", line 22, in wholecell.utils._build_sequences.buildSequences
    cpdef np.ndarray[np.int8_t, ndim=2] buildSequences(
  File "wholecell/utils/_build_sequences.pyx", line 30, in wholecell.utils._build_sequences.buildSequences
    raise IndexError('Elongation proceeds past end of sequence!')
IndexError: Elongation proceeds past end of sequence!
```