### PR TITLE
TF unbinding process

### DIFF
--- a/models/ecoli/processes/tf_binding.py
+++ b/models/ecoli/processes/tf_binding.py
@@ -111,7 +111,8 @@ class TfBinding(wholecell.processes.process.Process):
 
 		for tf_idx, tf_id in enumerate(self.tf_ids):
 			# Free all DNA-bound transcription factors into free active
-			# transcription factors
+			# transcription factors (this should already be taken care of in
+			# tf_unbinding)
 			active_tf_view = self.active_tf_view[tf_id]
 			bound_tf_counts = n_bound_TF[tf_idx]
 			active_tf_view.countInc(bound_tf_counts)

--- a/models/ecoli/processes/tf_unbinding.py
+++ b/models/ecoli/processes/tf_unbinding.py
@@ -1,22 +1,18 @@
 """
-TfBinding
+TfUnbinding
 
-Bind transcription factors to DNA
+Unbind transcription factors from DNA to allow signaling processes before
+binding back to DNA.
 """
-
-from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
 import wholecell.processes.process
-from wholecell.utils.constants import REQUEST_PRIORITY_TF_BINDING
-from wholecell.utils.random import stochasticRound
 from wholecell.utils import units
-import six
 
 
 class TfUnbinding(wholecell.processes.process.Process):
-	""" TfBinding """
+	""" TfUnbinding """
 
 	_name = "TfUnbinding"
 
@@ -40,7 +36,6 @@ class TfUnbinding(wholecell.processes.process.Process):
 			for tf_id in self.tf_ids]
 		self.active_tf_masses = (sim_data.internal_state.bulk_molecules.bulk_data[
 			"mass"][tf_indexes] / sim_data.constants.n_avogadro).asNumber(units.fg)
-
 
 	def calculateRequest(self):
 		# Request edit access to promoter molecules

--- a/models/ecoli/sim/simulation.py
+++ b/models/ecoli/sim/simulation.py
@@ -46,6 +46,7 @@ from models.ecoli.sim.initial_conditions import calcInitialConditions
 from wholecell.sim.divide_cell import divide_cell
 from models.ecoli.sim.initial_conditions import setDaughterInitialConditions
 
+
 class EcoliSimulation(Simulation):
 	_internalStateClasses = (
 		BulkMolecules,
@@ -60,10 +61,12 @@ class EcoliSimulation(Simulation):
 		(
 			TfUnbinding,
 		),
+		# Must run after TfUnbinding and before TfBinding
 		(
 			Equilibrium,
 			TwoComponentSystem,
 		),
+		# Must run before TranscriptInitiation
 		(
 			TfBinding,
 		),


### PR DESCRIPTION
This adds a new process `TfUnbinding` to complement `TfBinding` and reorders the process hierarchy of simulations to better handle some dependencies between processes.  The code for `TfUnbinding` comes directly from `TfBinding` since it was assumed that unbinding and binding were properly handled in a single process.  This does not quite hold because `Equilibrium` and `TwoComponentSystems` need to have all the TFs freed to properly calculate active and inactive counts of TFs to get the correct fraction bound to DNA.  This is the simplest solution to this problem but being able to request and allocate properties of unique molecules like bound TFs should allow all of these processes to coexist in the same process level in the hierarchy (can be done in a future PR if desired).

This issue is most apparent when looking at binding of some TFs and the associated ligand concentration.  In the third generation, ArgR inactive counts are nearly 0 and most promoters are bound even though we would expect around 20% to be active and bound.  This showed minimal response to changing Arg concentrations which affects stability of sims that need to respond to these changes in concentration:
![image](https://user-images.githubusercontent.com/18123227/130155585-bec1eeec-2d6f-479e-a090-7901fc24213d.png)
![image](https://user-images.githubusercontent.com/18123227/130155568-83beed7b-c1fd-4f40-b8ab-654e5c6a9681.png)
![image](https://user-images.githubusercontent.com/18123227/130155610-3c63a553-4e9d-4fdf-8219-13f4a4f0b240.png)

After adding the new process (same first 2 generation, new unbinding process for the 3rd generation), ArgR binding to Arg and DNA is as expected:
![image](https://user-images.githubusercontent.com/18123227/130155476-9b60b47f-9ce3-4aa5-9ee5-7c3f27338ee8.png)
![image](https://user-images.githubusercontent.com/18123227/130155494-8e2fa6b6-f899-47e5-8754-84f7eddc2594.png)

This issue is not seen for all TFs or even at all points in simulations.  It can also be seen in anaerobic conditions with crp, which might lead to some of the anaerobic daily build failures:
Before:
![image](https://user-images.githubusercontent.com/18123227/130156010-b1aa7318-4984-449e-a941-dc21f7399506.png)

After:
![image](https://user-images.githubusercontent.com/18123227/130156039-69516d0e-e3a4-4c44-8136-66add45803c5.png)
