### PR TITLE
Updates to charging debug script

### DIFF
--- a/runscripts/debug/charging.py
+++ b/runscripts/debug/charging.py
@@ -340,16 +340,16 @@ class ChargingDebug(scriptBase.ScriptBase):
 				if not result.successful():
 					result.get()
 
-	def plot_grid_results(self, path1: str, path2: str, filename: str):
+	def plot_grid_results(self, filename: str, path1: str, path2: str):
 		"""
 		Compares results from two different grid searches in an interactive
 		plot.  Useful for checking sets of parameters that give desired results
 		in different simulations.
 
 		Args:
+			filename: path to the html file with the comparison plot
 			path1: path to the tsv file results from one grid search
 			path2: path to the tsv file results from another grid search
-			filename: path to the html file with the comparison plot
 		"""
 
 		def load_data(path):
@@ -602,7 +602,7 @@ class ChargingDebug(scriptBase.ScriptBase):
 		if args.grid_search:
 			self.grid_search(args.output, cpus=args.cpus)
 		if args.grid_compare:
-			self.plot_grid_results(*args.grid_compare, args.output)
+			self.plot_grid_results(args.output, *args.grid_compare)
 		if args.interactive:
 			self.interactive_debug(args.port)
 


### PR DESCRIPTION
This makes a few changes to the charging debug script:
- Allow grid search to be run in parallel
- Use scattered time steps through the simulation to run the grid search
- Save the standard deviation for the grid search results
- Accept output file paths and # of CPUs from the command line