### PR TITLE
Remove downsampling in replication plot

### DIFF
--- a/models/ecoli/analysis/multigen/replication.py
+++ b/models/ecoli/analysis/multigen/replication.py
@@ -41,14 +41,6 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			# Get fork counts
 			pairsOfForks = np.logical_not(np.isnan(fork_coordinates)).sum(axis=1) / 2
 
-			# Down sample dna polymerase position, every position is only plotted once here
-			# using numpy ninja-ness
-			unique, index, value = np.unique(fork_coordinates, return_index=True, return_inverse=True)
-			m = np.zeros_like(value, dtype=bool)
-			m[index] = True
-			m = m.reshape(fork_coordinates.shape)
-			fork_coordinates[~m] = np.nan
-
 			# Skip plot if there are no replication forks in this generation
 			if fork_coordinates.shape[1] > 0:
 				axesList[0].plot(time, fork_coordinates, marker=',', markersize=1, linewidth=0)


### PR DESCRIPTION
This removes some "numpy ninja-ness" that doesn't quite work.  When running with an upshfit to rich media, I noticed that portions of the top plot panel were missing in the right half of the plot.  There might be a simple fix to get the expected downsampling for all time points but I don't know if that's really necessary here.

Before;
![old-replication](https://user-images.githubusercontent.com/18123227/133280045-0ee52792-63de-4056-987c-bd2bff2acc52.png)

After:
![replication](https://user-images.githubusercontent.com/18123227/133280074-3fdb04ad-5438-4b2c-b9eb-79469ec80668.png)
