### PR TITLE
Use probability transcribed instead of attenuated in enzyme plot

### DIFF
--- a/models/ecoli/analysis/multigen/aa_supply_enzymes.py
+++ b/models/ecoli/analysis/multigen/aa_supply_enzymes.py
@@ -79,7 +79,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		start = times[0, 0]
 		end = times[-1, 0]
 		enzyme_conc = (enzyme_counts @ enzyme_to_amino_acid * counts_to_mol).T
-		full_attenuation = np.ones((attenuation.shape[0], n_rnas))
+		full_attenuation = np.zeros((attenuation.shape[0], n_rnas))
 		full_attenuation[:, attenuated_indices] = attenuation
 		no_attenuation_probabilities = 1 - full_attenuation[:, enzyme_rna_indices]
 		rnas_per_amino_acid = (rna_to_enzyme @ enzyme_to_amino_acid).sum(axis=0)


### PR DESCRIPTION
This fixes the calculation for overall transcription probability in an analysis plot by using the probability that a transcript will be transcribed instead of attenuated.