### PR TITLE
fix Jenkins since Sherlock $PI_HOME & $PI_SCRATCH disappeared

### DIFF
--- a/docs/create-pyenv.md
+++ b/docs/create-pyenv.md
@@ -24,7 +24,7 @@ This page goes through the Python environment setup steps in more detail and wit
 `virtualenv` or `venv` in place of `pyenv`, be sure to put the environment
 *outside* the `wcEcoli/` directory. Otherwise `make clean` will break it!
 
-**Sherlock:** Sherlock is the Stanford scientific computing cluster. Outside the Covert lab, just skip our Sherlock notes. Inside the lab, look in `$PI_HOME/downloads/` and `$PI_HOME/installation_notes/` for downloaded software packages and notes on recompiling them as needed to install new packages, new libraries, and new Python releases for the team.
+**Sherlock:** Sherlock is the Stanford scientific computing cluster. Outside the Covert lab, just skip our Sherlock notes. Inside the lab, look in `$GROUP_HOME/downloads/` and `$GROUP_HOME/installation_notes/` for downloaded software packages and notes on recompiling them as needed to install new packages, new libraries, and new Python releases for the team.
 
 
 ## Prerequisites
@@ -90,6 +90,8 @@ This page goes through the Python environment setup steps in more detail and wit
    You'll need these newer git modules since they use a compatible version of `libressl`.
 
    ```shell script
+   export PI_HOME=$GROUP_HOME
+
    ##### Add group-wide path settings #####
    if [ -f "${PI_HOME}/etc/bash_profile" ]; then
        . "${PI_HOME}/etc/bash_profile"
@@ -118,14 +120,14 @@ This page goes through the Python environment setup steps in more detail and wit
 
 1. Install Python 3 **in a shared pyenv for the team** if it needs updating.
 
-   See `$PI_HOME/installation_notes/python3.txt`.
+   See `$GROUP_HOME/installation_notes/python3.txt`.
 
    If you need to update binary libraries like libressl, readline, or libffi,
-   see their `$PI_HOME/installation_notes/*.txt` files.
+   see their `$GROUP_HOME/installation_notes/*.txt` files.
 
    Each of these libraries and tools needs an _environment module_. We
    `module load` the module to make it accessible via environment variable paths
-   like `CPPFLAGS`. See for example `$PI_HOME/modules/xz/5.2.5.lua`.
+   like `CPPFLAGS`. See for example `$GROUP_HOME/modules/xz/5.2.5.lua`.
 
 ### On Ubuntu and other Linux environments
 
@@ -193,7 +195,7 @@ virtualenv.
    * Compiling from source with
      `make FC=gfortran && make PREFIX=/XYZ install` installs it in that specified `/XYZ`
      PREFIX directory.
-   * On Sherlock, it's installed in `$PI_HOME/downloads-sherlock2/compiled/openblas`.
+   * On Sherlock, it's installed in `$GROUP_HOME/downloads-sherlock2/compiled/openblas`.
      (Using an environment module to load the OpenBLAS when installing numpy and
      scipy works if the same environment module is loaded at runtime.)
 
@@ -375,8 +377,8 @@ source code, etc.
    ln -s $SCRATCH/wcEcoli_out out
    ```
 
-1. Create a symbolic link to a shared sim data cache directory on `$PI_SCRATCH` that should contain a copy of the newest sim data object (it should be updated by the daily build):
+1. Create a symbolic link to a shared sim data cache directory in `$GROUP_SCRATCH` that should contain a copy of the newest sim data object (it should be updated by the daily build):
 
    ```shell script
-   ln -s $PI_SCRATCH/wc_ecoli/cached cached
+   ln -s $GROUP_SCRATCH/wc_ecoli/cached cached
    ```

--- a/docs/dev-tools.md
+++ b/docs/dev-tools.md
@@ -39,7 +39,7 @@ sudo apt install -y gcc make build-essential wget curl llvm
 you might not need to bother with Sherlock except to view Jenkins CI build logs.)
 
 The needed tools are already installed for the group.
-Look in `$PI_HOME/downloads/`, `$PI_HOME/installation_notes/`, and `$PI_HOME/modules/`.
+Look in `$GROUP_HOME/downloads/`, `$GROUP_HOME/installation_notes/`, and `$GROUP_HOME/modules/`.
 
 * Just add to your shell login script as described below.
 
@@ -130,6 +130,8 @@ required libraries and library versions.
    - Example `~/.bash_profile` lines for Sherlock:
 
      ```shell script
+     export PI_HOME=$GROUP_HOME
+
      ##### Add group-wide path settings #####
      if [ -f "${PI_HOME}/etc/bash_profile" ]; then
          . "${PI_HOME}/etc/bash_profile"

--- a/runscripts/debug/summarize_environment.py
+++ b/runscripts/debug/summarize_environment.py
@@ -39,7 +39,8 @@ def main():
 
 	subtitle(os)
 	print_dictionary("os.environ", os.environ, [
-		'OPENBLAS_NUM_THREADS', 'HOME', 'LIBRARY_PATH', 'PI_HOME', 'PYENV_ROOT',
+		'OPENBLAS_NUM_THREADS', 'HOME', 'SCRATCH', 'LIBRARY_PATH',
+		'GROUP_HOME', 'GROUP_SCRATCH', 'PI_HOME', 'PYENV_ROOT',
 		'PYTHONPATH', 'SHERLOCK'])
 	print("os.getcwd(): {}".format(os.getcwd()))
 	print("os.uname(): {}".format(os.uname()))

--- a/runscripts/jenkins/ecoli-anaerobic.sh
+++ b/runscripts/jenkins/ecoli-anaerobic.sh
@@ -9,4 +9,4 @@ DESC="Anaerobic." VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1
 
 bash runscripts/jenkins/run-fireworks.sh
 
-runscripts/jenkins/save_output.sh out/ /scratch/PI/mcovert/wc_ecoli/anaerobic/
+runscripts/jenkins/save_output.sh out/ /scratch/groups/mcovert/wc_ecoli/anaerobic/

--- a/runscripts/jenkins/ecoli-glucose-minimal.sh
+++ b/runscripts/jenkins/ecoli-glucose-minimal.sh
@@ -9,11 +9,11 @@ DESC="Daily build." SINGLE_DAUGHTERS=1 N_GENS=25 MASS_DISTRIBUTION=0 COMPRESS_OU
 
 bash runscripts/jenkins/run-fireworks.sh
 
-cp out/2*/kb/rawData.cPickle.bz2 /scratch/PI/mcovert/wc_ecoli/cached/
-bunzip2 -f /scratch/PI/mcovert/wc_ecoli/cached/rawData.cPickle.bz2
-chmod 444 /scratch/PI/mcovert/wc_ecoli/cached/rawData.cPickle
-cp out/2*/kb/simData.cPickle.bz2 /scratch/PI/mcovert/wc_ecoli/cached/
-bunzip2 -f /scratch/PI/mcovert/wc_ecoli/cached/simData.cPickle.bz2
-chmod 444 /scratch/PI/mcovert/wc_ecoli/cached/simData.cPickle
+cp out/2*/kb/rawData.cPickle.bz2 /scratch/groups/mcovert/wc_ecoli/cached/
+bunzip2 -f /scratch/groups/mcovert/wc_ecoli/cached/rawData.cPickle.bz2
+chmod 444 /scratch/groups/mcovert/wc_ecoli/cached/rawData.cPickle
+cp out/2*/kb/simData.cPickle.bz2 /scratch/groups/mcovert/wc_ecoli/cached/
+bunzip2 -f /scratch/groups/mcovert/wc_ecoli/cached/simData.cPickle.bz2
+chmod 444 /scratch/groups/mcovert/wc_ecoli/cached/simData.cPickle
 
-runscripts/jenkins/save_output.sh out/ /scratch/PI/mcovert/wc_ecoli/daily_build/
+runscripts/jenkins/save_output.sh out/ /scratch/groups/mcovert/wc_ecoli/daily_build/

--- a/runscripts/jenkins/ecoli-optional-features.sh
+++ b/runscripts/jenkins/ecoli-optional-features.sh
@@ -26,4 +26,4 @@ DESC="Causality Network" BUILD_CAUSALITY_NETWORK=1 N_GENS=2 SEED=$RANDOM \
 
 bash runscripts/jenkins/run-fireworks.sh
 
-runscripts/jenkins/save_output.sh out/ /scratch/PI/mcovert/wc_ecoli/optional_features/
+runscripts/jenkins/save_output.sh out/ /scratch/groups/mcovert/wc_ecoli/optional_features/

--- a/runscripts/jenkins/ecoli-with-aa.sh
+++ b/runscripts/jenkins/ecoli-with-aa.sh
@@ -9,4 +9,4 @@ DESC="With AAs." VARIANT="condition" FIRST_VARIANT_INDEX=2 LAST_VARIANT_INDEX=2 
 
 bash runscripts/jenkins/run-fireworks.sh
 
-runscripts/jenkins/save_output.sh out/ /scratch/PI/mcovert/wc_ecoli/with_aa/
+runscripts/jenkins/save_output.sh out/ /scratch/groups/mcovert/wc_ecoli/with_aa/

--- a/runscripts/jenkins/fireworks-config.sh
+++ b/runscripts/jenkins/fireworks-config.sh
@@ -10,7 +10,7 @@
 set -eu
 
 WC_MONGO_DB=$1
-LOG_DIR="/scratch/PI/mcovert/jenkins/fireworks/logs/launchpad"
+LOG_DIR="/scratch/groups/mcovert/jenkins/fireworks/logs/launchpad"
 
 mkdir -p $LOG_DIR
 {

--- a/runscripts/jenkins/purge.sh
+++ b/runscripts/jenkins/purge.sh
@@ -5,7 +5,7 @@
 # Uses a relative month to now so that it can automatically remove old months when
 # scheduled to run in a Jenkins script.
 #
-# WARNING: will delete shared files in $PI_SCRATCH/wc_ecoli/
+# WARNING: will delete shared files in /scratch/groups/mcovert/wc_ecoli/
 #
 # Usage:
 #   ./purge.sh <directory> <months ago>
@@ -36,7 +36,7 @@ if ! [[ "$MONTHS_AGO_TO_PURGE" =~ $re ]] || [ "$MONTHS_AGO_TO_PURGE" -lt 6 ]; th
 	exit
 fi
 
-DIR="/scratch/PI/mcovert/wc_ecoli/$DIR_TO_PURGE"
+DIR="/scratch/groups/mcovert/wc_ecoli/$DIR_TO_PURGE"
 
 # Only deletes files from one month which is selected by MONTHS_AGO_TO_PURGE months prior to today
 MONTH=$((10#$(date +%m) - $MONTHS_AGO_TO_PURGE))

--- a/runscripts/jenkins/run-fireworks.sh
+++ b/runscripts/jenkins/run-fireworks.sh
@@ -19,7 +19,7 @@ if [ $N_FAILS -gt 0 ]; then
   lpad get_fws -s FIZZLED
   echo
   sed '/^$/N;/^\n$/D' stderr.log  # Print errors but filter out multiple blank lines in a row
-  mv out/2* /scratch/PI/mcovert/wc_ecoli/failed/
+  mv out/2* /scratch/groups/mcovert/wc_ecoli/failed/
 fi
 
 test $N_FAILS = 0


### PR DESCRIPTION
Sherlock's `$PI_HOME` and `$PI_SCRATCH` environment variables and their directories are gone. Switch to:
* `$GROUP_HOME` = `/home/groups/mcovert`
* `$GROUP_SCRATCH` = `/scratch/groups/mcovert`

Travis updated the Jenkins configuration.

In this PR:
1. Update the Jenkins scripts.
2. Update the `docs/create-pyenv.md` instructions.

*NB:* If you're using Sherlock, please add `export PI_HOME=$GROUP_HOME` to your bash profile (or change all uses to `$GROUP_HOME`) and replace your `~/wcEcoli/cached` symlink:

```shell script
cd ~/wcEcoli
rm cached
ln -s $GROUP_SCRATCH/wc_ecoli/cached cached
```