### PR TITLE
Remove nan/inf values for pearsonr

### DIFF
--- a/models/ecoli/analysis/variant/growth_correlations.py
+++ b/models/ecoli/analysis/variant/growth_correlations.py
@@ -37,7 +37,9 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		all_r = np.zeros((n_subproperties, n_growth_rates))
 		for i, property in enumerate(cell_property):
 			for j, growth in enumerate(growth_rates):
-				all_r[i, j] = stats.pearsonr(property[:len(growth)], growth)[0]
+				filter_mask = np.isfinite(property[:len(growth)]) & np.isfinite(growth)  # filter to prevent pearsonr ValueError
+				if np.any(filter_mask):
+					all_r[i, j] = stats.pearsonr(property[:len(growth)][filter_mask], growth[filter_mask])[0]
 
 		width = 0.8 / n_growth_rates
 		offsets = np.arange(n_growth_rates) * width - 0.4 + width / 2


### PR DESCRIPTION
This handles inf/nan values that might have been passed to the pearsonr function to prevent errors like:

```
Traceback (most recent call last):
  File "/scratch/groups/mcovert/jenkins/workspace@2/wholecell/fireworks/firetasks/analysisBase.py", line 222, in run_plot
    plot_class.main(*args, cpus=1)
  File "/scratch/groups/mcovert/jenkins/workspace@2/models/ecoli/analysis/analysisPlot.py", line 164, in main
    instance.plot(inputDir, plotOutDir, plotOutFileName, simDataFile,
  File "/scratch/groups/mcovert/jenkins/workspace@2/models/ecoli/analysis/analysisPlot.py", line 155, in plot
    do_plot()
  File "/scratch/groups/mcovert/jenkins/workspace@2/models/ecoli/analysis/analysisPlot.py", line 142, in do_plot
    self.do_plot(inputDir, plotOutDir, plotOutFileName, simDataFile,
  File "/scratch/groups/mcovert/jenkins/workspace@2/models/ecoli/analysis/variant/growth_correlations.py", line 150, in do_plot
    self.plot_bar(plt.subplot(gs[row, col + 1]), property[removed_mask, :], all_growth, label, aa_ids[removed_mask])
  File "/scratch/groups/mcovert/jenkins/workspace@2/models/ecoli/analysis/variant/growth_correlations.py", line 40, in plot_bar
    all_r[i, j] = stats.pearsonr(property[:len(growth)], growth)[0]
  File "/home/groups/mcovert/pyenv/versions/wcEcoli3/lib/python3.8/site-packages/scipy/stats/stats.py", line 3867, in pearsonr
    normxm = linalg.norm(xm)
  File "/home/groups/mcovert/pyenv/versions/wcEcoli3/lib/python3.8/site-packages/scipy/linalg/misc.py", line 140, in norm
    a = np.asarray_chkfinite(a)
  File "/home/groups/mcovert/pyenv/versions/wcEcoli3/lib/python3.8/site-packages/numpy/lib/function_base.py", line 485, in asarray_chkfinite
    raise ValueError(
ValueError: array must not contain infs or NaNs
```