### PR TITLE
Update rich/minimal environment cycling timelines

### DIFF
--- a/reconstruction/ecoli/flat/condition/timelines_def.tsv
+++ b/reconstruction/ecoli/flat/condition/timelines_def.tsv
@@ -26,4 +26,5 @@
 "000023_add_calcium"	"0 minimal_minus_calcium, 1200 minimal"
 "000024_cut_calcium"	"0 minimal, 1200 minimal_minus_calcium"
 "000025_cut_aa"	"0 minimal_plus_amino_acids, 1200 minimal"
-"000026_add_and_cut_aa"	"0 minimal, 1200 minimal_plus_amino_acids, 2400 minimal"
+"000026_add_and_cut_aa"	"0 minimal, 1200 minimal_plus_amino_acids, 12000 minimal"
+"000027_cut_and_add_aa"	"0 minimal_plus_amino_acids, 1200 minimal, 19200 minimal_plus_amino_acids"


### PR DESCRIPTION
This updates the timing for timeline `000026_add_and_cut_aa` to add amino acids after 20 minutes and then cut AA 3 hr later.  It also adds `000027_cut_and_add_aa` to cut AA after 20 minutes and add them 5 hr later.  These time scales allow the cells to reach new steady states before the second shift.