### PR TITLE
Update growth_trajectory plot for trimmed axes

### DIFF
--- a/models/ecoli/analysis/variant/growth_trajectory.py
+++ b/models/ecoli/analysis/variant/growth_trajectory.py
@@ -167,22 +167,22 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			stacked_times = np.vstack([data[:min_length_ma] for data in all_times]).mean(0)
 			stacked_times_ma = np.vstack([data[:min_length_ma] for data in all_times_ma]).mean(0)
 
-			for axes in [main_axes, trimmed_axes]:
+			for axes, tl in [(main_axes, timeline), (trimmed_axes, None)]:
 				plot(axes[0, 0], stacked_mass_means, stacked_growth_means,
 					xlabel='Average cell cycle mass (fg)', ylabel='Average cell cycle growth rate (1/hr)', label=variant)
 				plot(axes[1, 0], stacked_ratio_means, stacked_growth_means,
 					xlabel='Average cell cycle RNA/protein', ylabel='Average cell cycle growth rate (1/hr)', label=variant)
 				plot(axes[2, 0], stacked_ratio_ma, stacked_growth_ma,
-					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=timeline,
+					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=tl,
 					xlabel='RNA/protein', ylabel='Growth rate (1/hr)', label=variant)
 				plot(axes[0, 1], stacked_ratio_ma, stacked_protein_growth_ma,
-					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=timeline,
+					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=tl,
 					xlabel='RNA/protein', ylabel='Protein growth rate (1/hr)', label=variant)
 				plot(axes[1, 1], stacked_ratio_ma, stacked_rna_growth_ma,
-					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=timeline,
+					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=tl,
 					xlabel='RNA/protein', ylabel='RNA growth rate (1/hr)', label=variant)
 				plot(axes[2, 1], stacked_ratio_ma, stacked_small_mol_growth_ma,
-					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=timeline,
+					ma_time=stacked_times_ma, sim_time=stacked_times, timeline=tl,
 					xlabel='RNA/protein', ylabel='Small molecule growth rate (1/hr)', label=variant)
 
 			# Save average/std for output to a tsv


### PR DESCRIPTION
This updates the growth_trajectory variant analysis to save a trimmed version of the plot with fixed axes limits and less markup on the traces.

With all regulation (0), no ppGpp regulation (1), no mechanistic AA supply (2) and no growth regulation (3), this is what the new version looks like with a shift from rich to minimal back to rich (timelines 27 variant):
![growth_trajectory_trimmed](https://user-images.githubusercontent.com/18123227/141035620-cef3eab0-3e22-4ecb-80dc-07f9c86646e9.png)