### PR TITLE
Add ppGpp regulation of rpmF

### DIFF
--- a/reconstruction/ecoli/flat/ppgpp_regulation_added.tsv
+++ b/reconstruction/ecoli/flat/ppgpp_regulation_added.tsv
@@ -16,3 +16,4 @@
 "trpS"	-1								"trpS"	"tRNA synthetases are expected to be negatively regulated by ppGpp"
 "tyrS"	-1								"tyrS"	"tRNA synthetases are expected to be negatively regulated by ppGpp"
 "valS"	-1								"valS"	"tRNA synthetases are expected to be negatively regulated by ppGpp"
+"rpmF"	-1								"rpmF"	"Only ribosomal protein not curated with any ppGpp regulation"


### PR DESCRIPTION
This adds ppGpp regulation of rpmF which is the only ribosomal protein that did not include annotated ppGpp regulation and fold change data confirms that this should be down regulated with increased ppGpp concentrations.