### PR TITLE
Add longer lead in time before shifts

### DIFF
--- a/reconstruction/ecoli/flat/condition/timelines_def.tsv
+++ b/reconstruction/ecoli/flat/condition/timelines_def.tsv
@@ -26,5 +26,5 @@
 "000023_add_calcium"	"0 minimal_minus_calcium, 1200 minimal"
 "000024_cut_calcium"	"0 minimal, 1200 minimal_minus_calcium"
 "000025_cut_aa"	"0 minimal_plus_amino_acids, 1200 minimal"
-"000026_add_and_cut_aa"	"0 minimal, 1200 minimal_plus_amino_acids, 12000 minimal"
-"000027_cut_and_add_aa"	"0 minimal_plus_amino_acids, 1200 minimal, 19200 minimal_plus_amino_acids"
+"000026_add_and_cut_aa"	"0 minimal, 3600 minimal_plus_amino_acids, 14400 minimal"
+"000027_cut_and_add_aa"	"0 minimal_plus_amino_acids, 3600 minimal, 21600 minimal_plus_amino_acids"


### PR DESCRIPTION
This extends the lead in time before shifts in some timelines for better visualization when plotting the time series traces.