### PR TITLE
Use self.ap in analysis plots

### DIFF
--- a/models/ecoli/analysis/cohort/aa_conc.py
+++ b/models/ecoli/analysis/cohort/aa_conc.py
@@ -11,7 +11,6 @@ import numpy as np
 from six.moves import cPickle, range
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
@@ -26,10 +25,9 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		aa_ids = sim_data.molecule_groups.amino_acids
 		targets = np.array([sim_data.process.metabolism.conc_dict[key].asNumber(units.mmol / units.L) for key in aa_ids])
 
-		ap = AnalysisPaths(variantDir, cohort_plot=True)
 
 		aa_conc = None
-		for sim_dir in ap.get_cells():
+		for sim_dir in self.ap.get_cells():
 			simOutDir = os.path.join(sim_dir, 'simOut')
 
 			# Load data

--- a/models/ecoli/analysis/cohort/centralCarbonMetabolismCorrelationTimeCourse.py
+++ b/models/ecoli/analysis/cohort/centralCarbonMetabolismCorrelationTimeCourse.py
@@ -6,7 +6,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from models.ecoli.analysis.single.centralCarbonMetabolism import net_flux
@@ -25,7 +24,6 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		plt.figure(figsize = (8.5, 11))
 
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
 
 		validation_data = cPickle.load(open(validationDataFile, "rb"))
 		sim_data = cPickle.load(open(simDataFile, "rb"))
@@ -34,9 +32,9 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 
 		seed_color = {}
 		line_instances = {}
-		for seed_num in range(ap.n_seed):
+		for seed_num in range(self.ap.n_seed):
 			# Get all cells in this seed
-			seedDir = ap.get_cells(seed=[seed_num])
+			seedDir = self.ap.get_cells(seed=[seed_num])
 
 			for simDir in seedDir:
 				simOutDir = os.path.join(simDir, "simOut")

--- a/models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py
+++ b/models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py
@@ -12,7 +12,6 @@ from matplotlib import pyplot as plt
 from scipy.stats import pearsonr
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.utils.sparkline import whitePadSparklineAxis
@@ -27,8 +26,7 @@ from six.moves import zip
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		validation_data = cPickle.load(open(validationDataFile, "rb"))
 		toyaReactions = validation_data.reactionFlux.toya2010fluxes["reactionID"]

--- a/models/ecoli/analysis/cohort/doubling_times_histogram_all.py
+++ b/models/ecoli/analysis/cohort/doubling_times_histogram_all.py
@@ -20,7 +20,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.utils import units
@@ -49,15 +48,13 @@ TARGET_LINE_STYLE = dict(
 
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		analysis_paths = AnalysisPaths(variantDir, cohort_plot = True)
-
-		n_gens = analysis_paths.n_generation
+		n_gens = self.ap.n_generation
 
 		if n_gens - 1 < FIRST_GENERATION:
 			print('Not enough generations to plot.')
 			return
 
-		sim_dirs = analysis_paths.get_cells(
+		sim_dirs = self.ap.get_cells(
 			generation = list(range(FIRST_GENERATION, n_gens))
 			)
 

--- a/models/ecoli/analysis/cohort/expression_dynamics.py
+++ b/models/ecoli/analysis/cohort/expression_dynamics.py
@@ -7,7 +7,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle, zip
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils.sparkline import whitePadSparklineAxis
 from wholecell.analysis.rdp import rdp
@@ -39,8 +38,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			return
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, cohort_plot = True)
-		allDir = ap.get_cells(seed=[0], generation = GENS)
+		allDir = self.ap.get_cells(seed=[0], generation = GENS)
 		n_gens = GENS.size
 		if len(allDir) < n_gens:
 			print("Skipping - particular seed and/or gens were not simulated.")

--- a/models/ecoli/analysis/cohort/growthDynamics.py
+++ b/models/ecoli/analysis/cohort/growthDynamics.py
@@ -7,7 +7,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 import matplotlib.patches as patches
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 
@@ -41,9 +40,8 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		#ax4 = plt.subplot2grid((5,7), (4,0), colspan = 4, sharex=ax0)
 
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		#all_cells = ap.get_cells(seed=[0,1,2,3])
-		all_cells = ap.get_cells(seed=[4])
+		#all_cells = self.ap.get_cells(seed=[0,1,2,3])
+		all_cells = self.ap.get_cells(seed=[4])
 
 		if not len(all_cells):
 			return
@@ -206,8 +204,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		ax4 = plt.subplot2grid((2,4), (1,0), colspan = 4, sharex=ax0)
 
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		all_cells = ap.get_cells(seed=[4])
+		all_cells = self.ap.get_cells(seed=[4])
 
 		if not len(all_cells):
 			return

--- a/models/ecoli/analysis/cohort/growth_time_series.py
+++ b/models/ecoli/analysis/cohort/growth_time_series.py
@@ -10,7 +10,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.analysis.single.ribosome_limitation import calculate_ribosome_excesses
 from wholecell.analysis.analysis_tools import (exportFigure,
 	read_stacked_bulk_molecules, read_stacked_columns)
@@ -176,8 +175,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		is_rrna = transcription.rna_data['is_rRNA']
 		is_trna = transcription.rna_data['is_tRNA']
 
-		ap = AnalysisPaths(variantDir, cohort_plot=True)
-		cell_paths = ap.get_cells(only_successful=True)
+		cell_paths = self.ap.get_cells(only_successful=True)
 
 		# Load attributes
 		unique_molecule_reader = TableReader(os.path.join(cell_paths[0], 'simOut', 'UniqueMoleculeCounts'))

--- a/models/ecoli/analysis/cohort/histogramDoublingTime.py
+++ b/models/ecoli/analysis/cohort/histogramDoublingTime.py
@@ -5,7 +5,6 @@ import numpy as np
 import os
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader, TableReaderError
 from six.moves import range
@@ -14,23 +13,22 @@ from six.moves import range
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot=True)
 
 		max_cells_in_gen = 0
-		for genIdx in range(ap.n_generation):
-			n_cells = len(ap.get_cells(generation = [genIdx]))
+		for genIdx in range(self.ap.n_generation):
+			n_cells = len(self.ap.get_cells(generation = [genIdx]))
 
 			if n_cells > max_cells_in_gen:
 				max_cells_in_gen = n_cells
 
 		# noinspection PyTypeChecker
-		fig, axesList = plt.subplots(ap.n_generation,
-			sharex=True, sharey=True, figsize=(6, 3*ap.n_generation))
+		fig, axesList = plt.subplots(self.ap.n_generation,
+			sharex=True, sharey=True, figsize=(6, 3*self.ap.n_generation))
 
 		all_doubling_times = []
 
-		for genIdx in range(ap.n_generation):
-			gen_cells = ap.get_cells(generation = [genIdx])
+		for genIdx in range(self.ap.n_generation):
+			gen_cells = self.ap.get_cells(generation = [genIdx])
 			gen_doubling_times = []
 
 			for simDir in gen_cells:
@@ -56,7 +54,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			all_doubling_times.append(np.array(gen_doubling_times))
 
 		# Plot histograms of doubling times
-		if ap.n_generation == 1:
+		if self.ap.n_generation == 1:
 			axesList = [axesList]
 
 		for idx, axes in enumerate(axesList):

--- a/models/ecoli/analysis/cohort/histogramFinalMass.py
+++ b/models/ecoli/analysis/cohort/histogramFinalMass.py
@@ -5,7 +5,6 @@ import numpy as np
 import os
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader, TableReaderError
 from six.moves import range
@@ -14,23 +13,22 @@ from six.moves import range
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot=True)
 
 		max_cells_in_gen = 0
-		for genIdx in range(ap.n_generation):
-			n_cells = len(ap.get_cells(generation = [genIdx]))
+		for genIdx in range(self.ap.n_generation):
+			n_cells = len(self.ap.get_cells(generation = [genIdx]))
 
 			if n_cells > max_cells_in_gen:
 				max_cells_in_gen = n_cells
 
 		# noinspection PyTypeChecker
-		fig, axesList = plt.subplots(ap.n_generation,
-			sharey=True, sharex=True, figsize=(6, 3*ap.n_generation))
+		fig, axesList = plt.subplots(self.ap.n_generation,
+			sharey=True, sharex=True, figsize=(6, 3*self.ap.n_generation))
 
 		all_final_masses = []
 
-		for genIdx in range(ap.n_generation):
-			gen_cells = ap.get_cells(generation = [genIdx])
+		for genIdx in range(self.ap.n_generation):
+			gen_cells = self.ap.get_cells(generation = [genIdx])
 			gen_final_masses = []
 
 			for simDir in gen_cells:
@@ -57,7 +55,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 
 
 		# Plot histograms of final masses
-		if ap.n_generation == 1:
+		if self.ap.n_generation == 1:
 			axesList = [axesList]
 
 		for idx, axes in enumerate(axesList):

--- a/models/ecoli/analysis/cohort/histogramGrowthRate.py
+++ b/models/ecoli/analysis/cohort/histogramGrowthRate.py
@@ -5,7 +5,6 @@ import numpy as np
 import os
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader, TableReaderError
 from wholecell.utils import units
@@ -15,23 +14,22 @@ from six.moves import range
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
 
 		max_cells_in_gen = 0
-		for genIdx in range(ap.n_generation):
-			n_cells = len(ap.get_cells(generation = [genIdx]))
+		for genIdx in range(self.ap.n_generation):
+			n_cells = len(self.ap.get_cells(generation = [genIdx]))
 
 			if n_cells > max_cells_in_gen:
 				max_cells_in_gen = n_cells
 
 		# noinspection PyTypeChecker
-		fig, axesList = plt.subplots(ap.n_generation,
-			sharex=True, sharey=True, figsize=(6, 3*ap.n_generation))
+		fig, axesList = plt.subplots(self.ap.n_generation,
+			sharex=True, sharey=True, figsize=(6, 3*self.ap.n_generation))
 
 		all_growth_rates = []
 
-		for genIdx in range(ap.n_generation):
-			gen_cells = ap.get_cells(generation = [genIdx])
+		for genIdx in range(self.ap.n_generation):
+			gen_cells = self.ap.get_cells(generation = [genIdx])
 			gen_growth_rates = []
 
 			for simDir in gen_cells:
@@ -59,7 +57,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			all_growth_rates.append(np.array(gen_growth_rates))
 
 		# Plot histograms of growth rates
-		if ap.n_generation == 1:
+		if self.ap.n_generation == 1:
 			axesList = [axesList]
 
 		for idx, axes in enumerate(axesList):

--- a/models/ecoli/analysis/cohort/initialVsFinalMass.py
+++ b/models/ecoli/analysis/cohort/initialVsFinalMass.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import cohortAnalysisPlot
@@ -15,23 +14,22 @@ from six.moves import range
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
 
 		max_cells_in_gen = 0
-		for genIdx in range(ap.n_generation):
-			n_cells = len(ap.get_cells(generation = [genIdx]))
+		for genIdx in range(self.ap.n_generation):
+			n_cells = len(self.ap.get_cells(generation = [genIdx]))
 			if n_cells > max_cells_in_gen:
 				max_cells_in_gen = n_cells
 
 		# noinspection PyTypeChecker
-		fig, axesList = plt.subplots(ap.n_generation, sharey = True, sharex = True,
+		fig, axesList = plt.subplots(self.ap.n_generation, sharey = True, sharex = True,
 			subplot_kw={'aspect': 0.4, 'adjustable': 'box'})
 
-		initial_masses = np.zeros((max_cells_in_gen, ap.n_generation))
-		final_masses = np.zeros((max_cells_in_gen, ap.n_generation))
+		initial_masses = np.zeros((max_cells_in_gen, self.ap.n_generation))
+		final_masses = np.zeros((max_cells_in_gen, self.ap.n_generation))
 
-		for genIdx in range(ap.n_generation):
-			gen_cells = ap.get_cells(generation = [genIdx])
+		for genIdx in range(self.ap.n_generation):
+			gen_cells = self.ap.get_cells(generation = [genIdx])
 			for simDir in gen_cells:
 				simOutDir = os.path.join(simDir, "simOut")
 				mass = TableReader(os.path.join(simOutDir, "Mass"))
@@ -41,7 +39,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 				final_masses[np.where(simDir == gen_cells)[0], genIdx] = cellMass[-1] / 1000.
 
 		# Plot initial vs final masses
-		if ap.n_generation == 1:
+		if self.ap.n_generation == 1:
 			axesList = [axesList]
 
 		for idx, axes in enumerate(axesList):
@@ -55,7 +53,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 
 
 		axesList[-1].set_xlabel("Initial mass (pg)")
-		axesList[ap.n_generation // 2].set_ylabel("Final mass (pg)")
+		axesList[self.ap.n_generation // 2].set_ylabel("Final mass (pg)")
 
 		plt.subplots_adjust(hspace = 0.2, wspace = 0.5)
 

--- a/models/ecoli/analysis/cohort/kinetics_flux_comparison.py
+++ b/models/ecoli/analysis/cohort/kinetics_flux_comparison.py
@@ -12,7 +12,6 @@ from matplotlib import pyplot as plt
 from scipy.stats import pearsonr
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.io import tsv
 from wholecell.utils import units
@@ -32,8 +31,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 

--- a/models/ecoli/analysis/cohort/mass_fraction_instantaneous_growth_rates.py
+++ b/models/ecoli/analysis/cohort/mass_fraction_instantaneous_growth_rates.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 from matplotlib import pyplot as plt
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 
 NUM_SKIP_TIMESTEPS_AT_GEN_CHANGE = 1
@@ -25,10 +24,9 @@ def seriesScrubber(series, factor):
 
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, cohort_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells(seed=[0])
+		allDir = self.ap.get_cells(seed=[0])
 
 		# fig = plt.figure(figsize = (14, 10))
 		# ax1 = plt.subplot2grid((4,2), (0,0), rowspan = 4)

--- a/models/ecoli/analysis/cohort/promoter_probabilities.py
+++ b/models/ecoli/analysis/cohort/promoter_probabilities.py
@@ -11,7 +11,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
 
@@ -24,13 +23,12 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			sim_data = pickle.load(f)
 		tf_to_gene_id = sim_data.process.transcription_regulation.tf_to_gene_id
 
-		ap = AnalysisPaths(variantDir, cohort_plot=True)
 
 		expected = []
 		bound = []
 		active_tfs = []
 		promoters = []
-		for sim_dir in ap.get_cells():
+		for sim_dir in self.ap.get_cells():
 			simOutDir = os.path.join(sim_dir, 'simOut')
 
 			# Listeners used

--- a/models/ecoli/analysis/cohort/proteinCopyNumberDistribution.py
+++ b/models/ecoli/analysis/cohort/proteinCopyNumberDistribution.py
@@ -14,7 +14,6 @@ from itertools import cycle
 from six.moves import cPickle, range, zip
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.utils import units
@@ -26,9 +25,8 @@ PROTEIN_SAMPLE_COUNT = 10
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get paths for all cell simulations in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		n_seed = ap.n_seed
-		n_generation = ap.n_generation
+		n_seed = self.ap.n_seed
+		n_generation = self.ap.n_generation
 
 		# If the simulation does not have multiple seeds, skip analysis
 		if n_seed <= 1:
@@ -38,7 +36,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		# Divide simulations by generation number
 		sim_dirs_grouped_by_gen = []
 		for gen_idx in range(n_generation):
-			sim_dirs_grouped_by_gen.append(ap.get_cells(generation = [gen_idx]))
+			sim_dirs_grouped_by_gen.append(self.ap.get_cells(generation = [gen_idx]))
 
 		# Load simDataFile and get constants
 		sim_data = cPickle.load(open(simDataFile, 'rb'))

--- a/models/ecoli/analysis/cohort/proteinFoldChangeVsTranscriptionFrequency.py
+++ b/models/ecoli/analysis/cohort/proteinFoldChangeVsTranscriptionFrequency.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 
 from six.moves import cPickle
@@ -46,14 +45,13 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		rnap_subunit_stoich = data_rnap["subunitStoich"]
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, cohort_plot = True)
-		allDir = ap.get_cells(seed = [0])
+		allDir = self.ap.get_cells(seed = [0])
 
 		first_build = True
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		monomerExistMultigen = np.zeros((n_sims, n_monomers), dtype = bool)
 		ratioFinalToInitialCountMultigen = np.zeros((n_sims, n_monomers), dtype = float)
@@ -198,8 +196,8 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		scatterAxis.loglog(averageInitiationEventsPerMonomer[smallBurst], averageFoldChangePerMonomer[smallBurst], marker = '.', color = "blue", alpha = 0.5, lw = 0.)#, s = 5)
 		scatterAxis.loglog(averageInitiationEventsPerMonomer[~smallBurst], averageFoldChangePerMonomer[~smallBurst], marker = '.', color = "red", alpha = 0.5, lw = 0.)#, s = 5)
 
-		scatterAxis.set_ylabel("Fold change per protein\nin each generation ({} generations)".format(ap.n_generation), fontsize = FONT_SIZE)
-		scatterAxis.set_xlabel("Average number of transcription events\nper protein per generation ({} generations)".format(ap.n_generation), fontsize = FONT_SIZE)
+		scatterAxis.set_ylabel("Fold change per protein\nin each generation ({} generations)".format(self.ap.n_generation), fontsize = FONT_SIZE)
+		scatterAxis.set_xlabel("Average number of transcription events\nper protein per generation ({} generations)".format(self.ap.n_generation), fontsize = FONT_SIZE)
 
 		# lims = yhistAxis.get_ylim()
 		# step = (lims[1] - lims[0]) / 125

--- a/models/ecoli/analysis/cohort/rnaCopyNumberDistribution.py
+++ b/models/ecoli/analysis/cohort/rnaCopyNumberDistribution.py
@@ -13,7 +13,6 @@ import matplotlib.gridspec as gridspec
 from itertools import cycle
 from six.moves import cPickle, range, zip
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.analysis.analysis_tools import exportFigure
@@ -26,9 +25,8 @@ RNA_SAMPLE_COUNT = 10
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get paths for all cell simulations in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		n_seed = ap.n_seed
-		n_generation = ap.n_generation
+		n_seed = self.ap.n_seed
+		n_generation = self.ap.n_generation
 
 		# If the simulation does not have multiple seeds, skip analysis
 		if n_seed <= 1:
@@ -38,7 +36,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		# Group simulations by generation
 		sim_dirs_grouped_by_gen = []
 		for gen_idx in range(n_generation):
-			sim_dirs_grouped_by_gen.append(ap.get_cells(generation = [gen_idx]))
+			sim_dirs_grouped_by_gen.append(self.ap.get_cells(generation = [gen_idx]))
 
 		# Load simDataFile
 		simData = cPickle.load(open(simDataFile, 'rb'))

--- a/models/ecoli/analysis/cohort/rnap_stalled_sims.py
+++ b/models/ecoli/analysis/cohort/rnap_stalled_sims.py
@@ -6,14 +6,12 @@ stalled transcript elongation occurred
 import os
 import numpy as np
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 
 
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(variantDir, cohort_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		seed_gen_stalled = []
 		for sim_dir in cell_paths:

--- a/models/ecoli/analysis/cohort/template.py
+++ b/models/ecoli/analysis/cohort/template.py
@@ -10,7 +10,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import cohortAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import (exportFigure,
 	read_bulk_molecule_counts, read_stacked_bulk_molecules, read_stacked_columns)
 from wholecell.io.tablereader import TableReader
@@ -23,8 +22,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		with open(validationDataFile, 'rb') as f:
 			validation_data = pickle.load(f)
 
-		ap = AnalysisPaths(variantDir, cohort_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		# Load data
 		## Simple stacking functions for data from all cells

--- a/models/ecoli/analysis/cohort/transcriptFrequency.py
+++ b/models/ecoli/analysis/cohort/transcriptFrequency.py
@@ -11,7 +11,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils.sparkline import whitePadSparklineAxis
 from wholecell.analysis.analysis_tools import exportFigure
@@ -25,8 +24,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		return
 
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		allDir = ap.get_cells(generation = [3])
+		allDir = self.ap.get_cells(generation = [3])
 
 		if len(allDir) <= 1:
 			print("Skipping -- transcriptFrequency only runs for multiple seeds")

--- a/models/ecoli/analysis/cohort/transcriptionGenomeCoverage.py
+++ b/models/ecoli/analysis/cohort/transcriptionGenomeCoverage.py
@@ -10,7 +10,6 @@ from six.moves import cPickle
 import numpy as np
 import matplotlib.pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import cohortAnalysisPlot
@@ -36,8 +35,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		mRnaNamesSorted = mRnaNames[descendingOrderIndexing]
 
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
-		all_cells = ap.get_cells()
+		all_cells = self.ap.get_cells()
 
 		# Get number of mRNAs transcribed
 		transcribedFreq = []

--- a/models/ecoli/analysis/cohort/transcriptionGenomeCoverageSecondHalf.py
+++ b/models/ecoli/analysis/cohort/transcriptionGenomeCoverageSecondHalf.py
@@ -10,7 +10,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import cohortAnalysisPlot
@@ -36,13 +35,12 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		mRnaNamesSorted = mRnaNames[descendingOrderIndexing]
 
 		# Get all cells in each seed
-		ap = AnalysisPaths(variantDir, cohort_plot = True)
 
-		if ap.n_generation == 1:
+		if self.ap.n_generation == 1:
 			print("Only runs for 2 or more cells.")
 			return
 
-		second_half_cells = ap.get_cells(generation=range(ap.n_generation//2,ap.n_generation))
+		second_half_cells = self.ap.get_cells(generation=range(self.ap.n_generation//2,self.ap.n_generation))
 
 		# Get number of mRNAs transcribed
 		transcribedFreq = []

--- a/models/ecoli/analysis/multigen/aa_conc.py
+++ b/models/ecoli/analysis/multigen/aa_conc.py
@@ -11,7 +11,6 @@ import numpy as np
 from six.moves import cPickle, range
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
@@ -26,11 +25,10 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		aa_ids = sim_data.molecule_groups.amino_acids
 		targets = np.array([sim_data.process.metabolism.conc_dict[key].asNumber(units.mmol / units.L) for key in aa_ids])
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
 
 		aa_conc = None
 		time = None
-		for sim_dir in ap.get_cells():
+		for sim_dir in self.ap.get_cells():
 			simOutDir = os.path.join(sim_dir, 'simOut')
 
 			# Load data

--- a/models/ecoli/analysis/multigen/aa_growth_limits.py
+++ b/models/ecoli/analysis/multigen/aa_growth_limits.py
@@ -15,7 +15,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 from wholecell.utils import units
 
@@ -33,8 +32,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		media = sim_data.conditions[sim_data.condition]['nutrients']
 		expected_supply = (sim_data.translation_supply_rate[media] * sim_data.constants.n_avogadro).asNumber(1 / units.fg / units.s)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		# Load data
 		times = read_stacked_columns(cell_paths, 'Main', 'time', remove_first=True) / 60

--- a/models/ecoli/analysis/multigen/aa_supply.py
+++ b/models/ecoli/analysis/multigen/aa_supply.py
@@ -15,7 +15,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 from wholecell.utils import units
 
@@ -33,8 +32,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		media = sim_data.conditions[sim_data.condition]['nutrients']
 		expected_supply = (sim_data.translation_supply_rate[media] * sim_data.constants.n_avogadro).asNumber(1 / units.fg / units.s)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		# Load data
 		times = read_stacked_columns(cell_paths, 'Main', 'time', remove_first=True) / 60

--- a/models/ecoli/analysis/multigen/aa_supply_enzymes.py
+++ b/models/ecoli/analysis/multigen/aa_supply_enzymes.py
@@ -12,7 +12,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.processes.metabolism import CONC_UNITS
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 from wholecell.utils import units
@@ -103,8 +102,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		attenuated_indices = transcription.attenuated_rna_indices
 		n_rnas = len(transcription.rna_data)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		# Load data
 		times = read_stacked_columns(cell_paths, 'Main', 'time', remove_first=True) / 60

--- a/models/ecoli/analysis/multigen/biosynthesisProductionDynamics.py
+++ b/models/ecoli/analysis/multigen/biosynthesisProductionDynamics.py
@@ -9,7 +9,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from wholecell.io.tablereader import TableReader
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
 
@@ -19,9 +18,8 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		with open(simDataFile, 'rb') as f:
 			sim_data = pickle.load(f)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
-		allDirs = ap.get_cells()
+		allDirs = self.ap.get_cells()
 
 		tfs = [
 			"putA", "aldA", "gdhA", "carA", "carB", "argD",

--- a/models/ecoli/analysis/multigen/carRegulation.py
+++ b/models/ecoli/analysis/multigen/carRegulation.py
@@ -12,16 +12,14 @@ from six.moves import cPickle, range
 
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
 
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
-		allDirs = ap.get_cells()
+		allDirs = self.ap.get_cells()
 
 		# Load data from KB
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/cellCycleLength.py
+++ b/models/ecoli/analysis/multigen/cellCycleLength.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 import numpy as np
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -18,10 +17,9 @@ from models.ecoli.analysis import multigenAnalysisPlot
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		cellCycleLengths = []
 		generations = []

--- a/models/ecoli/analysis/multigen/centralCarbonMetabolismCorrelationTimeCourse.py
+++ b/models/ecoli/analysis/multigen/centralCarbonMetabolismCorrelationTimeCourse.py
@@ -6,7 +6,6 @@ from six.moves import cPickle
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 
@@ -28,10 +27,9 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		cellDensity = sim_data.constants.cell_density
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		plt.figure(figsize = (8.5, 11))
 

--- a/models/ecoli/analysis/multigen/centralCarbonMetabolismScatter.py
+++ b/models/ecoli/analysis/multigen/centralCarbonMetabolismScatter.py
@@ -11,7 +11,6 @@ import re
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.utils.sparkline import whitePadSparklineAxis
@@ -26,9 +25,8 @@ from six.moves import zip
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
-		# allDir = ap.get_cells(generation = [0, 1, 2])
+		allDir = self.ap.get_cells()
+		# allDir = self.ap.get_cells(generation = [0, 1, 2])
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 		metaboliteNames = np.array(sorted(sim_data.process.metabolism.conc_dict.keys()))

--- a/models/ecoli/analysis/multigen/charging_molecules.py
+++ b/models/ecoli/analysis/multigen/charging_molecules.py
@@ -20,7 +20,6 @@ from matplotlib.ticker import FormatStrFormatter
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 from wholecell.analysis.plotting_tools import COLORS_SMALL
@@ -107,7 +106,6 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		mol_ids = sim_data.molecule_ids
 		ppgpp_molecules = [mol_ids.RelA, mol_ids.SpoT, mol_ids.ppGpp]
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
 
 		# Create plot and axes
 		n_subplots = 13
@@ -140,7 +138,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		total_growth = 0.
 		total_ppgpp = 0.
 		timesteps = 0.
-		for sim_dir in ap.get_cells():
+		for sim_dir in self.ap.get_cells():
 			simOutDir = os.path.join(sim_dir, 'simOut')
 
 			# Listeners used

--- a/models/ecoli/analysis/multigen/environmental_shift_fluxes.py
+++ b/models/ecoli/analysis/multigen/environmental_shift_fluxes.py
@@ -10,7 +10,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.utils.sparkline import whitePadSparklineAxis
@@ -30,8 +29,7 @@ MA_WIDTH = 15
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 		rxnStoich = sim_data.process.metabolism.reaction_stoich

--- a/models/ecoli/analysis/multigen/functionalUnits.py
+++ b/models/ecoli/analysis/multigen/functionalUnits.py
@@ -6,7 +6,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.containers.bulk_objects_container import BulkObjectsContainer
 from wholecell.analysis.analysis_tools import exportFigure
@@ -58,8 +57,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			return
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Load sim data
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/growthAffectingPolymerases.py
+++ b/models/ecoli/analysis/multigen/growthAffectingPolymerases.py
@@ -7,7 +7,6 @@ from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
@@ -19,13 +18,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get first cell from each generation
 		firstCellLineage = []
 
-		for gen_idx in range(ap.n_generation):
-			firstCellLineage.append(ap.get_cells(generation = [gen_idx])[0])
+		for gen_idx in range(self.ap.n_generation):
+			firstCellLineage.append(self.ap.get_cells(generation = [gen_idx])[0])
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 

--- a/models/ecoli/analysis/multigen/growth_trajectory.py
+++ b/models/ecoli/analysis/multigen/growth_trajectory.py
@@ -13,7 +13,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 
 
@@ -53,8 +52,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		else:
 			timeline = []
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		_, axes = plt.subplots(3, 2, figsize=(8, 12))
 

--- a/models/ecoli/analysis/multigen/kineticsFluxComparison.py
+++ b/models/ecoli/analysis/multigen/kineticsFluxComparison.py
@@ -18,7 +18,6 @@ import numpy as np
 from six.moves import cPickle, zip
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.processes.metabolism import COUNTS_UNITS, VOLUME_UNITS, TIME_UNITS, MASS_UNITS
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.analysis.plotting_tools import COLORS_LARGE
@@ -36,9 +35,8 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
-		# allDir = ap.get_cells(generation = [0, 1, 2])
+		allDir = self.ap.get_cells()
+		# allDir = self.ap.get_cells(generation = [0, 1, 2])
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 

--- a/models/ecoli/analysis/multigen/limitedEnzymeGlutcyslig.py
+++ b/models/ecoli/analysis/multigen/limitedEnzymeGlutcyslig.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from models.ecoli.processes.metabolism import COUNTS_UNITS, TIME_UNITS, VOLUME_UNITS
 from wholecell.analysis.analysis_tools import exportFigure
@@ -25,8 +24,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		metaboliteId = "GLUTATHIONE[c]"
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		simOutDir = os.path.join(allDir[0], "simOut")
 		bulkMolecules = TableReader(os.path.join(simOutDir, "BulkMolecules"))

--- a/models/ecoli/analysis/multigen/limitedEnzymeUgd.py
+++ b/models/ecoli/analysis/multigen/limitedEnzymeUgd.py
@@ -10,7 +10,6 @@ from six.moves import cPickle
 import numpy as np
 import matplotlib.pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from models.ecoli.processes.metabolism import COUNTS_UNITS, TIME_UNITS, VOLUME_UNITS
 from wholecell.analysis.analysis_tools import exportFigure
@@ -20,8 +19,7 @@ from models.ecoli.analysis import multigenAnalysisPlot
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 		enzymeComplexId = "CPLX0-8098[c]"

--- a/models/ecoli/analysis/multigen/limitedMetabolites.py
+++ b/models/ecoli/analysis/multigen/limitedMetabolites.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -21,8 +20,7 @@ WINDOW = 50
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		fig, axesList = plt.subplots(3)
 		fig.set_size_inches(11, 11)

--- a/models/ecoli/analysis/multigen/massFractionSummary.py
+++ b/models/ecoli/analysis/multigen/massFractionSummary.py
@@ -4,7 +4,6 @@ import os
 
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -12,10 +11,9 @@ from models.ecoli.analysis import multigenAnalysisPlot
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		massNames = [
 					"dryMass",

--- a/models/ecoli/analysis/multigen/massFractionToUnity.py
+++ b/models/ecoli/analysis/multigen/massFractionToUnity.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -14,14 +13,13 @@ from six.moves import range
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# TODO: Declutter Y-axis
 
 		# Get first cell from each generation
 		firstCellLineage = []
-		for gen_idx in range(ap.n_generation):
-			firstCellLineage.append(ap.get_cells(generation = [gen_idx])[0])
+		for gen_idx in range(self.ap.n_generation):
+			firstCellLineage.append(self.ap.get_cells(generation = [gen_idx])[0])
 
 		massNames = [
 					#"dryMass",

--- a/models/ecoli/analysis/multigen/massShift.py
+++ b/models/ecoli/analysis/multigen/massShift.py
@@ -6,7 +6,6 @@ from six.moves import cPickle
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -16,7 +15,6 @@ NUM_SKIP_TIMESTEPS_AT_GEN_CHANGE = 1
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		T_ADD_AA = None
@@ -29,9 +27,9 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 				T_CUT_AA = sim_data.external_state.saved_timelines[current_timeline_id][2][0]
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 		nCells = allDir.shape[0]
-		nGens = ap.n_generation
+		nGens = self.ap.n_generation
 
 		massNames = ["dryMass", "proteinMass", "rnaMass", "dnaMass",]
 		cleanNames = ["Dry mass", "Protein mass", "RNA Mass", "DNA mass",]

--- a/models/ecoli/analysis/multigen/mene_limitations.py
+++ b/models/ecoli/analysis/multigen/mene_limitations.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils.sparkline import whitePadSparklineAxis
 from wholecell.utils import units
@@ -42,12 +41,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		metaboliteIds = ["REDUCED-MENAQUINONE[c]", "CPD-12115[c]"]
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		if 0 not in ap._path_data["seed"]:
+		if 0 not in self.ap._path_data["seed"]:
 			print("Skipping -- figure5D only runs for seed 0")
 			return
 
-		allDir = ap.get_cells(seed = [0])
+		allDir = self.ap.get_cells(seed = [0])
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 		cellDensity = sim_data.constants.cell_density

--- a/models/ecoli/analysis/multigen/polycistronic_transcription.py
+++ b/models/ecoli/analysis/multigen/polycistronic_transcription.py
@@ -8,7 +8,6 @@ import os
 from matplotlib import pyplot as plt
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import (exportFigure, read_stacked_columns)
 from wholecell.io.tablereader import TableReader
 
@@ -20,8 +19,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		with open(simDataFile, 'rb') as f:
 			sim_data = pickle.load(f)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		simOutDir = os.path.join(cell_paths[0], "simOut")
 		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'mRNACounts'))

--- a/models/ecoli/analysis/multigen/ppgpp_regulation.py
+++ b/models/ecoli/analysis/multigen/ppgpp_regulation.py
@@ -9,7 +9,6 @@ from matplotlib.gridspec import GridSpec
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_bulk_molecules, read_stacked_columns
 
 
@@ -43,8 +42,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		synthase_order = ['relA', 'spoT']
 
 		# Load simulation output
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 		time = read_stacked_columns(cell_paths, 'Main', 'time').squeeze() / 60  # min
 		counts_to_molar = read_stacked_columns(cell_paths, 'EnzymeKinetics', 'countsToMolar').squeeze()
 		synth_prob_per_cistron = read_stacked_columns(cell_paths, 'RnaSynthProb', 'rna_synth_prob_per_cistron')

--- a/models/ecoli/analysis/multigen/probProteinExistAndDouble.py
+++ b/models/ecoli/analysis/multigen/probProteinExistAndDouble.py
@@ -7,7 +7,6 @@ from matplotlib import pyplot as plt
 from six.moves import cPickle, range
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 
@@ -23,12 +22,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		monomerExistMultigen = np.zeros((n_sims, n_monomers), dtype = bool)
 		monomerDoubleMultigen = np.zeros((n_sims, n_monomers), dtype = bool)
@@ -72,10 +70,10 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			probDoubleByBurstSize[idx] = monomerDoubleMultigen[mask].sum() / float(mask.sum())
 
 		# Calculate generational standard deviation (row is generation, col is burst size)
-		probExistByBurstSizeGen = np.zeros((ap.n_generation, uniqueBurstSizes.size))
-		probDoubleByBurstSizeGen = np.zeros((ap.n_generation, uniqueBurstSizes.size))
+		probExistByBurstSizeGen = np.zeros((self.ap.n_generation, uniqueBurstSizes.size))
+		probDoubleByBurstSizeGen = np.zeros((self.ap.n_generation, uniqueBurstSizes.size))
 
-		for gen_idx in range(ap.n_generation):
+		for gen_idx in range(self.ap.n_generation):
 			for idx, burstSize in enumerate(uniqueBurstSizes):
 				mask = initiationEventsPerMonomerMultigen[gen_idx,:] == burstSize
 

--- a/models/ecoli/analysis/multigen/proteinAvgCountVsBurstSize.py
+++ b/models/ecoli/analysis/multigen/proteinAvgCountVsBurstSize.py
@@ -6,7 +6,6 @@ from six.moves import cPickle
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -20,12 +19,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		monomerExistMultigen = np.zeros((n_sims, n_monomers), dtype = bool)
 		ratioFinalToInitialCountMultigen = np.zeros((n_sims, n_monomers), dtype = float)

--- a/models/ecoli/analysis/multigen/proteinCountVsFoldChange.py
+++ b/models/ecoli/analysis/multigen/proteinCountVsFoldChange.py
@@ -6,7 +6,6 @@ from six.moves import cPickle
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -19,12 +18,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		monomerExistMultigen = np.zeros((n_sims, n_monomers), dtype = bool)
 		ratioFinalToInitialCountMultigen = np.zeros((n_sims, n_monomers), dtype = float)

--- a/models/ecoli/analysis/multigen/proteinCountsValidation.py
+++ b/models/ecoli/analysis/multigen/proteinCountsValidation.py
@@ -13,7 +13,6 @@ from six.moves import cPickle
 from wholecell.io.tablereader import TableReader
 from wholecell.utils.protein_counts import get_simulated_validation_counts
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
 
@@ -29,9 +28,8 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		schmidt_counts = validation_data.protein.schmidt2015Data["glucoseCounts"]
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		sim_schmidt_counts_multigen = []
 

--- a/models/ecoli/analysis/multigen/proteinExistVsBurstSize.py
+++ b/models/ecoli/analysis/multigen/proteinExistVsBurstSize.py
@@ -6,7 +6,6 @@ from six.moves import cPickle
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -20,12 +19,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		monomerExistMultigen = np.zeros((n_sims, n_monomers), dtype = bool)
 		ratioFinalToInitialCountMultigen = np.zeros((n_sims, n_monomers), dtype = bool)

--- a/models/ecoli/analysis/multigen/proteinFoldChangeVsRnaDeg.py
+++ b/models/ecoli/analysis/multigen/proteinFoldChangeVsRnaDeg.py
@@ -6,7 +6,6 @@ from six.moves import cPickle
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.analysis.analysis_tools import exportFigure
@@ -24,12 +23,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		ratioFinalToInitialCountMultigen = np.zeros((n_sims, n_monomers), dtype = float)
 		initiationEventsPerMonomerMultigen = np.zeros((n_sims, n_monomers), dtype = int)

--- a/models/ecoli/analysis/multigen/proteinFoldChangeVsTranscriptionEvents.py
+++ b/models/ecoli/analysis/multigen/proteinFoldChangeVsTranscriptionEvents.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 
@@ -21,12 +20,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		ratioFinalToInitialCountMultigen = np.zeros((n_sims, n_monomers), dtype = float)
 		initiationEventsPerMonomerMultigen = np.zeros((n_sims, n_monomers), dtype = int)

--- a/models/ecoli/analysis/multigen/proteinFoldChangeVsTranslationEff.py
+++ b/models/ecoli/analysis/multigen/proteinFoldChangeVsTranslationEff.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 
@@ -21,12 +20,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Pre-allocate variables. Rows = Generations, Cols = Monomers
 		n_monomers = sim_data.process.translation.monomer_data['id'].size
-		n_sims = ap.n_generation
+		n_sims = self.ap.n_generation
 
 		monomerExistMultigen = np.zeros((n_sims, n_monomers), dtype = bool)
 		ratioFinalToInitialCountMultigen = np.zeros((n_sims, n_monomers), dtype = float)

--- a/models/ecoli/analysis/multigen/replication.py
+++ b/models/ecoli/analysis/multigen/replication.py
@@ -6,7 +6,6 @@ from six.moves import cPickle
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -21,10 +20,9 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 		genomeLength = len(sim_data.process.replication.genome_sequence)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# noinspection PyTypeChecker
 		fig, axesList = plt.subplots(6, sharex = True)

--- a/models/ecoli/analysis/multigen/ribosomeProduction.py
+++ b/models/ecoli/analysis/multigen/ribosomeProduction.py
@@ -7,7 +7,6 @@ from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
@@ -19,12 +18,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get first cell from each generation
 		firstCellLineage = []
-		for gen_idx in range(ap.n_generation):
-			firstCellLineage.append(ap.get_cells(generation = [gen_idx])[0])
+		for gen_idx in range(self.ap.n_generation):
+			firstCellLineage.append(self.ap.get_cells(generation = [gen_idx])[0])
 
 		sim_data = cPickle.load(open(simDataFile, "rb"))
 

--- a/models/ecoli/analysis/multigen/ribosomeUsage.py
+++ b/models/ecoli/analysis/multigen/ribosomeUsage.py
@@ -11,7 +11,6 @@ from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.analysis.analysis_tools import exportFigure
@@ -20,14 +19,13 @@ from models.ecoli.analysis import multigenAnalysisPlot
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get first cell from each generation
 		firstCellLineage = []
 
 		# For all generation indexes subject to analysis, get first cell
-		for gen_idx in range(ap.n_generation):
-			firstCellLineage.append(ap.get_cells(generation = [gen_idx])[0])
+		for gen_idx in range(self.ap.n_generation):
+			firstCellLineage.append(self.ap.get_cells(generation = [gen_idx])[0])
 
 		# Get sim data from cPickle file
 		sim_data = cPickle.load(open(simDataFile, "rb"))
@@ -140,25 +138,25 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 			# ax1: Plot timestep
 			ax1.plot(time.asNumber(units.min), timeStep.asNumber(units.s), linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax1.set_xlim([-5, max(time.asNumber(units.min))])
 			ax1.set_ylabel("Length of\ntime step (s)")
 
 			# ax2: Plot cell volume
 			ax2.plot(time.asNumber(units.min), cellVolume.asNumber(units.L), linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax2.set_xlim([-5, max(time.asNumber(units.min))])
 			ax2.set_ylabel("Cell volume\n(L)")
 
 			# ax3: Plot total ribosome counts
 			ax3.plot(time.asNumber(units.min), totalRibosomeCounts, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax3.set_xlim([-5, max(time.asNumber(units.min))])
 			ax3.set_ylabel("Total ribosome\ncount")
 
 			# ax4: Plot total ribosome concentrations
 			ax4.plot(time.asNumber(units.min), totalRibosomeConcentration.asNumber(units.mmol / units.L), linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax4.set_xlim([-5, max(time.asNumber(units.min))])
 			ax4.set_ylabel("[Total ribosome]\n(mM)")
 
@@ -167,7 +165,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 				ax5.plot(time[1:].asNumber(units.min), activeRibosomeCounts[1:], linestyle='-')
 			else:
 				ax5.plot(time.asNumber(units.min), activeRibosomeCounts, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax5.set_xlim([-5, max(time.asNumber(units.min))])
 			ax5.set_ylabel("Active ribosome\ncount")
 
@@ -176,7 +174,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 				ax6.plot(time[1:].asNumber(units.min), activeRibosomeConcentration[1:].asNumber(units.mmol / units.L), linestyle='-')
 			else:
 				ax6.plot(time.asNumber(units.min), activeRibosomeConcentration.asNumber(units.mmol / units.L), linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax6.set_xlim([-5, max(time.asNumber(units.min))])
 			ax6.set_ylabel("[Active ribosome]\n(mM)")
 
@@ -185,7 +183,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 				ax7.plot(time[1:].asNumber(units.min), molarFractionActive[1:], linestyle='-')
 			else:
 				ax7.plot(time.asNumber(units.min), molarFractionActive, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax7.set_xlim([-5, max(time.asNumber(units.min))])
 			ax7.set_ylabel("Molar fraction\nactive ribosomes")
 
@@ -194,43 +192,43 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 				ax8.plot(time[1:].asNumber(units.min), massFractionActive[1:], linestyle='-')
 			else:
 				ax8.plot(time.asNumber(units.min), massFractionActive, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax8.set_xlim([-5, max(time.asNumber(units.min))])
 			ax8.set_ylabel("Mass fraction\nactive ribosomes")
 
 			# ax9: Plot number of activations
 			ax9.plot(time.asNumber(units.min), didInitialize, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax9.set_xlim([-5, max(time.asNumber(units.min))])
 			ax9.set_ylabel("Activations\nper timestep")
 
 			# ax10: Plot number of deactivations (terminated translations)
 			ax10.plot(time.asNumber(units.min), didTerminate, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax10.set_xlim([-5, max(time.asNumber(units.min))])
 			ax10.set_ylabel("Deactivations\nper timestep")
 
 			# ax11: Plot number of activations per time * volume
 			ax11.plot(time.asNumber(units.min), didInitialize / (timeStep.asNumber(units.s) * cellVolume.asNumber(units.L)), linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax11.set_xlim([-5, max(time.asNumber(units.min))])
 			ax11.set_ylabel("Activations\nper time*volume")
 
 			# ax12: Plot number of deactivations per time * volume
 			ax12.plot(time.asNumber(units.min), didTerminate / (timeStep.asNumber(units.s) * cellVolume.asNumber(units.L)), linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax12.set_xlim([-5, max(time.asNumber(units.min))])
 			ax12.set_ylabel("Deactivations\nper time*volume")
 
 			# ax13: Plot number of amino acids translated in each timestep
 			ax13.plot(time.asNumber(units.min), actualElongations, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax13.set_xlim([-5, max(time.asNumber(units.min))])
 			ax13.set_ylabel("AA translated")
 
 			# ax14: Plot effective ribosome elongation rate for each timestep
 			ax14.plot(time.asNumber(units.min), effectiveElongationRate, linestyle='-')
-			if gen == ap.n_generation - 1:
+			if gen == self.ap.n_generation - 1:
 				ax14.set_xlim([-5, max(time.asNumber(units.min))])
 			ax14.set_ylabel("Effective\nelongation rate")
 

--- a/models/ecoli/analysis/multigen/rnaVsProteinPerCell.py
+++ b/models/ecoli/analysis/multigen/rnaVsProteinPerCell.py
@@ -10,7 +10,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.containers.bulk_objects_container import BulkObjectsContainer
 import matplotlib.lines as mlines
@@ -49,8 +48,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			return
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Load sim data
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/rna_decay_03_high.py
+++ b/models/ecoli/analysis/multigen/rna_decay_03_high.py
@@ -22,7 +22,6 @@ from matplotlib import pyplot as plt
 from six.moves import cPickle, range
 
 from wholecell.io.tablereader import TableReader
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.utils import units
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -54,10 +53,9 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		cistron_idxs = [all_cistron_ids.index(x) for x in cistron_ids]
 		deg_rates = sim_data.process.transcription.cistron_data['deg_rate'][cistron_idxs]
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		rna_cistron_degraded_counts = []
 		rna_cistron_counts = []

--- a/models/ecoli/analysis/multigen/subgenerationalTranscription.py
+++ b/models/ecoli/analysis/multigen/subgenerationalTranscription.py
@@ -10,7 +10,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils.sparkline import whitePadSparklineAxis
 from wholecell.analysis.analysis_tools import exportFigure
@@ -33,11 +32,10 @@ def remove_xaxis(axis):
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		if 0 not in ap._path_data["seed"]:
+		if 0 not in self.ap._path_data["seed"]:
 			print("Skipping -- figure5B only runs for seed 0")
 			return
-		allDir = ap.get_cells(seed = [0])
+		allDir = self.ap.get_cells(seed = [0])
 
 		if len(allDir) <= 1:
 			print("Skipping -- figure5B only runs for multigen")

--- a/models/ecoli/analysis/multigen/template.py
+++ b/models/ecoli/analysis/multigen/template.py
@@ -10,7 +10,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import (exportFigure,
 	read_bulk_molecule_counts, read_stacked_bulk_molecules, read_stacked_columns)
 from wholecell.io.tablereader import TableReader
@@ -23,8 +22,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		with open(validationDataFile, 'rb') as f:
 			validation_data = pickle.load(f)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		# Load data
 		## Simple stacking functions for data from all cells

--- a/models/ecoli/analysis/multigen/tf_binding.py
+++ b/models/ecoli/analysis/multigen/tf_binding.py
@@ -12,7 +12,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import multigenAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_bulk_molecules, read_stacked_columns
 
 
@@ -92,8 +91,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 				# Dummy ID for 0CS since there is no inactive form
 				inactive_ids.append(tf + '[c]')
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot=True)
-		cell_paths = ap.get_cells()
+		cell_paths = self.ap.get_cells()
 
 		# Read data for all cells
 		times = read_stacked_columns(cell_paths, 'Main', 'time') / 60

--- a/models/ecoli/analysis/multigen/timeStep.py
+++ b/models/ecoli/analysis/multigen/timeStep.py
@@ -4,7 +4,6 @@ import os
 
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -12,10 +11,9 @@ from models.ecoli.analysis import multigenAnalysisPlot
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		plt.figure(figsize = (8.5, 11))
 

--- a/models/ecoli/analysis/multigen/transcriptionEvents.py
+++ b/models/ecoli/analysis/multigen/transcriptionEvents.py
@@ -10,7 +10,6 @@ from six.moves import cPickle
 import numpy as np
 import matplotlib.pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -21,8 +20,7 @@ N_GENES_TO_PLOT = -1
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Get mRNA data
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/transcriptionFrequency.py
+++ b/models/ecoli/analysis/multigen/transcriptionFrequency.py
@@ -14,7 +14,6 @@ from bokeh.plotting import figure, ColumnDataSource
 import matplotlib.pyplot as plt
 import numpy as np
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.analysis import multigenAnalysisPlot
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
@@ -26,8 +25,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Get mRNA data
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/transcriptionFrequencyOrdered.py
+++ b/models/ecoli/analysis/multigen/transcriptionFrequencyOrdered.py
@@ -11,7 +11,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -22,8 +21,7 @@ N_GENES_TO_PLOT = -1
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		validation_data = cPickle.load(open(validationDataFile, "rb"))
 		essential_cistrons = validation_data.essential_genes.essential_cistrons

--- a/models/ecoli/analysis/multigen/transcriptionGenomeCoverage.py
+++ b/models/ecoli/analysis/multigen/transcriptionGenomeCoverage.py
@@ -10,7 +10,6 @@ from six.moves import cPickle
 import numpy as np
 import matplotlib.pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.analysis.analysis_tools import exportFigure
@@ -22,8 +21,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		return
 
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Get IDs of mRNAs
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/translationFrequency.py
+++ b/models/ecoli/analysis/multigen/translationFrequency.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -18,8 +17,7 @@ from models.ecoli.analysis import multigenAnalysisPlot
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all cells
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		proteinPresence = []
 		for simDir in allDir:

--- a/models/ecoli/analysis/multigen/transport_comparison.py
+++ b/models/ecoli/analysis/multigen/transport_comparison.py
@@ -5,7 +5,6 @@ import os
 
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
@@ -22,10 +21,9 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		with open(validationDataFile, 'rb') as f:
 			validation_data = cPickle.load(f)
 
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
 		# Get all cells
-		allDir = ap.get_cells()
+		allDir = self.ap.get_cells()
 
 		# Constants
 		aa_c_ids = sim_data.molecule_groups.amino_acids

--- a/models/ecoli/analysis/multigen/trpRegulation.py
+++ b/models/ecoli/analysis/multigen/trpRegulation.py
@@ -13,16 +13,14 @@ from six.moves import cPickle, range
 
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
 
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
-		allDirs = ap.get_cells()
+		allDirs = self.ap.get_cells()
 
 		# Load data from KB
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/trpSynthaseCapacityVsUsage.py
+++ b/models/ecoli/analysis/multigen/trpSynthaseCapacityVsUsage.py
@@ -10,7 +10,6 @@ from matplotlib import pyplot as plt
 from six.moves import cPickle
 
 from wholecell.io.tablereader import TableReader
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
 
@@ -19,9 +18,8 @@ BURN_IN = 10
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
-		allDirs = ap.get_cells()
+		allDirs = self.ap.get_cells()
 
 		# Load data from KB
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/multigen/tyrRegulation.py
+++ b/models/ecoli/analysis/multigen/tyrRegulation.py
@@ -12,16 +12,14 @@ from six.moves import cPickle
 
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import multigenAnalysisPlot
 
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(seedOutDir, multi_gen_plot = True)
 
-		allDirs = ap.get_cells()
+		allDirs = self.ap.get_cells()
 
 		# Load data from KB
 		sim_data = cPickle.load(open(simDataFile, "rb"))

--- a/models/ecoli/analysis/variant/aa_synthesis_sensitivity.py
+++ b/models/ecoli/analysis/variant/aa_synthesis_sensitivity.py
@@ -11,7 +11,6 @@ import numpy as np
 from scipy import stats
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.sim.variants import aa_synthesis_sensitivity
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 
@@ -45,8 +44,7 @@ def calculate_sensitivity(data, variant, factors, attr, default=None):
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
 		with open(simDataFile, 'rb') as f:
 			sim_data = pickle.load(f)
@@ -63,7 +61,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			param_label = f'{aa_adjusted} {param}'
 
 			# Load data
-			cells = ap.get_cells(variant=[variant])
+			cells = self.ap.get_cells(variant=[variant])
 			growth_rate = read_stacked_columns(cells, 'Mass', 'instantaneous_growth_rate',
 				remove_first=True, ignore_exception=True).mean()
 			elong_rate = read_stacked_columns(cells, 'RibosomeData', 'effectiveElongationRate',

--- a/models/ecoli/analysis/variant/aa_uptake_sensitivity.py
+++ b/models/ecoli/analysis/variant/aa_uptake_sensitivity.py
@@ -10,7 +10,6 @@ from matplotlib import colors, pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.sim.variants.aa_uptake_sensitivity import get_aa_index, get_factor
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 from wholecell.utils import units
@@ -22,8 +21,7 @@ CONTROL_LABEL = 'Control'
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
 		with open(simDataFile, 'rb') as f:
 			sim_data = pickle.load(f)
@@ -63,7 +61,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		control_elong_rates = []
 		for variant in variants:
 			# Load data
-			cells = ap.get_cells(variant=[variant])
+			cells = self.ap.get_cells(variant=[variant])
 			growth_rate = read_stacked_columns(cells, 'Mass', 'instantaneous_growth_rate',
 				remove_first=True, ignore_exception=True).mean()
 			elong_rate = read_stacked_columns(cells, 'RibosomeData', 'effectiveElongationRate',

--- a/models/ecoli/analysis/variant/adder_sizer.py
+++ b/models/ecoli/analysis/variant/adder_sizer.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import variantAnalysisPlot
 from wholecell.io.tablereader import TableReader
@@ -21,9 +20,8 @@ trim = 0.05
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot = True)
 
-		if ap.n_generation == 1:
+		if self.ap.n_generation == 1:
 			print("Need more data to create addedMass")
 			return
 
@@ -42,7 +40,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		title_list = ["Glucose minimal\n" + r"$\tau = $" + "44 min", "Glucose minimal anaerobic\n" + r"$\tau = $" + "100 min", "Glucose minimal + 20 amino acids\n" + r"$\tau = $" + "22 min"]
 
 		plot = False
-		for varIdx in ap.get_variants():
+		for varIdx in self.ap.get_variants():
 
 			if varIdx == 0:
 				plotIdx = 1
@@ -59,7 +57,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			initial_masses = np.zeros(0)
 			final_masses = np.zeros(0)
 
-			all_cells = ap.get_cells(generation=gen, variant=[varIdx])
+			all_cells = self.ap.get_cells(generation=gen, variant=[varIdx])
 			if len(all_cells) == 0:
 				continue
 			plot = True

--- a/models/ecoli/analysis/variant/cell_growth.py
+++ b/models/ecoli/analysis/variant/cell_growth.py
@@ -13,7 +13,6 @@ import numpy as np
 from scipy.stats import pearsonr
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
@@ -102,8 +101,7 @@ def remove_border(ax, bottom=False):
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
 		with open(simDataFile, 'rb') as f:
 			sim_data = pickle.load(f)
@@ -134,7 +132,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			glc_yields = []
 			ppgpps = []
 			count = 0
-			for sim_dir in ap.get_cells(variant=[variant]):
+			for sim_dir in self.ap.get_cells(variant=[variant]):
 				glc_yield = 0
 				try:
 					sim_out_dir = os.path.join(sim_dir, "simOut")

--- a/models/ecoli/analysis/variant/doubling_time_histogram.py
+++ b/models/ecoli/analysis/variant/doubling_time_histogram.py
@@ -2,7 +2,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 
 
@@ -28,7 +27,6 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		ax.legend()
 
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
 
 		doubling_times = {}
 		growth_rates = {}
@@ -40,8 +38,8 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 				x = x[:-extra_points]
 			return x.reshape(-1, n_downsample).mean(1).reshape(-1, 1)
 
-		for variant in ap.get_variants():
-			all_cells = ap.get_cells(variant=[variant], only_successful=True)
+		for variant in self.ap.get_variants():
+			all_cells = self.ap.get_cells(variant=[variant], only_successful=True)
 			if len(all_cells) == 0:
 				continue
 

--- a/models/ecoli/analysis/variant/growthConditionComparison.py
+++ b/models/ecoli/analysis/variant/growthConditionComparison.py
@@ -12,7 +12,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import variantAnalysisPlot
@@ -25,8 +24,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot = True)
-		all_cells = ap.get_cells()
+		all_cells = self.ap.get_cells()
 
 		rnaToProteinDict = {}
 		dnaToProteinDict = {}
@@ -34,7 +32,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		stableRnaFractionDict = {}
 		doublingPerHourDict = {}
 
-		variantSimDataFile = ap.get_variant_kb(ap.get_variants()[0])
+		variantSimDataFile = self.ap.get_variant_kb(self.ap.get_variants()[0])
 		sim_data = cPickle.load(open(variantSimDataFile, "rb"))
 		nAvogadro = sim_data.constants.n_avogadro.asNumber()
 		chromMass = (sim_data.getter.get_mass(sim_data.molecule_ids.full_chromosome) / sim_data.constants.n_avogadro).asNumber()

--- a/models/ecoli/analysis/variant/growth_condition_comparison_validation.py
+++ b/models/ecoli/analysis/variant/growth_condition_comparison_validation.py
@@ -7,7 +7,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 
 from wholecell.utils.sparkline import whitePadSparklineAxis
@@ -19,7 +18,6 @@ FONT_SIZE=9
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot = True)
 
 		fig = plt.figure()
 		fig.set_figwidth(5)
@@ -33,26 +31,26 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		bremer_rna_mass_per_cell = [77, 20,  211]
 		bremer_elng_rate = [18, 12,  21]
 
-		sim_doubling_time = np.zeros(ap.n_variant)
-		sim_doubling_time_std = np.zeros(ap.n_variant)
+		sim_doubling_time = np.zeros(self.ap.n_variant)
+		sim_doubling_time_std = np.zeros(self.ap.n_variant)
 
-		sim_origins_per_cell_at_initiation = np.zeros(ap.n_variant)
-		sim_rna_mass_per_cell = np.zeros(ap.n_variant)
-		sim_elng_rate = np.zeros(ap.n_variant)
-		sim_rrn_init_rate = np.zeros(ap.n_variant)
+		sim_origins_per_cell_at_initiation = np.zeros(self.ap.n_variant)
+		sim_rna_mass_per_cell = np.zeros(self.ap.n_variant)
+		sim_elng_rate = np.zeros(self.ap.n_variant)
+		sim_rrn_init_rate = np.zeros(self.ap.n_variant)
 
-		sim_origins_per_cell_at_initiation_std = np.zeros(ap.n_variant)
-		sim_elng_rate_std = np.zeros(ap.n_variant)
-		sim_rna_mass_per_cell_std = np.zeros(ap.n_variant)
-		sim_rrn_init_rate_std = np.zeros(ap.n_variant)
+		sim_origins_per_cell_at_initiation_std = np.zeros(self.ap.n_variant)
+		sim_elng_rate_std = np.zeros(self.ap.n_variant)
+		sim_rna_mass_per_cell_std = np.zeros(self.ap.n_variant)
+		sim_rrn_init_rate_std = np.zeros(self.ap.n_variant)
 
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
-		for varIdx in range(ap.n_variant):
+		for varIdx in range(self.ap.n_variant):
 			variant = variants[varIdx]
-			all_cells = ap.get_cells(variant=[variant])
+			all_cells = self.ap.get_cells(variant=[variant])
 			try:
-				sim_data = cPickle.load(open(ap.get_variant_kb(variant), 'rb'))
+				sim_data = cPickle.load(open(self.ap.get_variant_kb(variant), 'rb'))
 			except Exception as e:
 				print("Couldn't load sim_data object. Exiting.", e)
 				return

--- a/models/ecoli/analysis/variant/growth_correlations.py
+++ b/models/ecoli/analysis/variant/growth_correlations.py
@@ -19,7 +19,6 @@ import numpy as np
 from scipy import stats
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 from wholecell.io.tablereader import TableReader
 
@@ -65,8 +64,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			aa_ids[aa_ids == original] = replacement
 		removed_mask = np.array([aa not in REMOVED_NAMES for aa in aa_ids], dtype=bool)
 
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 		n_variants = len(variants)
 
 		scaling = 3
@@ -75,7 +73,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		gs = gridspec.GridSpec(nrows=n_variants, ncols=n_cols)
 
 		for row, variant in enumerate(variants):
-			cell_paths = ap.get_cells(variant=[variant])
+			cell_paths = self.ap.get_cells(variant=[variant])
 
 			# Load attributes
 			unique_molecule_reader = TableReader(os.path.join(cell_paths[0], 'simOut', 'UniqueMoleculeCounts'))

--- a/models/ecoli/analysis/variant/growth_expression_comparison.py
+++ b/models/ecoli/analysis/variant/growth_expression_comparison.py
@@ -14,7 +14,6 @@ import numpy as np
 from scipy import stats
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 from wholecell.io.tablereader import TableReader
 
@@ -56,16 +55,15 @@ def compare_to_validation(parca, validation):
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
 		minimal_sim = None
 		rich_sim = None
 		for variant in variants:
-			with open(ap.get_variant_kb(variant), 'rb') as f:
+			with open(self.ap.get_variant_kb(variant), 'rb') as f:
 				variant_sim_data = pickle.load(f)
 
-			cell_paths = ap.get_cells(variant=[variant])
+			cell_paths = self.ap.get_cells(variant=[variant])
 			if variant_sim_data.condition == 'basal':
 				minimal_sim = read_counts(cell_paths)
 			elif variant_sim_data.condition == 'with_aa':

--- a/models/ecoli/analysis/variant/growth_rate_time_series.py
+++ b/models/ecoli/analysis/variant/growth_rate_time_series.py
@@ -12,7 +12,6 @@ from matplotlib import gridspec
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 from wholecell.utils import units
 
@@ -24,8 +23,7 @@ HALF_WINDOW = MOVING_WINDOW // 2
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 		n_variants = len(variants)
 
 		with open(simDataFile, 'rb') as f:
@@ -38,7 +36,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		# Get average growth rate in the control simulation if it was run
 		control_variant = aa_ids.index(CONTROL_LABEL)
 		if control_variant in variants:
-			cell_paths = ap.get_cells(variant=[control_variant])
+			cell_paths = self.ap.get_cells(variant=[control_variant])
 			control_growth_rate = read_stacked_columns(cell_paths, 'Mass', 'instantaneous_growth_rate', remove_first=True, ignore_exception=True).mean()
 		else:
 			control_growth_rate = 1
@@ -65,9 +63,9 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			cmap = plt.get_cmap('tab10')
 
 			# Plot moving average of growth rate and horizontal line of average for each initial seed
-			for seed in range(ap.n_seed):
+			for seed in range(self.ap.n_seed):
 				color = cmap(seed)
-				cell_paths = ap.get_cells(variant=[variant], seed=[seed])
+				cell_paths = self.ap.get_cells(variant=[variant], seed=[seed])
 				times = read_stacked_columns(cell_paths, 'Main', 'time', remove_first=True, ignore_exception=True) / 3600
 				growth_rates = read_stacked_columns(cell_paths, 'Mass', 'instantaneous_growth_rate',
 					remove_first=True, ignore_exception=True).squeeze()

--- a/models/ecoli/analysis/variant/growth_trajectory.py
+++ b/models/ecoli/analysis/variant/growth_trajectory.py
@@ -14,7 +14,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
 
 
@@ -61,8 +60,7 @@ def set_lim(ax, xmin=0, xmax=0.6, ymin=0, ymax=2):
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
 		# Create plot
 		_, main_axes = plt.subplots(3, 2, figsize=(8, 12))
@@ -74,7 +72,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		growth_function = lambda x: np.diff(x, axis=0) / x[:-1]
 		average_data = {}
 		for variant in variants:
-			with open(ap.get_variant_kb(variant), 'rb') as f:
+			with open(self.ap.get_variant_kb(variant), 'rb') as f:
 				sim_data = pickle.load(f)
 			if sim_data.external_state.current_timeline_id:
 				timeline = sim_data.external_state.saved_timelines[sim_data.external_state.current_timeline_id]
@@ -94,9 +92,9 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			all_growth = []
 			all_ratio = []
 			data_to_plot = False
-			for seed in ap.get_seeds(variant):
-				cell_paths = ap.get_cells(variant=[variant], seed=[seed])
-				if len(cell_paths) == 0 or not ap.get_successful(cell_paths[-1]):
+			for seed in self.ap.get_seeds(variant):
+				cell_paths = self.ap.get_cells(variant=[variant], seed=[seed])
+				if len(cell_paths) == 0 or not self.ap.get_successful(cell_paths[-1]):
 					continue
 
 				# Load data

--- a/models/ecoli/analysis/variant/massFractionSummary.py
+++ b/models/ecoli/analysis/variant/massFractionSummary.py
@@ -6,7 +6,6 @@ import itertools
 from matplotlib import pyplot as plt
 from six.moves import zip
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.analysis import variantAnalysisPlot
 from wholecell.analysis.plotting_tools import COLORS_LARGE
 from wholecell.analysis.analysis_tools import exportFigure
@@ -34,8 +33,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 					"DNA\nmass"
 					]
 
-		ap = AnalysisPaths(inputDir, variant_plot = True)
-		all_cells = ap.get_cells()
+		all_cells = self.ap.get_cells()
 
 		# Build a mapping from variant id to color
 		idToColor = {}
@@ -65,7 +63,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 				if cellCycleTime > currentMaxTime:
 					currentMaxTime = cellCycleTime
 
-				axesList[massIdx].set_xlim(0, currentMaxTime*ap.n_generation*1.1)
+				axesList[massIdx].set_xlim(0, currentMaxTime*self.ap.n_generation*1.1)
 				axesList[massIdx].set_ylabel(cleanNames[massIdx] + " (fg)")
 
 		for idx, axes in enumerate(axesList):

--- a/models/ecoli/analysis/variant/meneSensitivity.py
+++ b/models/ecoli/analysis/variant/meneSensitivity.py
@@ -10,7 +10,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle, range
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import units
 from wholecell.utils.sparkline import whitePadSparklineAxis
@@ -28,13 +27,12 @@ MARKERSIZE = 1
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get cells
-		ap = AnalysisPaths(inputDir, variant_plot = True)
-		if ap.n_variant != 9:
+		if self.ap.n_variant != 9:
 			print("This plot expects all variants of mene_params")
 			return
 
 		# Get constants from wildtype variant
-		sim_data = cPickle.load(open(ap.get_variant_kb(4), "rb")) # 4 is the wildtype variant
+		sim_data = cPickle.load(open(self.ap.get_variant_kb(4), "rb")) # 4 is the wildtype variant
 		cellDensity = sim_data.constants.cell_density
 		nAvogadro = sim_data.constants.n_avogadro
 
@@ -44,14 +42,14 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		TARGET_CONC = len(endProductIds) * TARGET_CONC_SINGLE
 
 		# Investigate each variant
-		meneDepletion = np.zeros([ap.n_seed, ap.n_variant])
-		endProductDepletion = np.zeros([ap.n_seed, ap.n_variant])
+		meneDepletion = np.zeros([self.ap.n_seed, self.ap.n_variant])
+		endProductDepletion = np.zeros([self.ap.n_seed, self.ap.n_variant])
 
 		simOutDir = None
 
-		for variant in range(ap.n_variant):
-			for seed in range(ap.n_seed):
-				cells = ap.get_cells(variant = [variant], seed = [seed])
+		for variant in range(self.ap.n_variant):
+			for seed in range(self.ap.n_seed):
+				cells = self.ap.get_cells(variant = [variant], seed = [seed])
 				timeMeneDepleted = [] # seconds
 				timeEndProdDepleted = [] # seconds
 
@@ -100,7 +98,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		# Plot
 		fig, axesList = plt.subplots(2, 1, figsize = (8, 8))
 		ax1, ax2 = axesList
-		xvals = np.arange(ap.n_variant)
+		xvals = np.arange(self.ap.n_variant)
 		fig.suptitle("Sensitivity Analysis: menE depletion")
 
 		for ax, avg, std in zip(axesList, [meneDepletion_avg, endProductDepletion_avg], [meneDepletion_std, endProductDepletion_std]):

--- a/models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py
+++ b/models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py
@@ -12,9 +12,9 @@ from matplotlib import pyplot as plt
 import numpy as np
 from six.moves import cPickle, range
 
+from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.analysis import variantAnalysisPlot
 from models.ecoli.processes.metabolism import COUNTS_UNITS, VOLUME_UNITS, TIME_UNITS
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader
 from wholecell.utils import parallelization, units
@@ -193,10 +193,9 @@ def analyze_variant(args):
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 		n_variants = len(variants)
-		total_sims = ap.n_seed * ap.n_generation
+		total_sims = self.ap.n_seed * self.ap.n_generation
 
 		if n_variants <= 1:
 			print('This plot {} only runs for multiple variants'.format(__name__))
@@ -229,7 +228,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		pool = parallelization.pool(num_processes=self.cpus)
 		args = list(zip(
 			variants,
-			[ap] * n_variants,
+			[self.ap] * n_variants,
 			[toya_reactions] * n_variants,
 			[toya_fluxes] * n_variants,
 			[outlier_filter] * n_variants

--- a/models/ecoli/analysis/variant/metabolism_secretion_penalty.py
+++ b/models/ecoli/analysis/variant/metabolism_secretion_penalty.py
@@ -14,7 +14,6 @@ from matplotlib import gridspec
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.sim.variants.metabolism_secretion_penalty import SECRETION_PENALTY
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader
@@ -51,8 +50,7 @@ def plot_fluxes(gs, col, selected, x_vals, fluxes, labels):
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 		n_variants = len(variants)
 
 		all_doubling_times = np.zeros(n_variants)
@@ -67,7 +65,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 
 			doubling_times = []
 			exchange_fluxes = []
-			for sim_dir in ap.get_cells(variant=[variant]):
+			for sim_dir in self.ap.get_cells(variant=[variant]):
 				simOutDir = os.path.join(sim_dir, "simOut")
 
 				# Listeners used

--- a/models/ecoli/analysis/variant/param_sensitivity.py
+++ b/models/ecoli/analysis/variant/param_sensitivity.py
@@ -166,8 +166,8 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			return
 
 		global ap
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = np.array(ap.get_variants())
+		ap = self.ap
+		variants = np.array(self.ap.get_variants())
 
 		# Check to analyze control (variant 0) separately from other variants
 		use_control = False

--- a/models/ecoli/analysis/variant/ppgpp_conc.py
+++ b/models/ecoli/analysis/variant/ppgpp_conc.py
@@ -11,7 +11,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.analysis.single.ribosome_limitation import calculate_ribosome_excesses
 from models.ecoli.sim.variants.ppgpp_conc import BASE_FACTOR, CONDITIONS, split_index
 from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns, read_stacked_bulk_molecules
@@ -58,8 +57,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		charged_trna_names = transcription.charged_trna_names
 		aa_from_trna = transcription.aa_from_trna.T
 
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 		n_variants = len(variants)
 
 		conditions = np.zeros(n_variants, int)
@@ -103,7 +101,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		enzyme_protein_fraction_mean = np.zeros(n_variants)
 		enzyme_protein_fraction_std = np.zeros(n_variants)
 		for i, variant in enumerate(variants):
-			all_cells = ap.get_cells(variant=[variant], only_successful=True)
+			all_cells = self.ap.get_cells(variant=[variant], only_successful=True)
 			conditions[i], factors[i] = split_index(variant)
 
 			unique_molecule_reader = TableReader(os.path.join(all_cells[0], 'simOut', 'UniqueMoleculeCounts'))

--- a/models/ecoli/analysis/variant/remove_aa_inhibition.py
+++ b/models/ecoli/analysis/variant/remove_aa_inhibition.py
@@ -17,7 +17,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.sim.variants.remove_aa_inhibition import AA_TO_ENZYME, get_aa_and_ki_factor
 from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
@@ -119,8 +118,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
 		aa_ids = sorted({aa for aas in HEATMAP_COLS for aa in aas[1]})
 		aa_idx = {aa: i for i, aa in enumerate(aa_ids)}
@@ -134,7 +132,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		ki_factors = []
 		for i, variant in enumerate(variants):
 			variant_conc = []
-			for sim_dir in ap.get_cells(variant=[variant], only_successful=True):
+			for sim_dir in self.ap.get_cells(variant=[variant], only_successful=True):
 				simOutDir = os.path.join(sim_dir, "simOut")
 
 				# Listeners used

--- a/models/ecoli/analysis/variant/template.py
+++ b/models/ecoli/analysis/variant/template.py
@@ -10,7 +10,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.analysis.analysis_tools import (exportFigure,
 	read_bulk_molecule_counts, read_stacked_bulk_molecules, read_stacked_columns)
 from wholecell.io.tablereader import TableReader
@@ -23,17 +22,16 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		with open(validationDataFile, 'rb') as f:
 			validation_data = pickle.load(f)
 
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 
 		for variant in variants:
 			# Load modified variant sim_data
 			## Consider calculating variant difference and only loading
 			## sim_data once above for better performance.
-			with open(ap.get_variant_kb(variant), 'rb') as f:
+			with open(self.ap.get_variant_kb(variant), 'rb') as f:
 				variant_sim_data = pickle.load(f)
 
-			cell_paths = ap.get_cells(variant=[variant])
+			cell_paths = self.ap.get_cells(variant=[variant])
 
 			# Load data
 			## Simple stacking functions for data from all cells

--- a/models/ecoli/analysis/variant/tfFit.py
+++ b/models/ecoli/analysis/variant/tfFit.py
@@ -12,7 +12,6 @@ import numpy as np
 from six.moves import cPickle
 import scipy.stats
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.analysis import variantAnalysisPlot
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
@@ -29,8 +28,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			print("This plot only runs for the 'tf_activity' variant.")
 			return
 
-		ap = AnalysisPaths(inputDir, variant_plot = True)
-		variants = sorted(ap._path_data['variant'].tolist()) # Sorry for accessing private data
+		variants = sorted(self.ap._path_data['variant'].tolist()) # Sorry for accessing private data
 
 		if 0 in variants:
 			variants.remove(0)
@@ -38,7 +36,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		if len(variants) == 0:
 			return
 
-		all_cells = sorted(ap.get_cells(variant = variants, seed = [0], generation = [0]))
+		all_cells = sorted(self.ap.get_cells(variant = variants, seed = [0], generation = [0]))
 
 		expectedProbBound = []
 		simulatedProbBound = []
@@ -49,7 +47,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		targetToTfType = {}
 
 		for variant, simDir in zip(variants, all_cells):
-			sim_data = cPickle.load(open(ap.get_variant_kb(variant), "rb"))
+			sim_data = cPickle.load(open(self.ap.get_variant_kb(variant), "rb"))
 
 			delta_prob = sim_data.process.transcription_regulation.delta_prob
 

--- a/models/ecoli/analysis/variant/tfFitComparison.py
+++ b/models/ecoli/analysis/variant/tfFitComparison.py
@@ -6,7 +6,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from six.moves import cPickle
 
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from wholecell.io.tablereader import TableReader
 from wholecell.analysis.analysis_tools import exportFigure
 from models.ecoli.analysis import variantAnalysisPlot
@@ -21,8 +20,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			print("This plot only runs for the 'tf_activity' variant.")
 			return
 
-		ap = AnalysisPaths(inputDir, variant_plot = True)
-		variants = sorted(ap._path_data['variant'].tolist()) # Sorry for accessing private data
+		variants = sorted(self.ap._path_data['variant'].tolist()) # Sorry for accessing private data
 
 		if 0 in variants:
 			variants.remove(0)
@@ -30,7 +28,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		if len(variants) == 0:
 			return
 
-		all_cells = sorted(ap.get_cells(variant = variants, seed = [0], generation = [0]))
+		all_cells = sorted(self.ap.get_cells(variant = variants, seed = [0], generation = [0]))
 
 		expectedProbBound = [[], [], []]
 		simulatedProbBound = [[], [], []]
@@ -39,7 +37,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 
 		for variant, simDir in zip(variants, all_cells):
 
-			sim_data = cPickle.load(open(ap.get_variant_kb(variant), "rb"))
+			sim_data = cPickle.load(open(self.ap.get_variant_kb(variant), "rb"))
 			tfList = ["basal (no TF)"] + sorted(sim_data.tf_to_active_inactive_conditions)
 			simOutDir = os.path.join(simDir, "simOut")
 			tf = tfList[(variant + 1) // 2]

--- a/models/ecoli/analysis/variant/time_step.py
+++ b/models/ecoli/analysis/variant/time_step.py
@@ -13,7 +13,6 @@ from matplotlib import gridspec
 import numpy as np
 
 from models.ecoli.analysis import variantAnalysisPlot
-from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
 from models.ecoli.sim.variants.time_step import TIME_STEP_FACTOR
 from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
 from wholecell.io.tablereader import TableReader
@@ -43,8 +42,7 @@ def plot_bar(gs, x, y, y_label, show_x=False):
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		ap = AnalysisPaths(inputDir, variant_plot=True)
-		variants = ap.get_variants()
+		variants = self.ap.get_variants()
 		n_variants = len(variants)
 
 		with open(simDataFile, 'rb') as f:
@@ -88,7 +86,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			trna_fold_changes = []
 			rrna_fold_changes = []
 			mrna_fold_changes = []
-			for sim_dir in ap.get_cells(variant=[variant]):
+			for sim_dir in self.ap.get_cells(variant=[variant]):
 				simOutDir = os.path.join(sim_dir, "simOut")
 
 				# Listeners used


### PR DESCRIPTION
See #1250 - this changes the analysis scripts to take advantage of the new framework.

I used `sed` to remove imports and `ap = AnalysisPaths...` and switch from `ap.*` to `self.ap.*` so there might be some edge cases that I missed where the format was not the same.