### PR TITLE
Set text to be editable in illustrator

### DIFF
--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,3 +1,6 @@
 # Set the backend globally to Agg (non-interactive backend)
 backend: Agg
 
+# Set for editable text in illustrator with a widely available font
+pdf.fonttype: 42
+font.sans-serif: Arial


### PR DESCRIPTION
This makes an update to our matplotlibrc file so that output pdf files now have editable text when opened in illustrator instead of individual strokes for each character.  This should make editing these for paper figures much easier.  It also sets arial as the default font since this seems to be widely available on most machines.

old illustrator:
![image](https://user-images.githubusercontent.com/18123227/156816963-074522fd-91e6-43cc-b4ea-f5fd7e79acfd.png)

new illustrator:
![image](https://user-images.githubusercontent.com/18123227/156817049-748fba6e-ae91-4db6-9410-455960f625ed.png)
