### PR TITLE
Add sim option to disable ppGpp elongation inhibition

### DIFF
--- a/models/ecoli/processes/polypeptide_elongation.py
+++ b/models/ecoli/processes/polypeptide_elongation.py
@@ -41,6 +41,7 @@ class PolypeptideElongation(wholecell.processes.process.Process):
 		self.mechanistic_translation_supply = sim._mechanistic_translation_supply
 		self.mechanistic_aa_transport = sim._mechanistic_aa_transport
 		self.ppgpp_regulation = sim._ppgpp_regulation
+		self.disable_ppgpp_elongation_inhibition = sim._disable_ppgpp_elongation_inhibition
 		self.variable_elongation = sim._variable_elongation_translation
 		self.variable_polymerize = self.ppgpp_regulation or self.variable_elongation
 		translation_supply = sim._translationSupply
@@ -435,7 +436,7 @@ class SteadyStateElongationModel(TranslationSupplyElongationModel):
 		self.aa_exporters = self.process.bulkMoleculesView(metabolism.aa_exporter_names)
 
 	def elongation_rate(self):
-		if self.process.ppgpp_regulation:
+		if self.process.ppgpp_regulation and not self.process.disable_ppgpp_elongation_inhibition:
 			cell_mass = self.process.readFromListener("Mass", "cellMass") * units.fg
 			cell_volume = cell_mass / self.cellDensity
 			counts_to_molar = 1 / (self.process.n_avogadro * cell_volume)

--- a/runscripts/fireworks/fw_queue.py
+++ b/runscripts/fireworks/fw_queue.py
@@ -100,6 +100,10 @@ Modeling options:
 		effect if TRNA_CHARGING option is used.
 	PPGPP_REGULATION (int, "0"): if nonzero, ppGpp concentration is determined
 		with kinetic equations
+	DISABLE_PPGPP_ELONGATION_INHIBITION (int, "0"): if nonzero, ppGpp inhibition
+		of ribosome elongation (GTPase inhibition) is turned off (max elongation
+		rate is not dependent on ppGpp).  Only has an effect if
+		PPGPP_REGULATION option is used.
 	SUPERHELICAL_DENSITY (int, "0"): if nonzero, dynamically compute
 		superhelical densities of each DNA fragment
 	RECYCLE_STALLED_ELONGATION (int "0"): if nonzero, recycle RNAP and fragment
@@ -287,6 +291,7 @@ TRANSLATION_SUPPLY = bool(int(get_environment("TRANSLATION_SUPPLY", DEFAULT_SIMU
 TRNA_CHARGING = bool(int(get_environment("TRNA_CHARGING", DEFAULT_SIMULATION_KWARGS["trna_charging"])))
 AA_SUPPLY_IN_CHARGING = bool(int(get_environment("AA_SUPPLY_IN_CHARGING", DEFAULT_SIMULATION_KWARGS["aa_supply_in_charging"])))
 PPGPP_REGULATION = bool(int(get_environment("PPGPP_REGULATION", DEFAULT_SIMULATION_KWARGS["ppgpp_regulation"])))
+DISABLE_PPGPP_ELONGATION_INHIBITION = bool(int(get_environment("DISABLE_PPGPP_ELONGATION_INHIBITION", DEFAULT_SIMULATION_KWARGS["disable_ppgpp_elongation_inhibition"])))
 SUPERHELICAL_DENSITY = bool(int(get_environment("SUPERHELICAL_DENSITY", DEFAULT_SIMULATION_KWARGS["superhelical_density"])))
 RECYCLE_STALLED_ELONGATION = bool(int(get_environment("RECYCLE_STALLED_ELONGATION", DEFAULT_SIMULATION_KWARGS["recycle_stalled_elongation"])))
 MECHANISTIC_REPLISOME = bool(int(get_environment("MECHANISTIC_REPLISOME", DEFAULT_SIMULATION_KWARGS["mechanistic_replisome"])))
@@ -451,6 +456,7 @@ class WorkflowBuilder:
 			"trna_charging": TRNA_CHARGING,
 			"aa_supply_in_charging": AA_SUPPLY_IN_CHARGING,
 			"ppgpp_regulation": PPGPP_REGULATION,
+			"disable_ppgpp_elongation_inhibition": DISABLE_PPGPP_ELONGATION_INHIBITION,
 			"superhelical_density": SUPERHELICAL_DENSITY,
 			"recycle_stalled_elongation": RECYCLE_STALLED_ELONGATION,
 			"mechanistic_replisome": MECHANISTIC_REPLISOME,
@@ -733,6 +739,7 @@ class WorkflowBuilder:
 							trna_charging=TRNA_CHARGING,
 							aa_supply_in_charging=AA_SUPPLY_IN_CHARGING,
 							ppgpp_regulation=PPGPP_REGULATION,
+							disable_ppgpp_elongation_inhibition=DISABLE_PPGPP_ELONGATION_INHIBITION,
 							superhelical_density=SUPERHELICAL_DENSITY,
 							recycle_stalled_elongation=RECYCLE_STALLED_ELONGATION,
 							mechanistic_replisome=MECHANISTIC_REPLISOME,

--- a/wholecell/fireworks/firetasks/simulation.py
+++ b/wholecell/fireworks/firetasks/simulation.py
@@ -35,6 +35,7 @@ class SimulationTask(FiretaskBase):
 		"trna_charging",
 		"aa_supply_in_charging",
 		"ppgpp_regulation",
+		"disable_ppgpp_elongation_inhibition",
 		"superhelical_density",
 		"recycle_stalled_elongation",
 		"mechanistic_replisome",
@@ -79,6 +80,7 @@ class SimulationTask(FiretaskBase):
 		options["trna_charging"] = self._get_default("trna_charging")
 		options["aa_supply_in_charging"] = self._get_default("aa_supply_in_charging")
 		options["ppgpp_regulation"] = self._get_default("ppgpp_regulation")
+		options["disable_ppgpp_elongation_inhibition"] = self._get_default("disable_ppgpp_elongation_inhibition")
 		options["superhelical_density"] = self._get_default("superhelical_density")
 		options["recycle_stalled_elongation"] = self._get_default("recycle_stalled_elongation")
 		options["mechanistic_replisome"] = self._get_default("mechanistic_replisome")

--- a/wholecell/fireworks/firetasks/simulationDaughter.py
+++ b/wholecell/fireworks/firetasks/simulationDaughter.py
@@ -36,6 +36,7 @@ class SimulationDaughterTask(FiretaskBase):
 		"trna_charging",
 		"aa_supply_in_charging",
 		"ppgpp_regulation",
+		"disable_ppgpp_elongation_inhibition",
 		"superhelical_density",
 		"recycle_stalled_elongation",
 		"mechanistic_replisome",
@@ -81,6 +82,7 @@ class SimulationDaughterTask(FiretaskBase):
 		options["trna_charging"] = self._get_default("trna_charging")
 		options["aa_supply_in_charging"] = self._get_default("aa_supply_in_charging")
 		options["ppgpp_regulation"] = self._get_default("ppgpp_regulation")
+		options["disable_ppgpp_elongation_inhibition"] = self._get_default("disable_ppgpp_elongation_inhibition")
 		options["superhelical_density"] = self._get_default("superhelical_density")
 		options["recycle_stalled_elongation"] = self._get_default("recycle_stalled_elongation")
 		options["mechanistic_replisome"] = self._get_default("mechanistic_replisome")

--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -39,6 +39,7 @@ DEFAULT_SIMULATION_KWARGS = dict(
 	trna_charging = True,
 	aa_supply_in_charging = False,
 	ppgpp_regulation = False,
+	disable_ppgpp_elongation_inhibition = False,
 	superhelical_density = False,
 	recycle_stalled_elongation = False,
 	mechanistic_replisome = True,

--- a/wholecell/utils/scriptBase.py
+++ b/wholecell/utils/scriptBase.py
@@ -39,6 +39,7 @@ METADATA_KEYS = (
 	'trna_charging',
 	'aa_supply_in_charging',
 	'ppgpp_regulation',
+	'disable_ppgpp_elongation_inhibition',
 	'superhelical_density',
 	'recycle_stalled_elongation',
 	'mechanistic_replisome',
@@ -74,6 +75,7 @@ SIM_KEYS = (
 	'trna_charging',
 	'aa_supply_in_charging',
 	'ppgpp_regulation',
+	'disable_ppgpp_elongation_inhibition',
 	'superhelical_density',
 	'recycle_stalled_elongation',
 	'mechanistic_replisome',
@@ -500,6 +502,10 @@ class ScriptBase(metaclass=abc.ABCMeta):
 				 ' Only has an effect if --trna-charging option is used.')
 		add_bool_option('ppgpp_regulation', 'ppgpp_regulation',
 			help='if true, ppGpp concentration is determined with kinetic equations.')
+		add_bool_option('disable_ppgpp_elongation_inhibition', 'disable_ppgpp_elongation_inhibition',
+			help='if nonzero, ppGpp inhibition of ribosome elongation (GTPase'
+				 ' inhibition) is turned off (max elongation rate is not dependent'
+				 ' on ppGpp).  Only has an effect if --ppgpp-regulation option is used.')
 		add_bool_option('superhelical_density', 'superhelical_density',
 			help='if true, dynamically calculate superhelical densities of each DNA segment')
 		add_bool_option('recycle_stalled_elongation', 'recycle_stalled_elongation',


### PR DESCRIPTION
This adds a new sim option (`DISABLE_PPGPP_ELONGATION_INHIBITION` or `--disable_ppgpp_elongation_inhibition`) to disable the effect that ppGpp has on the translation elongation rate (through the abstracted inhibition of GTPases involved in translation).  It will only have an effect when ppGpp regulation is enabled.