### PR TITLE
Add rerun_lost_tasks.py script for fireworks on owners

### DIFF
--- a/runscripts/fireworks/rerun_lost_tasks.py
+++ b/runscripts/fireworks/rerun_lost_tasks.py
@@ -34,7 +34,7 @@ RUN_CMD = len(sys.argv) > 1 and sys.argv[1] == '-f'
 def get_fws(criteria):
 	result = json.loads(filepath.run_cmdline(f'lpad get_fws {criteria}', fallback='[]'))
 
-	# Handle single fw case to always make a lits of dicts
+	# Handle single fw case to always make a list of dicts
 	if isinstance(result, dict):
 		result = [result]
 	return result
@@ -81,7 +81,8 @@ while True:
 				if result is None:
 					filepath.run_cmdline('lpad admin unlock')
 			else:
-				print(f'Would rerun fw_ids {fws_to_rerun} if -f passed as arg')
+				print(f'Would rerun fw_ids {fws_to_rerun} if -f passed as arg. Manually rerun with:'
+					f'\n\tlpad rerun_fws -i {fws_to_rerun}')
 
 	# Sleep for a bit
 	print(f'{time.ctime()}: sleeping for {SLEEP} s...')


### PR DESCRIPTION
This adds a helper script for running large workflows on the owners partition on Sherlock where jobs can be preempted.  Preempted jobs do not have a way of updating the status in mongoDB to FIZZLED and will be stuck on RUNNING.  This checks the name of RUNNING tasks against those in slurm to see if any RUNNING tasks are not actually running.

Just run `runscripts/fireworks/rerun_lost_tasks.py -f` to automatically rerun tasks that are detected as stuck in running and it will check every 5 minutes.  I used the `-f` option to make debugging easier so that mongoDB wasn't actually updated at all.  Without `-f` the lost tasks are only printed and must be manually rerun.  We could remove that option to make it simpler to use.