### PR TITLE
Make operon variants by adding new transcription units

### DIFF
--- a/reconstruction/ecoli/flat/transcription_unit_prototypes/transcription_units_added_v1.tsv
+++ b/reconstruction/ecoli/flat/transcription_unit_prototypes/transcription_units_added_v1.tsv
@@ -1,0 +1,3 @@
+# Modifications to transcription units required to successfully run the model
+"id"	"common_name"	"genes"	"left_end_pos"	"right_end_pos"	"direction"	"evidence"	"_comments"
+"hisGDCBHAFI"	"hisGDCBHAFI"	["EG10449", "EG10447", "EG10446", "EG10445", "EG10450", "EG10444", "EG10448", "EG10451"]	2090192	2097225	"+"	[]	"Leader peptide hisL removed from TU00285 to allow for higher expression of all other enzymes; ParCa fails without this modification"

--- a/reconstruction/ecoli/flat/transcription_unit_prototypes/transcription_units_modified_v1.tsv
+++ b/reconstruction/ecoli/flat/transcription_unit_prototypes/transcription_units_modified_v1.tsv
@@ -1,3 +1,0 @@
-# Modifications to transcription units required to successfully run the model
-"id"	"common_name"	"genes"	"left_end_pos"	"right_end_pos"	"direction"	"_comments"
-"TU00285"	"hisGDCBHAFI"	["EG10449", "EG10447", "EG10446", "EG10445", "EG10450", "EG10444", "EG10448", "EG10451"]	2090192	2097225	"+"	"Leader peptide hisL removed to allow for higher expression of all other enzymes; ParCa fails without this modification"

--- a/reconstruction/ecoli/flat/transcription_units_added.tsv
+++ b/reconstruction/ecoli/flat/transcription_units_added.tsv
@@ -1,0 +1,4 @@
+"id"	"common_name"	"genes"	"left_end_pos"	"right_end_pos"	"direction"	"evidence"	"_comments"
+"hisGDCBHAFI"	"hisGDCBHAFI"	["EG10449", "EG10447", "EG10446", "EG10445", "EG10450", "EG10444", "EG10448", "EG10451"]	2090192	2097225	"+"	[]	"Leader peptide hisL removed from TU00285 to allow for higher expression of all other enzymes; ParCa fails without this modification"
+"rplKAJL"	"rplKAJL"	["EG10873", "EG10871", "EG10864", "EG10872"]	4178354	4180925	"+"	[]	"Suggested from R-end sequencing data (Lalanne et al., 2018) by the existence of a transcription terminator after rplL"
+"rplJL"	"rplJL"	["EG10871", "EG10873"]	4179623	4180925	"+"	[]	"Suggested from R-end sequencing data (Lalanne et al., 2018) by the existence of a transcription terminator after rplL"

--- a/reconstruction/ecoli/flat/transcription_units_modified.tsv
+++ b/reconstruction/ecoli/flat/transcription_units_modified.tsv
@@ -1,4 +1,0 @@
-"id"	"common_name"	"genes"	"left_end_pos"	"right_end_pos"	"direction"	"_comments"
-"TU00285"	"hisGDCBHAFI"	["EG10449", "EG10447", "EG10446", "EG10445", "EG10450", "EG10444", "EG10448", "EG10451"]	2090192	2097225	"+"	"Leader peptide hisL removed to allow for higher expression of all other enzymes; ParCa fails without this modification"
-"TU0-6512"	"rplKAJL"	["EG10873", "EG10871", "EG10864", "EG10872"]	4178354	4180925	"+"	"Truncated to allow for decoupled transcription of rpl and rpo genes"
-"TU00335"	"rplJL"	["EG10871", "EG10873"]	4179623	4180925	"+"	"Truncated to allow for decoupled transcription of rpl and rpo genes"

--- a/reconstruction/ecoli/knowledge_base_raw.py
+++ b/reconstruction/ecoli/knowledge_base_raw.py
@@ -67,7 +67,7 @@ LIST_OF_DICT_FILENAMES = [
 	"sequence_motifs.tsv",
 	"transcription_factors.tsv",
 	# "transcription_units.tsv",  # special cased in the constructor
-	"transcription_units_modified.tsv",
+	"transcription_units_added.tsv",
 	"transcription_units_removed.tsv",
 	"transcriptional_attenuation.tsv",
 	"transcriptional_attenuation_removed.tsv",
@@ -111,7 +111,7 @@ LIST_OF_DICT_FILENAMES = [
 	os.path.join("adjustments", "rna_deg_rates_adjustments.tsv"),
 	os.path.join("adjustments", "protein_deg_rates_adjustments.tsv"),
 	os.path.join("adjustments", "relative_metabolite_concentrations_changes.tsv"),
-	os.path.join('transcription_unit_prototypes', 'transcription_units_modified_v1.tsv'),
+	os.path.join('transcription_unit_prototypes', 'transcription_units_added_v1.tsv'),
 	]
 SEQUENCE_FILE = 'sequence.fasta'
 LIST_OF_PARAMETER_FILENAMES = (
@@ -147,12 +147,12 @@ ADDED_DATA = {
 	'trna_charging_reactions': 'trna_charging_reactions_added',
 	}
 
-# Dictionary mapping operon option names to the name of the modification file
+# Dictionary mapping operon option names to the name of the added operons file
 # corresponding to the option. Must be specified for every operon option except
 # "off".
-OPERON_OPTION_TO_MODIFIED_DATA = {
-	'v1': 'transcription_unit_prototypes.transcription_units_modified_v1',
-	'on': 'transcription_units_modified',
+OPERON_OPTION_TO_ADDED_DATA = {
+	'v1': 'transcription_unit_prototypes.transcription_units_added_v1',
+	'on': 'transcription_units_added',
 	}
 
 class DataStore(object):
@@ -180,8 +180,8 @@ class KnowledgeBaseEcoli(object):
 			self.removed_data.update({
 				'transcription_units': 'transcription_units_removed',
 				})
-			self.modified_data.update({
-				'transcription_units': OPERON_OPTION_TO_MODIFIED_DATA[self.operon_option],
+			self.added_data.update({
+				'transcription_units': OPERON_OPTION_TO_ADDED_DATA[self.operon_option],
 				})
 
 		# Load raw data from TSV files
@@ -281,7 +281,9 @@ class KnowledgeBaseEcoli(object):
 		for data_attr, attr_to_add in self.added_data.items():
 			# Get datasets to join
 			data = getattr(self, data_attr)
-			added_data = getattr(self, attr_to_add)
+			added_data = getattr(self, attr_to_add.split('.')[0])
+			for attr in attr_to_add.split('.')[1:]:
+				added_data = getattr(added_data, attr)
 
 			# Check columns are the same for each dataset
 			col_diff = set(data[0].keys()).symmetric_difference(added_data[0].keys())


### PR DESCRIPTION
This PR changes how we make sim_data objects for the operon variants by having them add new transcription units instead of modifying existing ones. Since we are making these calls for changes in the transcription unit structure mostly based on the existence of new promoters or terminators, it seemed more reasonable that we add more transcription units instead of removing some of the existing transcription units. This change should not lead to any functional differences in the model since it will choose to simply not use the original TUs based on the solution to the NNLS problem. 