### PR TITLE
Save numpy arrays for remove_aa_inhibition variant analysis

### DIFF
--- a/models/ecoli/analysis/variant/remove_aa_inhibition.py
+++ b/models/ecoli/analysis/variant/remove_aa_inhibition.py
@@ -174,10 +174,10 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 					conc[:, i, j] = aa_conc[key]
 					variance[:, i, j] = aa_var[key]
 
-		np.save('remove-inhib-conc-control.npy', control_conc)
-		np.save('remove-inhib-conc-control-var.npy', control_var)
-		np.save('remove-inhib-conc.npy', conc)
-		np.save('remove-inhib-conc-var.npy', variance)
+		np.save(os.path.join(plotOutDir, plotOutFileName + '_control.npy'), control_conc)
+		np.save(os.path.join(plotOutDir, plotOutFileName + '_control_var.npy'), control_var)
+		np.save(os.path.join(plotOutDir, plotOutFileName + '.npy'), conc)
+		np.save(os.path.join(plotOutDir, plotOutFileName + '_var.npy'), variance)
 
 		# Skip plotting if data does not exist
 		if len(aa_variants) == 0 or len(ki_factors) == 0:


### PR DESCRIPTION
This saves some of the data processed for the remove_aa_inhibition variant plot as an .npy file to use in an ad hoc analysis script I'm working on as part of the growth paper (to be added later).