### PR TITLE
Use second amino acid in monomer sequence for N-end rule if initial methionine is cleaved

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/translation.py
+++ b/reconstruction/ecoli/dataclasses/process/translation.py
@@ -138,7 +138,13 @@ class Translation(object):
 			if protein['id'] in measured_deg_rates:
 				deg_rate[i] = measured_deg_rates[protein['id']]
 			elif protein['id'] not in ribosomalProteins:
-				deg_rate[i] = n_end_rule_deg_rates[protein['seq'][0]]
+				seq = protein['seq']
+				assert seq[0] == 'M'  # All protein sequences should start with methionine
+
+				# Set N-end residue as second amino acid if initial methionine
+				# is cleaved
+				n_end_residue = seq[protein['cleavage_of_initial_methionine']]
+				deg_rate[i] = n_end_rule_deg_rates[n_end_residue]
 			else:
 				deg_rate[i] = slow_deg_rate
 


### PR DESCRIPTION
This PR fixes an error in our model that set the half-lives of most protein monomers to 10 hours, regardless of their actual N-terminal amino acid residue. Since EcoCyc lists the "full" sequence of each protein without cleavage of the initial methionine residue, the `proteins.tsv` file we imported from EcoCyc had methionine as the starting amino acid for all protein monomers. Since methionine is a slow-degrading N-terminal amino acid, this set the half-lives of all proteins in our model to 10 hours, except for the ones we have measured half-lives for. It looks like before this file was imported directly from EcoCyc, methionine was manually removed from some of the sequences by an undocumented procedure. Since the `proteins.tsv` file that we are importing has a column that tells us whether the initial methionine is cleaved (`"cleavage_of_initial_methionine"`), I simply used the second amino acid residue in the protein sequence for monomers where this column had the value of `1`.

Just these 7 protein monomers now have half-lives of 2 minutes instead of 10 hours as a result of this fix:

EG10506-MONOMER
EG10765-MONOMER
G7426-MONOMER
ISOCIT-LYASE-MONOMER
OROPRIBTRANS-MONOMER
PGPPHOSPHAB-MONOMER
PPENTOMUT-MONOMER