### PR TITLE
Elongate initiated transcripts and polypeptides in the same timestep

### DIFF
--- a/models/ecoli/sim/simulation.py
+++ b/models/ecoli/sim/simulation.py
@@ -71,14 +71,16 @@ class EcoliSimulation(Simulation):
 			TfBinding,
 		),
 		(
-			RnaDegradation,
 			TranscriptInitiation,
-			TranscriptElongation,
 			PolypeptideInitiation,
-			PolypeptideElongation,
 			ChromosomeReplication,
 			ProteinDegradation,
+			RnaDegradation,
 			Complexation,
+		),
+		(
+			TranscriptElongation,
+			PolypeptideElongation,
 		),
 		(
 			ChromosomeStructure,


### PR DESCRIPTION
This PR sets the `TranscriptElongation` and `PolypeptideElongation` processes to run after the `TranscriptInitiation` and `TranscriptElongation` processes, such that the transcripts and polypeptides that are newly initiated during a timestep starts to be elongated in the same timestep instead of the next. This will help remove timestep-dependent delays in the initiation of transcripts/polypeptides, and hopefully pave the way for more precise control of transcription/translation initiation frequencies that we hope to implement in future PRs. 