### PR TITLE
Add number of total init sims to metadata for fireworks workflows

### DIFF
--- a/models/ecoli/analysis/cohort/ecocyc_table.py
+++ b/models/ecoli/analysis/cohort/ecocyc_table.py
@@ -201,8 +201,8 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		ecocyc_metadata = {
 			'git_hash': metadata['git_hash'],
 			'n_ignored_generations': IGNORE_FIRST_N_GENS,
-			'n_total_generations': metadata['generations'],
-			'n_seeds': metadata['init_sims'],
+			'n_total_generations': metadata['total_gens'],
+			'n_seeds': metadata['total_init_sims'],
 			'n_cells': len(cell_paths),
 			'n_timesteps': len(counts_to_molar),
 			'protein_validation_r_squared': r**2,

--- a/runscripts/cloud/wcm.py
+++ b/runscripts/cloud/wcm.py
@@ -150,7 +150,9 @@ class WcmWorkflow(Workflow):
 			python=sys.version.splitlines()[0],
 			variant=variant_type,
 			total_variants=str(variant_count),
-			total_gens=args['generations'])
+			total_gens=args['generations'],
+			total_init_sims=args['init_sims'],
+		)
 
 		python_args = dict(output_file=metadata_file, data=metadata)  # type: Dict[str, Any]
 		metadata_task = self.add_python_task(WriteJsonTask, python_args,

--- a/runscripts/fireworks/fw_queue.py
+++ b/runscripts/fireworks/fw_queue.py
@@ -444,6 +444,7 @@ class WorkflowBuilder:
 			"time": SUBMISSION_TIME,
 			"python": sys.version.splitlines()[0],
 			"total_gens": N_GENS,
+			"total_init_sims": N_INIT_SIMS,
 			"analysis_type": None,
 			"variant": VARIANT,
 			"total_variants": str(len(VARIANTS_TO_RUN)),

--- a/runscripts/manual/runSim.py
+++ b/runscripts/manual/runSim.py
@@ -101,7 +101,9 @@ class RunSimulation(scriptBase.ScriptBase):
 			analysis_type=None,
 			variant=variant_type,
 			total_variants=str(variant_spec[2] + 1 - variant_spec[1]),
-			total_gens=args.total_gens or args.generations)
+			total_gens=args.total_gens or args.generations,
+			total_init_sims=args.total_init_sims or args.init_sims,
+			)
 		metadata_dir = fp.makedirs(args.sim_path, constants.METADATA_DIR)
 		metadata_path = os.path.join(metadata_dir, constants.JSON_METADATA_FILE)
 		fp.write_json_file(metadata_path, metadata)

--- a/wholecell/utils/scriptBase.py
+++ b/wholecell/utils/scriptBase.py
@@ -441,6 +441,10 @@ class ScriptBase(metaclass=abc.ABCMeta):
 		self.define_option(parser, 'init_sims', int, 1, flag='i',
 			help='Number of initial sims (cell lineages) per variant. The'
 				 ' lineages get sequential seeds starting with the --seed value.')
+		if manual_script:
+			parser.add_argument(dashize('--total_init_sims'), type=int,
+				help='(int) Total number of initial simulations to write into'
+					 ' the metadata.json file. Default = the value of init_sims.')
 
 	def define_sim_options(self, parser):
 		# type: (argparse.ArgumentParser) -> None


### PR DESCRIPTION
This PR adds to the simulation metadata the `N_INIT_SIMS` environmental variable if the simulations were run from a Fireworks workflow, and has the new EcoCyc table analysis script use this new value from the metadata. This should fix the daily build failures we had this morning. 