### PR TITLE
Add simple shell scripts to help build EcoCyc modeling tab files

### DIFF
--- a/models/ecoli/analysis/comparison/__init__.py
+++ b/models/ecoli/analysis/comparison/__init__.py
@@ -27,5 +27,4 @@ TAGS = {
 		"growth_histograms.py",
 		"massFractionComparison.py",
 		],
-	'ECOCYC': [],
 	}

--- a/models/ecoli/analysis/multigen/__init__.py
+++ b/models/ecoli/analysis/multigen/__init__.py
@@ -69,7 +69,6 @@ TAGS = {
 	'DIVISION': [
 		"cellCycleLength.py",
 		],
-	'ECOCYC': [],
 	'ENVIRONMENT_SHIFT': [
 		"aa_supply.py",
 		"environmental_shift_fluxes.py",  # TODO(jerry): include this?

--- a/models/ecoli/analysis/parca/__init__.py
+++ b/models/ecoli/analysis/parca/__init__.py
@@ -27,7 +27,6 @@ TAGS = {
 		'metabolite_concentrations.py',
 		'interpolation.py',
 		],
-	'ECOCYC': [],
 	'METABOLISM': [
 		'aa_synthesis_enzymes.py',
 		'aa_synthesis_pathways.py',

--- a/models/ecoli/analysis/single/__init__.py
+++ b/models/ecoli/analysis/single/__init__.py
@@ -95,7 +95,6 @@ TAGS = {
 		"rnapCounts.py",
 		"rnaseCounts.py",
 		],
-	'ECOCYC': [],
 	'PARCA': [
 		"KmOptimization.py",
 		"KmRNAdecayComparison.py",

--- a/models/ecoli/analysis/variant/__init__.py
+++ b/models/ecoli/analysis/variant/__init__.py
@@ -33,7 +33,6 @@ TAGS = {
 	'CORE': [           # the default list to run in development
 		"growthConditionComparison.py",
 		],
-	'ECOCYC': [],
 	'ENVIRONMENT_SHIFT': [
 		'growth_trajectory',
 		],


### PR DESCRIPTION
This PR adds some manual shell scripts that can be used on Sherlock to help build and export the `.tsv` files that need to be sent to EcoCyc to update the data on their modeling tabs. One of the scripts builds the fireworks workflow, and the other extracts the required files from the completed sims and exports them to a remote storage outside of Sherlock (I set it to be my Google Drive). I'll keep working on this feature to make the pipeline more streamlined in the future. The PR also adds an option to the `update_biocyc_files.py` file to use the EcoCyc preview server to update flat files.

@1fish2 Would it be trivial to have each class of analysis scripts skip a certain tag if the given tag doesn't exist for the class? For this PR I added an empty list under the tag `ECOCYC` for each class to avoid getting errors.
