### PR TITLE
Set the default mass of active replisomes to zero

### DIFF
--- a/models/ecoli/processes/chromosome_replication.py
+++ b/models/ecoli/processes/chromosome_replication.py
@@ -41,6 +41,14 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 		self.replication_coordinate = sim_data.process.transcription.rna_data[
 			"replication_coordinate"]
 		self.D_period = sim_data.process.replication.d_period.asNumber(units.s)
+		replisome_trimer_subunit_masses = np.vstack([
+			sim_data.getter.get_submass_array(x).asNumber(units.fg/units.count)
+			for x in sim_data.molecule_groups.replisome_trimer_subunits])
+		replisome_monomer_subunit_masses = np.vstack([
+			sim_data.getter.get_submass_array(x).asNumber(units.fg/units.count)
+			for x in sim_data.molecule_groups.replisome_monomer_subunits])
+		replisome_mass_array = 3*replisome_trimer_subunit_masses.sum(axis=0) + replisome_monomer_subunit_masses.sum(axis=0)
+		self.replisome_protein_mass = replisome_mass_array.sum()
 
 		# Create molecule views for replisome subunits, active replisomes,
 		# origins of replication, chromosome domains, and free active TFs
@@ -202,12 +210,16 @@ class ChromosomeReplication(wholecell.processes.process.Process):
 				np.array([True, False], dtype=bool), n_oriC)
 			domain_index_new_replisome = np.repeat(
 				domain_index_existing_oric, 2)
+			massDiff_protein_new_replisome = np.full(n_new_replisome,
+				self.replisome_protein_mass if self.mechanistic_replisome else 0.)
 
 			self.active_replisomes.moleculesNew(
 				n_new_replisome,
 				coordinates=coordinates_replisome,
 				right_replichore=right_replichore,
-				domain_index=domain_index_new_replisome)
+				domain_index=domain_index_new_replisome,
+				massDiff_protein=massDiff_protein_new_replisome,
+				)
 
 			# Add and set attributes of new chromosome domains. All new domains
 			# should have have no children domains.

--- a/models/ecoli/sim/initial_conditions.py
+++ b/models/ecoli/sim/initial_conditions.py
@@ -31,7 +31,7 @@ def calcInitialConditions(sim, sim_data):
 		randomState, massCoeff, sim._ppgpp_regulation, sim._trna_attenuation)
 	cell_mass = init.calculate_cell_mass(sim.internal_states)
 	init.initializeUniqueMoleculesFromBulk(bulkMolCntr, uniqueMolCntr, sim_data, cell_mass,
-		randomState, sim._superhelical_density, sim._ppgpp_regulation, sim._trna_attenuation)
+		randomState, sim._superhelical_density, sim._ppgpp_regulation, sim._trna_attenuation, sim._mechanistic_replisome)
 
 	# Must be called after unique and bulk molecules are initialized to get
 	# concentrations for ribosomes, tRNA, synthetases etc from cell volume

--- a/reconstruction/ecoli/dataclasses/state/internal_state.py
+++ b/reconstruction/ecoli/dataclasses/state/internal_state.py
@@ -215,27 +215,18 @@ class InternalState(object):
 		# Add active replisomes
 		# Note that the replisome does not functionally replicate the
 		# chromosome, but instead keeps track of the mass associated with
-		# essential subunits of the replisome complex. The list of essential
-		# subunits and their stoichiometry were taken from Reyes-Lamothe et
-		# al., 2010.
+		# essential subunits of the replisome complex (if the mechanistic
+		# replisome option is turned on). The list of essential subunits and
+		# their stoichiometry were taken from Reyes-Lamothe et al., 2010.
 		replisome_mass = (units.g / units.mol) * np.zeros_like(RNAP_mass)
-
-		trimer_ids = sim_data.molecule_groups.replisome_trimer_subunits
-		monomer_ids = sim_data.molecule_groups.replisome_monomer_subunits
-
-		for trimer_id in trimer_ids:
-			replisome_mass += 3*bulk_molecule_id_to_mass[trimer_id]
-		for monomer_id in monomer_ids:
-			replisome_mass += bulk_molecule_id_to_mass[monomer_id]
-
-		replisomeAttributes = {
+		replisome_attributes = {
 			'domain_index': 'i4',
 			'right_replichore': '?',
 			'coordinates': 'i8',
 			}
 
 		self.unique_molecule.add_to_unique_state(
-			'active_replisome', replisomeAttributes, replisome_mass)
+			'active_replisome', replisome_attributes, replisome_mass)
 
 		# Active replisomes are divided based on their domain index
 		sim_data.molecule_groups.unique_molecules_domain_index_division.append(


### PR DESCRIPTION
This PR sets the mass of the `active_replisome` unique molecule to zero, and only assigns a mass to these molecules if the `mechanistic_replisome` option is turned on. This should fix #1035, where we had mass imbalance issues with the `ChromosomeReplication` process if this option was turned off.