### PR TITLE
Add optional feature tests for no GRC or operons

### DIFF
--- a/runscripts/jenkins/ecoli-optional-features.sh
+++ b/runscripts/jenkins/ecoli-optional-features.sh
@@ -5,9 +5,12 @@ sh runscripts/jenkins/fireworks-config.sh optional
 
 echo y | lpad reset
 
-DESC="No tRNA Charging" TRNA_CHARGING=0 N_GENS=8 \
-  PARALLEL_PARCA=1 SINGLE_DAUGHTERS=1 COMPRESS_OUTPUT=1 RAISE_ON_TIME_LIMIT=1 \
-  PLOTS=ACTIVE WC_ANALYZE_FAST=1 \
+DESC="No growth rate control" TRNA_ATTENUATION=0 PPGPP_REGULATION=0 \
+  MECHANISTIC_TRANSLATION_SUPPLY=0 MECHANISTIC_AA_TRANSPORT=0 \
+  AA_SUPPLY_IN_CHARGING=0 D_PERIOD_DIVISION=0 MECHANISTIC_REPLISOME=1 \
+  N_GENS=8 PLOTS=ACTIVE WC_ANALYZE_FAST=1 \
+  python runscripts/fireworks/fw_queue.py
+DESC="No operons" OPERONS="off" N_GENS=8 PLOTS=ACTIVE WC_ANALYZE_FAST=1 \
   python runscripts/fireworks/fw_queue.py
 # Better regulation of replisome subunits should allow MECHANISTIC_REPLISOME=1
 DESC="ppGpp regulation" PPGPP_REGULATION=1 MECHANISTIC_REPLISOME=0 N_GENS=8 \


### PR DESCRIPTION
This PR adds optional features tests on Jenkins to test the no growth rate control and no operons options, now that these two options are turned on by default.