### PR TITLE
Ensure sufficient expression of all RNAP and ribosomal protein genes from operons

### DIFF
--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -34,12 +34,12 @@ MAX_FITTING_ITERATIONS = 100
 N_SEEDS = 10
 
 # Parameters used in fitPromoterBoundProbability()
-PROMOTER_PDIFF_THRESHOLD = 0.06  # Minimum difference between binding probabilities of a TF in conditions where TF is active and inactive
+PROMOTER_PDIFF_THRESHOLD = 0.05  # Minimum difference between binding probabilities of a TF in conditions where TF is active and inactive
 PROMOTER_REG_COEFF = 1e-3  # Optimization weight on how much probability should stay close to original values
 PROMOTER_SCALING = 10  # Multiplied to all matrices for numerical stability
 PROMOTER_NORM_TYPE = 1  # Matrix 1-norm
 PROMOTER_MAX_ITERATIONS = 100
-PROMOTER_CONVERGENCE_THRESHOLD = 5e-8
+PROMOTER_CONVERGENCE_THRESHOLD = 1e-9
 ECOS_0_TOLERANCE = 1e-10  # Tolerance to adjust solver output to 0
 
 BASAL_EXPRESSION_CONDITION = "M9 Glucose minus AAs"


### PR DESCRIPTION
This PR makes a few changes to the ParCa to ensure that we get sufficient expression of genes encoding for RNA polymerase subunits and ribosomal proteins. The main change is that we now set the expression levels of all genes within RNAP/ribosome-encoding operons to the maximum expression level among the genes within the operon, which is reverse-calculated from the required number of proteins. This ensures that all RNAP/ribosome subunits are expressed to the level that is required for the RNA/protein masses to double within the expected doubling times. Before this change, some ribosomal subunits with lower translational efficiencies were being underexpressed due to the NNLS solution returning expression levels that are between the highest and lowest-expression genes within these operons.

Another major change that was made was to use the ppGpp-regulated ribosome elongation rate to estimate the number of ribosomes that would be required to double the protein mass within the expected doubling time, instead of the elongation rates given by Dennis & Bremer. This new value (20aa/s in basal conditions) better represents the ribosome elongation rate that is actually used in our simulations compared to the old value (17aa/s in basal conditions). This increase in the elongation rate decreases the counts of ribosomes required to double the protein mass to roughly 16,000 under basal conditions, which is very close to the counts of each rRNA species expected from their RNA mass fractions.

This PR also includes a minor change in how we calculate the loss rates of RNAs. Just as the changes made in PR #1320, we now use the functional masses of rRNAs and tRNAs to determine the total number of RNA molecules that are used to calculate these loss rates. 

These changes required some changes to the fitting parameters for promoter binding probabilities later in the ParCa in order for the solver to find an optimal solution.