### PR TITLE
Fix matplotlib errors introduced with 3.3.4

### DIFF
--- a/models/ecoli/analysis/comparison/polycistronic_transcription.py
+++ b/models/ecoli/analysis/comparison/polycistronic_transcription.py
@@ -125,7 +125,7 @@ class Plot(comparisonAnalysisPlot.ComparisonAnalysisPlot):
 		ax3.set_xlim([0, time_off[-1] / 60])
 		ax3.set_ylim([0, 300])
 		ax3.set_yticks([0, 300])
-		ax3.set_xticks(list(gen_start_time_off / 60) + [time_off[-1]/60])
+		ax3.set_xticks((gen_start_time_off / 60).flatten().tolist() + [time_off.flatten()[-1]/60])
 		ax3.set_xticklabels(np.arange(len(gen_start_time_off) + 1))
 
 		# Plot counts of each protein when operon="on"
@@ -143,8 +143,8 @@ class Plot(comparisonAnalysisPlot.ComparisonAnalysisPlot):
 		ax4.spines["left"].set_visible(False)
 		ax4.get_yaxis().set_visible(False)
 		ax4.set_xlim([0, time_on[-1]/60])
-		ax4.set_xticks(list(gen_start_time_on / 60) + [time_on[-1] / 60])
-		ax4.set_xticklabels(np.arange(len(gen_start_time_on) + 1))
+		ax4.set_xticks((gen_start_time_on / 60).flatten().tolist() + [time_on.flatten()[-1] / 60])
+		ax4.set_xticklabels(np.arange(len(gen_start_time_on) + 1).tolist())
 
 		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)

--- a/models/ecoli/analysis/multigen/subgenerationalTranscription.py
+++ b/models/ecoli/analysis/multigen/subgenerationalTranscription.py
@@ -104,7 +104,10 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		alwaysPresentIndexes = np.where(transcribedBoolOrdered == 1.)[0]
 		neverPresentIndexes = np.where(transcribedBoolOrdered == 0.)[0]
-		sometimesPresentIndexes = np.array([x for x in np.arange(len(transcribedBoolOrdered)) if x not in alwaysPresentIndexes and x not in neverPresentIndexes])
+		sometimesPresentIndexes = np.array([
+			x for x in np.arange(len(transcribedBoolOrdered))
+			if x not in alwaysPresentIndexes and x not in neverPresentIndexes],
+			dtype=int)
 		colors = np.repeat(COLOR_FSUB, len(transcribedBoolOrdered))
 		colors[alwaysPresentIndexes] = COLOR_F1
 		colors[neverPresentIndexes] = COLOR_F0
@@ -223,7 +226,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		alwaysAxis.set_ylabel("Freq. = 1", fontsize = 14)
 		sometimesAxis.set_ylabel("0 < Freq. < 1", fontsize = 14)
 		sometimesAxis.set_xlabel("Time (gens)", fontsize = 14)
-		sometimesAxis.set_xticklabels(np.arange(FIRST_N_GENS + 1))
+		sometimesAxis.set_xticklabels(np.arange(len(time_eachGen)))
 		exportFigure(plt, plotOutDir, "figure5B__bottom", metadata)
 		plt.close("all")
 


### PR DESCRIPTION
This PR fixes the two analysis scripts that ran into errors after upgrading `matplotlib` to version `3.3.4`. We are also getting a lot of new deprecation warnings which I'll get to shortly.