### PR TITLE
Fix more analysis scripts with errors/warnings after matplotlib update

### DIFF
--- a/models/ecoli/analysis/cohort/promoter_probabilities.py
+++ b/models/ecoli/analysis/cohort/promoter_probabilities.py
@@ -73,8 +73,8 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		ax.plot([0, max_prob], [0, max_prob], '--k')
 		scatter = ax.scatter(expected, actual, c=frac_limited, alpha=0.5, cmap='hot', edgecolors='k')
 		fig.colorbar(scatter)
-		ax.set_xscale('symlog', linthreshx=min_prob)
-		ax.set_yscale('symlog', linthreshy=min_prob)
+		ax.set_xscale('symlog', linthresh=min_prob)
+		ax.set_yscale('symlog', linthresh=min_prob)
 
 		# Add text labels
 		limited_cutoff = 0.05

--- a/models/ecoli/analysis/single/external_exchange_fluxes.py
+++ b/models/ecoli/analysis/single/external_exchange_fluxes.py
@@ -56,7 +56,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		ax.set_ylim(max(0, ylim[0]), ylim[1])
 		ax.set_ylabel('Carbon source import\n(mmol/gDCW/hr)')
 		ax.tick_params(labelsize=8, which='both', direction='out')
-		ax.legend()
+		ax.legend(loc=1)
 
 		# Plot other uptake of interest
 		for index, molecule in enumerate(molecule_ids):
@@ -81,7 +81,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 				])
 			ymin = np.floor(ave_flux - y_range)
 			ymax = np.ceil(ave_flux + y_range)
-			ax.set_ylim([ymin, ymax])
+			if ymin == 0 and ymax == 0:
+				ax.set_ylim([-1, 1])
+			else:
+				ax.set_ylim([ymin, ymax])
 
 			abs_max = np.max(molecule_flux)
 			abs_min = np.min(molecule_flux)
@@ -119,8 +122,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		ax_export.set_yscale('symlog')
 		ax_import.set_yscale('symlog')
 		handles, labels = ax_export.get_legend_handles_labels()
-		ax_export.legend(handles[::-1], labels[::-1], fontsize=6)
-		ax_import.legend(fontsize=6)
+		ax_export.legend(handles[::-1], labels[::-1], fontsize=6, loc=1)
+		ax_import.legend(fontsize=6, loc=1)
 		ax_export.set_title('Export Fluxes', fontsize=8)
 		ax_import.set_title('Import Fluxes', fontsize=8)
 		ax_export.tick_params(labelsize=8, which='both', direction='out')

--- a/models/ecoli/analysis/single/fbaOptimizationProblem.py
+++ b/models/ecoli/analysis/single/fbaOptimizationProblem.py
@@ -73,7 +73,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		ax.set_ylabel('Shadow Price\n(Metabolites)', fontsize=8)
 		if len(idx):
 			ax.plot(time[burnIn:], shadowPrices[burnIn:, idx])
-			ax.legend(metaboliteNames[idx], fontsize=4)
+			ax.legend(metaboliteNames[idx], fontsize=4, loc=1)
 			ax.tick_params(axis='both', which='major', labelsize=6)
 
 		# Find outliers for reduced costs and plot with legend to identify
@@ -90,7 +90,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		if len(idx):
 			shortenedNames = [x[:20] for x in reactionNames[idx]] # prevent long names from covering both subplots
 			ax.plot(time[burnIn:], reducedCosts[burnIn:, idx])
-			ax.legend(shortenedNames, fontsize=4)
+			ax.legend(shortenedNames, fontsize=4, loc=1)
 			ax.tick_params(axis='both', which='major', labelsize=6)
 
 		# Find outliers for reduced costs and plot with legend to identify
@@ -107,7 +107,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		if len(idx):
 			shortenedNames = [x[:20] for x in reactionNames[idx]] # prevent long names from covering both subplots
 			ax.plot(time[burnIn:], reducedCosts[burnIn:, idx])
-			ax.legend(shortenedNames, fontsize=4)
+			ax.legend(shortenedNames, fontsize=4, loc=1)
 			ax.tick_params(axis='both', which='major', labelsize=6)
 
 		# Check if there are kinetic reactions (FBA kinetics enabled)
@@ -138,7 +138,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			if len(idx):
 				shortenedNames = [x[:20] for x in kineticReactionNames[idx]]  # prevent long names from covering both subplots
 				ax.plot(time[burnIn:], kineticsReducedCosts[burnIn:, idx])
-				ax.legend(shortenedNames, fontsize=4)
+				ax.legend(shortenedNames, fontsize=4, loc=1)
 				ax.tick_params(axis='both', which='major', labelsize=6)
 
 		plt.tight_layout()

--- a/models/ecoli/analysis/variant/remove_aa_inhibition.py
+++ b/models/ecoli/analysis/variant/remove_aa_inhibition.py
@@ -118,6 +118,10 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
+		if metadata.get('variant', '') != 'remove_aa_inhibition':
+			print('This plot only runs for the remove_aa_inhibition variant.')
+			return
+
 		variants = self.ap.get_variants()
 
 		aa_ids = sorted({aa for aas in HEATMAP_COLS for aa in aas[1]})


### PR DESCRIPTION
This PR fixes more analysis scripts that emits errors/warnings after the matplotlib version update. Having `models/ecoli/analysis/variant/remove_aa_inhibition.py` run only for the specific variant should fix the +AA and anaerobic daily builds.