### PR TITLE
Add variant function to relocate rRNA genes

### DIFF
--- a/models/ecoli/sim/variants/__init__.py
+++ b/models/ecoli/sim/variants/__init__.py
@@ -21,6 +21,7 @@ variants = [
 	'remove_aas_shift',
 	'remove_one_aa',
 	'remove_one_aa_shift',
+	'rrna_location',
 	'rrna_orientation',
 	'tf_activity',
 	'time_step',

--- a/models/ecoli/sim/variants/rrna_location.py
+++ b/models/ecoli/sim/variants/rrna_location.py
@@ -1,0 +1,46 @@
+"""
+Variant to compare the impacts of changing the locations of rRNA genes on the
+chromosome.
+
+Modifies:
+	sim_data.process.transcription.rna_data["replication_coordinate"]
+
+Expected variant indices:
+	0: control
+	1: symmetrically flip the chromosomal positions of all rRNA-encoding geness
+	such that most of them lie closer to terC than oriC (Note: there may be
+	some genes that physically overlap as a result of this change)
+"""
+
+import numpy as np
+
+CONTROL_OUTPUT = dict(
+	shortName = "control",
+	desc = "Control simulation"
+	)
+
+
+def rrna_location(sim_data, index):
+	if index == 1:
+		is_rrna = sim_data.process.transcription.rna_data['is_rRNA']
+		coordinate = sim_data.process.transcription.rna_data[
+			"replication_coordinate"]
+		replichore_lengths = sim_data.process.replication.replichore_lengths
+
+		def flip_coordinates(orig_coordinates):
+			if orig_coordinates >= 0:
+				return replichore_lengths[0] - orig_coordinates
+			else:
+				return -replichore_lengths[1] - orig_coordinates
+
+		# Flip coordinates of all rRNA genes
+		for i in np.where(is_rrna)[0]:
+			coordinate[i] = flip_coordinates(coordinate[i])
+
+		return dict(
+			shortName = "rrna_relocated",
+			desc = "Simulation with relocated rRNA genes",
+			), sim_data
+
+	else:
+		return CONTROL_OUTPUT, sim_data

--- a/models/ecoli/sim/variants/rrna_orientation.py
+++ b/models/ecoli/sim/variants/rrna_orientation.py
@@ -2,14 +2,13 @@
 Variant to compare the impacts of reversing the orientation of rRNA genes.
 
 Modifies:
-	sim_data.process.transcription.rnaData["is_forward"]
+	sim_data.process.transcription.rna_data["is_forward"]
+	sim_data.process.transcription.rna_data["replication_coordinate"]
 
 Expected variant indices:
 	0: control
-	1: reverse orientation of all rRNA genes
+	1: reverse orientation of all rRNA-encoding genes
 """
-
-from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from wholecell.utils import units
@@ -34,8 +33,8 @@ def rrna_orientation(sim_data, index):
 		is_forward[is_rrna] = ~is_forward[is_rrna]
 
 		return dict(
-			shortName = "rrna_reversed",
-			desc = "Simulation with all rRNA orientations reversed"
+			shortName = "rrna_orientation_reversed",
+			desc = "Simulation with the orientations of all rRNA genes reversed"
 			), sim_data
 
 	else:


### PR DESCRIPTION
This PR adds a variant function that changes the chromosomal location of all rRNA-encoding genes on the genome, such that most of them are placed closer to the terC than the oriC. To do this I chose to simply reset the replication coordinates of the rRNA-encoding genes, and not change any other data points within `sim_data`. Ideally, we should also change the genome sequences and the coordinates of the other genes on the genome, but I don't think this added complexity would bring any meaningful changes in simulation results. I haven't tried running any detailed analyses on these variant sims, except to check that the relocation of the genes works as intended.