### PR TITLE
Balance out translational efficiencies of some 30S ribosomal proteins

### DIFF
--- a/reconstruction/ecoli/dataclasses/adjustments.py
+++ b/reconstruction/ecoli/dataclasses/adjustments.py
@@ -17,6 +17,10 @@ class Adjustments(object):
 			adj["name"]: adj["value"]
 			for adj in raw_data.adjustments.translation_efficiencies_adjustments
 		}
+		self.balanced_translation_efficiencies = [
+			adj["proteins"]
+			for adj in raw_data.adjustments.balanced_translation_efficiencies
+		]
 		self.rna_expression_adjustments = {
 			adj["name"]: adj["value"]
 			for adj in raw_data.adjustments.rna_expression_adjustments

--- a/reconstruction/ecoli/fit_sim_data_1.py
+++ b/reconstruction/ecoli/fit_sim_data_1.py
@@ -192,6 +192,7 @@ def input_adjustments(sim_data, cell_specs, debug=False, **kwargs):
 
 	# Make adjustments for metabolic enzymes
 	setTranslationEfficiencies(sim_data)
+	set_balanced_translation_efficiencies(sim_data)
 	setRNAExpression(sim_data)
 	setRNADegRates(sim_data)
 	setProteinDegRates(sim_data)
@@ -965,6 +966,31 @@ def setTranslationEfficiencies(sim_data):
 	for protein in sim_data.adjustments.translation_efficiencies_adjustments:
 		idx = np.where(sim_data.process.translation.monomer_data["id"] == protein)[0]
 		sim_data.process.translation.translation_efficiencies_by_monomer[idx] *= sim_data.adjustments.translation_efficiencies_adjustments[protein]
+
+
+def set_balanced_translation_efficiencies(sim_data):
+	"""
+	Sets the translation efficiencies of a group of proteins to be equal to the
+	mean value of all proteins within the group.
+
+	Requires
+	--------
+	- List of proteins that should have balanced translation efficiencies.
+
+	Modifies
+	--------
+	- Translation efficiencies of proteins within each specified group.
+	"""
+	monomer_id_to_index = {
+		monomer['id'][:-3]: i for (i, monomer) in enumerate(
+			sim_data.process.translation.monomer_data)
+		}
+
+	for proteins in sim_data.adjustments.balanced_translation_efficiencies:
+		protein_indexes = np.array([monomer_id_to_index[m] for m in proteins])
+		mean_trl_eff = sim_data.process.translation.translation_efficiencies_by_monomer[protein_indexes].mean()
+		sim_data.process.translation.translation_efficiencies_by_monomer[protein_indexes] = mean_trl_eff
+
 
 def setRNAExpression(sim_data):
 	"""

--- a/reconstruction/ecoli/flat/adjustments/balanced_translation_efficiencies.tsv
+++ b/reconstruction/ecoli/flat/adjustments/balanced_translation_efficiencies.tsv
@@ -1,2 +1,4 @@
-# Adjustments to have the translational efficiencies of proteins that constitute the same operon have the same values
+# Adjustments to have the translational efficiencies of proteins that constitute
+# the same operon have the same values
 "proteins"	"_comments"
+["EG10910-MONOMER", "EG10903-MONOMER", "EG10912-MONOMER"]	"Adjusted to prevent severe underexpression of 30S ribosomal proteins"

--- a/reconstruction/ecoli/knowledge_base_raw.py
+++ b/reconstruction/ecoli/knowledge_base_raw.py
@@ -115,6 +115,7 @@ LIST_OF_DICT_FILENAMES = [
 	os.path.join("base_codes", "nmp.tsv"),
 	os.path.join("base_codes", "ntp.tsv"),
 	os.path.join("adjustments", "amino_acid_pathways.tsv"),
+	os.path.join("adjustments", "balanced_translation_efficiencies.tsv"),
 	os.path.join("adjustments", "translation_efficiencies_adjustments.tsv"),
 	os.path.join("adjustments", "rna_expression_adjustments.tsv"),
 	os.path.join("adjustments", "rna_deg_rates_adjustments.tsv"),


### PR DESCRIPTION
This PR makes some adjustments to the translational efficiencies of some 30S ribosomal proteins to ensure that we get sufficient expression of all ribosomal proteins that constitute the 30S subunit. Some of these proteins were being underexpressed because other proteins that constitute the same operon had higher translational efficiencies, which set the mRNA expression levels for this operon to be lower than what's needed for these proteins with lower translational efficiencies. The changes made will balance out the translational efficiencies for a set of 30S ribosomal proteins that is most severely affected by this imbalance, and slightly bump up the counts of the 30S ribosomal subunit.