### PR TITLE
Fix PR #1348

### DIFF
--- a/models/ecoli/processes/chromosome_structure.py
+++ b/models/ecoli/processes/chromosome_structure.py
@@ -356,7 +356,7 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 						mature_rna_end_pos = self.mature_rna_end_positions[
 							:, self.unprocessed_rna_index_mapping[ri]]
 						mature_rnas_produced = np.logical_and(
-							mature_rna_end_pos != 0, mature_rna_end_pos <= sl)
+							mature_rna_end_pos != 0, mature_rna_end_pos < sl)
 
 						# Increment counts of mature RNAs
 						mature_rna_counts += mature_rnas_produced


### PR DESCRIPTION
This corrects an error I made in PR #1348 that led to some anaerobic daily builds failing. The sequence lengths of incomplete transcripts need to be strictly higher than the indexes of the end positions of mature RNAs on those transcripts in order for them to completely cover the sequence of the mature transcript. 