### PR TITLE
Add sample paper runs file for rRNA operon paper

### DIFF
--- a/models/ecoli/analysis/single/rRNA_operon_expression.py
+++ b/models/ecoli/analysis/single/rRNA_operon_expression.py
@@ -14,7 +14,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 
 LABELPAD = 10
 FONTSIZE = 15
-COLORS = ['b', 'r', 'g', 'c']
+COLORS = ['C0', 'C1', 'C2', 'royalblue']
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
@@ -58,6 +58,15 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			rRNA_cistron_to_type_mapping_matrix @ rRNA_actual_synth_prob.T)
 		grouped_rRNA_target_synth_prob = np.array(
 			rRNA_cistron_to_type_mapping_matrix @ rRNA_target_synth_prob.T)
+
+		# Actual transcription initiation events
+		rnap_data_reader = TableReader(os.path.join(simOutDir, "RnapData"))
+		actual_rna_init_per_cistron = rnap_data_reader.readColumn("rna_init_event_per_cistron")
+		rRNA_actual_rna_init = actual_rna_init_per_cistron[:, rRNA_idxs]
+		rRNA_actual_rna_init_rate = np.array(
+			[rna_init / timestep for rna_init in rRNA_actual_rna_init.T]).T
+		grouped_rRNA_actual_rna_init_rate = np.array(
+			rRNA_cistron_to_type_mapping_matrix @ rRNA_actual_rna_init_rate.T)
 
 		# Expected transcription initiation events
 		expected_rna_init_per_cistron = rna_synth_prob.readColumn("expected_rna_init_per_cistron")
@@ -126,100 +135,136 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Concentration of ppGpp
 		counts_to_molar = TableReader(os.path.join(simOutDir, 'EnzymeKinetics')).readColumn('countsToMolar').squeeze()
-		ppGpp_conc = ppGpp_counts * counts_to_molar
+		ppGpp_conc = ppGpp_counts * counts_to_molar * 1000  # uM
 
 		## Make figure
-		# Ncols is number of rRNA TUs, 1 for total, and 3 for 5S/16S/23S
-		ncols = 8
-		nrows=7
+		# ncols is number of rRNA operons + 1 for total
+		ncols = len(rRNA_operon_names) + 1
+		nrows = 8
 
-		fig, axs = plt.subplots(nrows=nrows, ncols=ncols, figsize=(5 * ncols, 5 * nrows), sharex='all')
+		fig, axs = plt.subplots(nrows=nrows, ncols=ncols, figsize=(3.5 * ncols, 3.5 * nrows), sharex='all')
+
 		# Make the plots
-		axs[0, 0].set_ylabel("Initiations per second", labelpad=LABELPAD)
-		axs[1, 0].set_ylabel("Target and actual rRNA synthesis probabilities", labelpad=LABELPAD)
-		axs[2, 0].set_ylabel("rRNA gene dosages", labelpad=LABELPAD),
-		axs[3, 0].set_ylabel("Initiations per second per gene dosage", labelpad=LABELPAD)
-		axs[4, 0].set_ylabel("RNAP counts on rrn genes", labelpad=LABELPAD)
-		axs[5, 0].set_ylabel("Fraction of active RNAPs on rrn genes", labelpad=LABELPAD)
-		axs[6, 0].set_ylabel("rRNA counts")
-		for i in range(len(rRNA_operon_names)):
+		axs[0, 0].set_ylabel("Actual initiations per second", labelpad=LABELPAD)
+		axs[1, 0].set_ylabel("Expected initiations per second", labelpad=LABELPAD)
+		axs[2, 0].set_ylabel("Synthesis probabilities", labelpad=LABELPAD)
+		axs[3, 0].set_ylabel("Gene dosages", labelpad=LABELPAD),
+		axs[4, 0].set_ylabel("Initiations per second per gene copy", labelpad=LABELPAD)
+		axs[5, 0].set_ylabel("Active RNAP counts", labelpad=LABELPAD)
+		axs[6, 0].set_ylabel("Fraction of active RNAPs", labelpad=LABELPAD)
+		axs[7, 0].set_ylabel("Counts")
+
+		for i in range(ncols - 1):
 			this_operon_idxs = np.where(rRNA_TU_to_cistron_mapping_matrix[i, :] == 1)[0]
+
 			for (n, idx) in enumerate(this_operon_idxs):
-				axs[0, i].plot(time, rRNA_expected_rna_init_rate[:, idx],
-							   c=COLORS[n], label=cistron_rRNA_ids[idx])
-				axs[0,i].legend()
-				axs[0,i].set_ylim(0, 3)
-				axs[1, i].plot(time, rRNA_actual_synth_prob[:, idx],
+				axs[0, i].plot(
+					time, rRNA_actual_rna_init_rate[:, idx],
+					c=COLORS[n], label=cistron_rRNA_ids[idx])
+				axs[0, i].legend(loc=1)
+				axs[0, i].set_ylim(0, 10)
+
+				axs[1, i].plot(
+					time, rRNA_expected_rna_init_rate[:, idx],
+					c=COLORS[n], label=cistron_rRNA_ids[idx])
+				axs[1, i].legend(loc=1)
+				axs[1, i].set_ylim(0, 3)
+
+				axs[2, i].plot(time, rRNA_actual_synth_prob[:, idx],
 							   c=COLORS[n],label=cistron_rRNA_ids[idx]+" actual")
-				axs[1, i].plot(time, rRNA_target_synth_prob[:, idx],
+				axs[2, i].plot(time, rRNA_target_synth_prob[:, idx],
 							   linestyle='dashed', c=COLORS[n],
 							   label=cistron_rRNA_ids[idx]+" target")
-				axs[1, i].legend()
-				axs[1, i].set_ylim(0, 0.03)
-				axs[2, i].plot(time, rRNA_gene_dosages[:, idx],
+				axs[2, i].legend(loc=1)
+				axs[2, i].set_ylim(0, 0.03)
+
+				axs[3, i].plot(time, rRNA_gene_dosages[:, idx],
 							   c=COLORS[n], label=cistron_rRNA_ids[idx])
-				axs[2, i].legend()
-				axs[2, i].set_ylim(0, 5)
-				axs[3, i].plot(time, rRNA_initiation_per_gene_dosage[:, idx],
+				axs[3, i].legend(loc=1)
+				axs[3, i].set_ylim(0, 10)
+
+				axs[4, i].plot(time, rRNA_initiation_per_gene_dosage[:, idx],
 							   c=COLORS[n], label=cistron_rRNA_ids[idx])
-				axs[3, i].legend()
-				axs[3, i].set_ylim(0, 1)
-				axs[4, i].plot(time, RNAP_on_rRNA_counts[:, idx],
+				axs[4, i].legend(loc=1)
+				axs[4, i].set_ylim(0, 1)
+
+				axs[5, i].plot(time, RNAP_on_rRNA_counts[:, idx],
 							   c=COLORS[n], label=cistron_rRNA_ids[idx])
-				axs[4, i].legend()
-				axs[4, i].set_ylim(0, 100)
-				axs[5, i].plot(time, RNAP_active_fraction_on_rRNA[:, idx],
+				axs[5, i].legend(loc=1)
+				axs[5, i].set_ylim(0, 200)
+
+				axs[6, i].plot(time, RNAP_active_fraction_on_rRNA[:, idx],
 							   c=COLORS[n], label=cistron_rRNA_ids[idx])
-				axs[5, i].legend()
-				axs[5, i].set_ylim(0, 0.15)
+				axs[6, i].legend(loc=1)
+				axs[6, i].set_ylim(0, 0.15)
+
 			axs[0, i].set_title(rRNA_operon_names[i])
-			axs[0, i].set_xlabel("Time (min)", labelpad=LABELPAD, fontsize=FONTSIZE)
+			axs[nrows - 1, i].set_xlabel("Time (min)", labelpad=LABELPAD, fontsize=FONTSIZE)
 
 		for idx in range(np.shape(rRNA_cistron_to_type_mapping_matrix)[0]):
-			axs[0, len(rRNA_operon_names)].plot(time, grouped_rRNA_expected_rna_init_rate[idx],
-												c=COLORS[idx], label=rRNA_cistron_types[idx])
-			axs[0, len(rRNA_operon_names)].legend()
-			axs[1, len(rRNA_operon_names)].plot(time, grouped_rRNA_actual_synth_prob[idx],
-												c=COLORS[idx], label=rRNA_cistron_types[idx]+" actual")
-			axs[1, len(rRNA_operon_names)].plot(time, grouped_rRNA_target_synth_prob[idx],
-												c=COLORS[idx], linestyle='dashed',
-												label=rRNA_cistron_types[idx]+" target")
-			axs[1, len(rRNA_operon_names)].legend()
-			axs[2, len(rRNA_operon_names)].plot(time, grouped_rRNA_gene_dosages[idx],
-												c=COLORS[idx], label=rRNA_cistron_types[idx])
-			axs[2, len(rRNA_operon_names)].legend()
-			axs[3, len(rRNA_operon_names)].plot(time, grouped_rRNA_initiation_per_gene_dosage[idx],
-												c=COLORS[idx], label=rRNA_cistron_types[idx])
-			axs[3, len(rRNA_operon_names)].legend()
-			axs[4, len(rRNA_operon_names)].plot(time, grouped_RNAP_on_rRNA_counts[idx],
-												c=COLORS[idx], label=rRNA_cistron_types[idx])
-			axs[4, len(rRNA_operon_names)].legend()
-			axs[5, len(rRNA_operon_names)].plot(time, grouped_RNAP_active_fraction_on_rRNA[idx],
-												c=COLORS[idx], label=rRNA_cistron_types[idx])
-			axs[5, len(rRNA_operon_names)].legend()
-		axs[0, len(rRNA_operon_names)].set_title("Total")
-		axs[0, len(rRNA_operon_names)].set_xlabel("Time (min)", labelpad=LABELPAD, fontsize=FONTSIZE)
+			axs[0, ncols - 1].plot(
+				time, grouped_rRNA_actual_rna_init_rate[idx],
+				c=COLORS[idx], label=rRNA_cistron_types[idx])
+			axs[0, ncols - 1].legend(loc=1)
 
-		axs[6, 0].plot(time, total_rRNA_5S_counts, c=COLORS[0], label="5S rRNA")
-		axs[6, 0].plot(time, total_rRNA_23S_counts, c=COLORS[1], label="23S rRNA")
-		axs[6, 0].plot(time, total_rRNA_16S_counts, c=COLORS[2], label="16S rRNA")
-		axs[6, 0].set_title("Total rRNA counts")
-		axs[6, 0].legend()
+			axs[1, ncols - 1].plot(
+				time, grouped_rRNA_expected_rna_init_rate[idx],
+				c=COLORS[idx], label=rRNA_cistron_types[idx])
+			axs[1, ncols - 1].legend(loc=1)
 
-		axs[6, 1].plot(time, total_30S_counts, label="30S subunit")
-		axs[6, 1].plot(time, total_50S_counts, label="50S subunit")
-		axs[6, 1].set_title("Total ribosomal subunit counts")
-		axs[6, 1].legend()
+			axs[2, ncols - 1].plot(
+				time, grouped_rRNA_actual_synth_prob[idx],
+				c=COLORS[idx], label=rRNA_cistron_types[idx] + " actual")
+			axs[2, ncols - 1].plot(
+				time, grouped_rRNA_target_synth_prob[idx],
+				c=COLORS[idx], linestyle='dashed',
+				label=rRNA_cistron_types[idx] + " target")
+			axs[2, ncols - 1].legend(loc=1)
 
-		axs[6, 2].plot(time, free_rRNA_5S_counts, c=COLORS[0], label="5S rRNA")
-		axs[6, 2].plot(time, free_rRNA_23S_counts, c=COLORS[1], label="23S rRNA")
-		axs[6, 2].plot(time, free_rRNA_16S_counts, c=COLORS[2], label="16S rRNA")
-		axs[6, 2].set_title("Free rRNA counts")
-		axs[6, 2].legend()
+			axs[3, ncols - 1].plot(
+				time, grouped_rRNA_gene_dosages[idx],
+				c=COLORS[idx], label=rRNA_cistron_types[idx])
+			axs[3, ncols - 1].legend(loc=1)
 
-		axs[6, 3].plot(time, ppGpp_conc)
-		axs[6, 3].set_title("ppGpp concentration")
-		axs[6, 3].set_ylabel("Concentration (mol)")
+			axs[4, ncols - 1].plot(
+				time, grouped_rRNA_initiation_per_gene_dosage[idx],
+				c=COLORS[idx], label=rRNA_cistron_types[idx])
+			axs[4, ncols - 1].legend(loc=1)
+
+			axs[5, ncols - 1].plot(
+				time, grouped_RNAP_on_rRNA_counts[idx],
+				c=COLORS[idx], label=rRNA_cistron_types[idx])
+			axs[5, ncols - 1].legend(loc=1)
+
+			axs[6, ncols - 1].plot(
+				time, grouped_RNAP_active_fraction_on_rRNA[idx],
+				c=COLORS[idx], label=rRNA_cistron_types[idx])
+			axs[6, ncols - 1].legend(loc=1)
+
+		axs[0, ncols - 1].set_title("All operons")
+		axs[nrows - 1, ncols - 1].set_xlabel(
+			"Time (min)", labelpad=LABELPAD, fontsize=FONTSIZE)
+
+		axs[7, 0].plot(time, total_rRNA_5S_counts, c=COLORS[0], label="5S rRNA")
+		axs[7, 0].plot(time, total_rRNA_23S_counts, c=COLORS[1], label="23S rRNA")
+		axs[7, 0].plot(time, total_rRNA_16S_counts, c=COLORS[2], label="16S rRNA")
+		axs[7, 0].set_title("Total rRNA counts")
+		axs[7, 0].legend(loc=1)
+
+		axs[7, 1].plot(time, total_30S_counts, label="30S subunit")
+		axs[7, 1].plot(time, total_50S_counts, label="50S subunit")
+		axs[7, 1].set_title("Total ribosomal subunit counts")
+		axs[7, 1].legend(loc=1)
+
+		axs[7, 2].plot(time, free_rRNA_5S_counts, c=COLORS[0], label="5S rRNA")
+		axs[7, 2].plot(time, free_rRNA_23S_counts, c=COLORS[1], label="23S rRNA")
+		axs[7, 2].plot(time, free_rRNA_16S_counts, c=COLORS[2], label="16S rRNA")
+		axs[7, 2].set_title("Free rRNA counts")
+		axs[7, 2].legend(loc=1)
+
+		axs[7, 3].plot(time, ppGpp_conc)
+		axs[7, 3].set_title("ppGpp concentration")
+		axs[7, 3].set_ylabel("Concentration (uM)")
 
 		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)

--- a/runscripts/rrna_paper/paper_runs.sh
+++ b/runscripts/rrna_paper/paper_runs.sh
@@ -1,0 +1,94 @@
+# Script to run simulations used to generate data for figures in the rRNA paper.
+
+lpad reset
+make clean compile
+
+## Set A - WT, glucose minimal media
+# No changes to rRNA operons
+DESC="SET A 8 gens 1 seed WT with glucose minimal media" \
+VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+## Set B - no rRNA operons, glucose minimal media
+# All rRNA genes are transcribed as single-gene transcription units
+DESC="SET B 8 gens 1 seed single gene rRNA tus with glucose minimal media" \
+VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
+REMOVE_RRNA_OPERONS=1 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+## Set C - rRNA operon knockouts, glucose minimal media
+# Remove one rRNA operon
+DESC="SET C 8 gens 1 seed 6 rRNA operons with glucose minimal media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Remove two rRNA operons
+DESC="SET C 8 gens 1 seed 5 rRNA operons with glucose minimal media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=8 LAST_VARIANT_INDEX=8 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Remove three rRNA operons
+DESC="SET C 8 gens 1 seed 4 rRNA operons with glucose minimal media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=29 LAST_VARIANT_INDEX=29 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Remove four rRNA operons
+DESC="SET C 8 gens 1 seed 3 rRNA operons with glucose minimal media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=64 LAST_VARIANT_INDEX=64 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Remove five rRNA operons
+DESC="SET C 8 gens 1 seed 2 rRNA operons with glucose minimal media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=99 LAST_VARIANT_INDEX=99 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Remove six rRNA operons
+DESC="SET C 8 gens 1 seed 1 rRNA operon with glucose minimal media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=120 LAST_VARIANT_INDEX=120 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+## Set D - flipped locations of rRNA operons, glucose minimal media
+# Change the chromosomal location of rRNA operons
+DESC="SET D 8 gens 1 seed flipped rRNA locations with glucose minimal media" \
+VARIANT="rrna_location" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+## Set E - flipped orientations of rRNA operons, glucose minimal media
+# Change the orientation of rRNA operons
+DESC="SET E 8 gens 1 seed flipped rRNA orientations with glucose minimal media" \
+VARIANT="rrna_orientation" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+## Set F - remove extra 5S gene, glucose minimal media
+# Remove the extra 5S gene (rrfF)
+DESC="SET F 8 gens 1 seed remove extra 5S with glucose minimal media" \
+VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
+REMOVE_RRFF=1 \
+SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+## Launch the fireworks created with fw_queue.py
+# Uncomment one method - rlaunch is interactive, qlaunch is distributed
+# rlaunch rapidfire
+# qlaunch -r rapidfire --nlaunches infinite --sleep 5 --maxjobs_queue 100


### PR DESCRIPTION
This PR adds a sample `paper_runs.sh` file that can be used to initiate simulation workflows that will be used for the rRNA operon paper. Based on the simulations run with this sample workflow, I made some changes to the rRNA operon expression plots, the biggest of which was adding plots for the actual number of RNA initiation events at the first row. The remaining changes were to improve code and plot readability. The new sample plot looks something like this:
![rRNA_operon_expression](https://user-images.githubusercontent.com/32276711/219477755-b780dcec-47ce-41b9-9a21-638f59ccf8e4.png)


