### PR TITLE
Test only with operons for PR builds

### DIFF
--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -10,7 +10,7 @@ sh runscripts/jenkins/fireworks-config.sh "pr$EXECUTOR_NUMBER"
 
 echo y | lpad reset
 
-DESC="2 generations completion test." OPERONS=both WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 \
+DESC="2 generations completion test." OPERONS=on WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 \
 	PARALLEL_PARCA=1 COMPRESS_OUTPUT=0 PLOTS=ACTIVE BUILD_CAUSALITY_NETWORK=1 RAISE_ON_TIME_LIMIT=1 python runscripts/fireworks/fw_queue.py
 
 bash runscripts/jenkins/run-fireworks.sh


### PR DESCRIPTION
This PR changes the Jenkins PR builds to use the `operon="on"` option instead of `operon="both"` for the 2-generation completion test. I think this is a reasonable change as the `operon="on"` option is much more established as the default option, and this will significantly improve the build time of these tests as well. The `operon="off"` option is being tested as part of the optional features builds.