### PR TITLE
Add comparison analysis for active ribosome counts

### DIFF
--- a/models/ecoli/analysis/comparison/__init__.py
+++ b/models/ecoli/analysis/comparison/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 # Active analysis modules to run, in this order.
 # Tip: Edit this during development to run ones you're working on first.
 ACTIVE = [
+	"active_ribosome_counts_histogram.py",
 	"coexpression_probabilities.py",
 	"doubling_time_histogram.py",
 	"excess_protein_monomers.py",

--- a/models/ecoli/analysis/comparison/active_ribosome_counts_histogram.py
+++ b/models/ecoli/analysis/comparison/active_ribosome_counts_histogram.py
@@ -1,0 +1,93 @@
+"""
+Compare histograms of active ribosome counts between two sets of simulations.
+"""
+
+from typing import Tuple
+
+from matplotlib import pyplot as plt
+# noinspection PyUnresolvedReferences
+import numpy as np
+import os
+
+from models.ecoli.analysis import comparisonAnalysisPlot
+from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
+from reconstruction.ecoli.simulation_data import SimulationDataEcoli
+from validation.ecoli.validation_data import ValidationDataEcoli
+from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns
+# noinspection PyUnresolvedReferences
+from wholecell.io.tablereader import TableReader, TableReaderError
+
+
+FIGSIZE = (4, 4)
+BOUNDS = [0, 30000]
+N_BINS = 30
+
+class Plot(comparisonAnalysisPlot.ComparisonAnalysisPlot):
+	def do_plot(self, reference_sim_dir, plotOutDir, plotOutFileName, input_sim_dir, unused, metadata):
+		# noinspection PyUnusedLocal
+		ap1, sim_data1, _ = self.setup(reference_sim_dir)
+		# noinspection PyUnusedLocal
+		ap2, sim_data2, _ = self.setup(input_sim_dir)
+
+		if ap1.n_generation <= 4 or ap2.n_generation <= 4:
+			print('Not enough generations to run analysis.')
+			return
+
+		def read_sims(ap):
+			# Ignore data from first four gens
+			cell_paths = ap.get_cells(generation=np.arange(4, ap.n_generation))
+
+			# Get index of active ribosomes in the unique molecule counts reader
+			unique_molecule_counts_reader = TableReader(
+				os.path.join(cell_paths[0], 'simOut', 'UniqueMoleculeCounts'))
+			unique_molecule_ids = unique_molecule_counts_reader.readAttribute(
+				'uniqueMoleculeIds')
+			active_ribosome_idx = unique_molecule_ids.index('active_ribosome')
+
+			active_ribosome_counts = read_stacked_columns(
+				cell_paths, 'UniqueMoleculeCounts','uniqueMoleculeCounts',
+				ignore_exception=True, fun=lambda x: x[0, active_ribosome_idx])
+
+			return active_ribosome_counts
+
+		# Get initial active ribosome counts from each set of sims
+		active_ribosome_counts1 = read_sims(ap1)
+		active_ribosome_counts2 = read_sims(ap2)
+
+		# Plot histogram
+		fig = plt.figure(figsize=FIGSIZE)
+		ax = fig.add_subplot(1, 1, 1)
+
+		bins = np.linspace(BOUNDS[0], BOUNDS[1], N_BINS + 1)
+
+		ax.hist(
+			active_ribosome_counts1, bins=bins, alpha=0.5,
+			label=f'reference ({np.mean(active_ribosome_counts1):.2f} $\pm$ {np.std(active_ribosome_counts1):.2f}, n={len(active_ribosome_counts1)})')
+		ax.axvline(np.mean(active_ribosome_counts1), ls='--', lw=2, c='C0')
+		ax.hist(
+			active_ribosome_counts2, bins=bins, alpha=0.5,
+			label=f'input ({np.mean(active_ribosome_counts2):.2f} $\pm$ {np.std(active_ribosome_counts2):.2f}, n={len(active_ribosome_counts2)})')
+		ax.axvline(np.mean(active_ribosome_counts2), ls='--', lw=2, c='C1')
+
+		ax.legend(prop={'size': 6})
+
+		ax.set_xlim(BOUNDS)
+		ax.set_xlabel('Active ribosome counts')
+		ax.spines["top"].set_visible(False)
+		ax.spines["right"].set_visible(False)
+
+		plt.tight_layout()
+		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
+		plt.close('all')
+
+	def setup(self, inputDir: str) -> Tuple[
+			AnalysisPaths, SimulationDataEcoli, ValidationDataEcoli]:
+		"""Return objects used for analyzing multiple sims."""
+		ap = AnalysisPaths(inputDir, variant_plot=True)
+		sim_data = self.read_sim_data_file(inputDir)
+		validation_data = self.read_validation_data_file(inputDir)
+		return ap, sim_data, validation_data
+
+
+if __name__ == "__main__":
+	Plot().cli()

--- a/runscripts/rrna_paper/paper_runs.sh
+++ b/runscripts/rrna_paper/paper_runs.sh
@@ -5,18 +5,18 @@ make clean compile
 
 ## Set A - WT, glucose minimal media
 # No changes to rRNA operons
-DESC="SET A 8 gens 1 seed WT with glucose minimal media" \
+DESC="SET A 16 gens 64 seed WT with glucose minimal media" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
 ## Set B - no rRNA operons, glucose minimal media
 # All rRNA genes are transcribed as single-gene transcription units
-DESC="SET B 8 gens 1 seed single gene rRNA tus with glucose minimal media" \
+DESC="SET B 16 gens 64 seed single gene rRNA tus with glucose minimal media" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
 REMOVE_RRNA_OPERONS=1 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 


### PR DESCRIPTION
This PR adds a comparison analysis script that compares the histograms between active ribosome counts (of cells at t=0 of each generation) between two sets of simulations. Sample output (for a very small set of sims) shown below.

![active_ribosome_counts_histogram](https://github.com/CovertLab/wcEcoli/assets/32276711/0216be31-44e0-409f-aab7-a4623b00e978)
