### PR TITLE
Exclude failed sims for doubling time histogram comparison plot

### DIFF
--- a/models/ecoli/analysis/comparison/active_ribosome_counts_histogram.py
+++ b/models/ecoli/analysis/comparison/active_ribosome_counts_histogram.py
@@ -44,6 +44,7 @@ class Plot(comparisonAnalysisPlot.ComparisonAnalysisPlot):
 				'uniqueMoleculeIds')
 			active_ribosome_idx = unique_molecule_ids.index('active_ribosome')
 
+			# Get counts of active ribosome at first timestep from every cell
 			active_ribosome_counts = read_stacked_columns(
 				cell_paths, 'UniqueMoleculeCounts','uniqueMoleculeCounts',
 				ignore_exception=True, fun=lambda x: x[0, active_ribosome_idx])

--- a/models/ecoli/analysis/comparison/doubling_time_histogram.py
+++ b/models/ecoli/analysis/comparison/doubling_time_histogram.py
@@ -31,12 +31,12 @@ class Plot(comparisonAnalysisPlot.ComparisonAnalysisPlot):
 		ap2, _, _ = self.setup(input_sim_dir)
 
 		def read_sims(ap):
-			sim_dirs = ap.get_cells()
+			sim_dirs = ap.get_cells(only_successful=True)
 			doubling_times_minutes = []
 
 			for sim_dir in sim_dirs:
 				try:
-					sim_out_dir = os.path.join(sim_dir, "simOut")
+					sim_out_dir = os.path.join(sim_dir, 'simOut')
 
 					# Assume simulated time == doubling time
 					time = TableReader(os.path.join(sim_out_dir, 'Main')).readColumn('time')


### PR DESCRIPTION
This PR adds a check in the doubling time comparison plot to check and exclude cells that have terminated prematurely prior to division due to a simulation error. Since we were calculating the doubling time by simply subtracting the last entry of the time column by the first entry, the doubling times from these sims were falsely contributing to the shorter ends of the distributions. I just opted to check for the existence of the file `Daughter1_inherited_state.cPickle` in the `simOut` directory, which only gets written if the simulation has been completed all the way through division.