### PR TITLE
Fix RNA degradation bugs

### DIFF
--- a/models/ecoli/processes/rna_degradation.py
+++ b/models/ecoli/processes/rna_degradation.py
@@ -241,9 +241,9 @@ class RnaDegradation(wholecell.processes.process.Process):
 		# mRNA becomes a full transcript to simplify the transcript elongation
 		# process.
 		n_bulk_RNAs_to_degrade = n_RNAs_to_degrade.copy()
-		n_bulk_RNAs_to_degrade[self.is_mRNA] = 0
+		n_bulk_RNAs_to_degrade[self.is_mRNA.astype(bool)] = 0
 		self.n_unique_RNAs_to_deactivate = n_RNAs_to_degrade.copy()
-		self.n_unique_RNAs_to_deactivate[np.logical_not(self.is_mRNA)] = 0
+		self.n_unique_RNAs_to_deactivate[np.logical_not(self.is_mRNA.astype(bool))] = 0
 
 		self.bulk_RNAs.requestIs(n_bulk_RNAs_to_degrade)
 		self.unique_RNAs.request_access(self.EDIT_DELETE_ACCESS)

--- a/models/ecoli/processes/rna_degradation.py
+++ b/models/ecoli/processes/rna_degradation.py
@@ -213,12 +213,12 @@ class RnaDegradation(wholecell.processes.process.Process):
 		# Boolean variable that tracks existence of each RNA
 		rna_exists = (total_RNA_counts > 0).astype(np.int64)
 
-		# Compute degradation probabilities of each RNA: for mRNAs, this
-		# is based on the specificity of each mRNA. For tRNAs and rRNAs,
-		# this is distributed evenly.
+		# Compute degradation probabilities of each RNA: for mRNAs and rRNAs,
+		# this is based on the specificity of each RNA. For tRNAs, this is
+		# distributed evenly.
 		mrna_deg_probs = 1. / np.dot(rna_specificity, self.is_mRNA * rna_exists) * rna_specificity * self.is_mRNA * rna_exists
+		rrna_deg_probs = 1. / np.dot(rna_specificity, self.is_rRNA * rna_exists) * rna_specificity * self.is_rRNA * rna_exists
 		trna_deg_probs = 1. / np.dot(self.is_tRNA, rna_exists) * self.is_tRNA * rna_exists
-		rrna_deg_probs = 1. / np.dot(self.is_rRNA, rna_exists) * self.is_rRNA * rna_exists
 
 		# Mask RNA counts into each class of RNAs
 		mrna_counts = total_RNA_counts * self.is_mRNA


### PR DESCRIPTION
This PR fixes two bugs that I found within the RNA degradation process while addressing issues with rRNA degradation. The first fix was to have the rRNA degradation probabilities use the specificity of each rRNA molecule to the RNAses, as different rRNAs now have different target degradation rates based on whether they are mature rRNAs or not. The second fix was to convert the `self.is_mRNA` array to a boolean type array before using it as a masking array. 