### PR TITLE
Modify rRNA mass fraction for remove_rrff variant

### DIFF
--- a/reconstruction/ecoli/flat/mass_parameters.tsv
+++ b/reconstruction/ecoli/flat/mass_parameters.tsv
@@ -1,8 +1,8 @@
-name	value	units	_source	_comments
-avg_cell_cell_cycle_progress	0.44		Neidhardt page 9
-cell_water_mass_fraction	0.7		Neidhardt pg 4	Water is 70% of the mass of the cell
-_rrna23s_mass_sub_fraction	0.525		Neidhardt pg 4	This is the fraction of RNA that is 23S rRNA
-_rrna16s_mass_sub_fraction	0.271		Neidhardt pg 4	This is the fraction of RNA that is 16S rRNA
-_rrna5s_mass_sub_fraction	0.017		Neidhardt pg 4	This is the fraction of RNA that is 5S rRNA
-_trna_mass_sub_fraction	0.146		Neidhardt pg 4	This is the fraction of RNA that is tRNA
-_mrna_mass_sub_fraction	0.041		Neidhardt pg 4	This is the fraction of RNA that is mRNA
+"name"	"value"	"units"	"_source"	"_comments"
+"avg_cell_cell_cycle_progress"	0.44		Neidhardt page 9
+"cell_water_mass_fraction"	0.7		Neidhardt pg 4	Water is 70% of the mass of the cell
+"_rrna23s_mass_sub_fraction"	0.525		Neidhardt pg 4	This is the fraction of RNA that is 23S rRNA
+"_rrna16s_mass_sub_fraction"	0.271		Neidhardt pg 4	This is the fraction of RNA that is 16S rRNA
+"_rrna5s_mass_sub_fraction"	0.017		Neidhardt pg 4	This is the fraction of RNA that is 5S rRNA
+"_trna_mass_sub_fraction"	0.146		Neidhardt pg 4	This is the fraction of RNA that is tRNA
+"_mrna_mass_sub_fraction"	0.041		Neidhardt pg 4	This is the fraction of RNA that is mRNA

--- a/reconstruction/ecoli/flat/rrna_options/remove_rrff/mass_parameters_modified.tsv
+++ b/reconstruction/ecoli/flat/rrna_options/remove_rrff/mass_parameters_modified.tsv
@@ -1,0 +1,6 @@
+"name"	"value"	"units"
+"_rrna23s_mass_sub_fraction"	0.5230575	""
+"_rrna16s_mass_sub_fraction"	0.2699973	""
+"_rrna5s_mass_sub_fraction"	0.0169371	""
+"_trna_mass_sub_fraction"	0.1483486	""
+"_mrna_mass_sub_fraction"	0.0416595	""

--- a/reconstruction/ecoli/knowledge_base_raw.py
+++ b/reconstruction/ecoli/knowledge_base_raw.py
@@ -123,11 +123,11 @@ LIST_OF_DICT_FILENAMES = [
 	os.path.join("adjustments", "relative_metabolite_concentrations_changes.tsv"),
 	]
 SEQUENCE_FILE = 'sequence.fasta'
-LIST_OF_PARAMETER_FILENAMES = (
+LIST_OF_PARAMETER_FILENAMES = [
 	"dna_supercoiling.tsv",
 	"parameters.tsv",
 	"mass_parameters.tsv",
-	)
+	]
 
 REMOVED_DATA = {
 	'amino_acid_export_kms': 'amino_acid_export_kms_removed',
@@ -179,10 +179,15 @@ class KnowledgeBaseEcoli(object):
 		# Make copies to prevent issues with sticky global variables when
 		# running multiple operon workflows through Fireworks
 		self.list_of_dict_filenames: List[str] = LIST_OF_DICT_FILENAMES.copy()
+		self.list_of_parameter_filenames: List[str] = LIST_OF_PARAMETER_FILENAMES.copy()
 		self.removed_data: Dict[str, str] = REMOVED_DATA.copy()
 		self.modified_data: Dict[str, str] = MODIFIED_DATA.copy()
 		self.added_data: Dict[str, str] = ADDED_DATA.copy()
 		self.new_gene_added_data: Dict[str,str] = {}
+		self.parameter_file_attribute_names: List[str] = [
+			os.path.splitext(os.path.basename(filename))[0]
+			for filename in self.list_of_parameter_filenames
+			]
 
 		if self.operons_on:
 			self.list_of_dict_filenames.append('transcription_units.tsv')
@@ -201,9 +206,14 @@ class KnowledgeBaseEcoli(object):
 				})
 
 		if remove_rrff:
+			self.list_of_parameter_filenames.append(
+				os.path.join("rrna_options", "remove_rrff", "mass_parameters_modified.tsv"))
 			self.removed_data.update({
 				'genes': 'rrna_options.remove_rrff.genes_removed',
 				'rnas': 'rrna_options.remove_rrff.rnas_removed',
+				})
+			self.modified_data.update({
+				'mass_parameters': 'rrna_options.remove_rrff.mass_parameters_modified',
 				})
 			if self.operons_on:
 				self.modified_data.update({
@@ -246,8 +256,8 @@ class KnowledgeBaseEcoli(object):
 		for filename in self.list_of_dict_filenames:
 			self._load_tsv(FLAT_DIR, os.path.join(FLAT_DIR, filename))
 
-		for filename in LIST_OF_PARAMETER_FILENAMES:
-			self._load_parameters(os.path.join(FLAT_DIR, filename))
+		for filename in self.list_of_parameter_filenames:
+			self._load_parameters(FLAT_DIR, os.path.join(FLAT_DIR, filename))
 
 		self.genome_sequence = self._load_sequence(os.path.join(FLAT_DIR, SEQUENCE_FILE))
 
@@ -295,13 +305,17 @@ class KnowledgeBaseEcoli(object):
 			for record in SeqIO.parse(handle, "fasta"):
 				return record.seq
 
-	def _load_parameters(self, file_path):
-		attr_name = file_path.split(os.path.sep)[-1].split(".")[0]
+	def _load_parameters(self, dir_name, file_name):
+		path = self
+		for sub_path in file_name[len(dir_name) + 1:].split(os.path.sep)[:-1]:
+			if not hasattr(path, sub_path):
+				setattr(path, sub_path, DataStore())
+			path = getattr(path, sub_path)
+		attr_name = file_name.split(os.path.sep)[-1].split(".")[0]
 		param_dict = {}
 
-		with io.open(file_path, "rb") as csvfile:
+		with io.open(file_name, "rb") as csvfile:
 			reader = tsv.dict_reader(csvfile)
-
 			for row in reader:
 				value = json.loads(row['value'])
 				if row['units'] != '':
@@ -313,7 +327,7 @@ class KnowledgeBaseEcoli(object):
 					value = value * unit
 				param_dict[row['name']] = value
 
-		setattr(self, attr_name, param_dict)
+		setattr(path, attr_name, param_dict)
 
 	def _prune_data(self):
 		"""
@@ -390,38 +404,51 @@ class KnowledgeBaseEcoli(object):
 			data_to_modify = getattr(self, modify_attr.split('.')[0])
 			for attr in modify_attr.split('.')[1:]:
 				data_to_modify = getattr(data_to_modify, attr)
-			id_col_name = list(data_to_modify[0].keys())[0]
 
-			id_to_modified_cols = {}
-			for row in data_to_modify:
-				id_to_modified_cols[row[id_col_name]] = row
-
-			# Modify any matching rows with identical IDs
 			data = getattr(self, data_attr)
 
-			if list(data[0].keys())[0] != id_col_name:
-				raise ValueError(f'Could not modify data {data_attr} with '
-					f'{modify_attr} because the names of the first columns '
-					f'do not match.')
+			# If modifying a parameter file, replace values in dictionary
+			if data_attr in self.parameter_file_attribute_names:
+				for key, value in data_to_modify.items():
+					if key not in data:
+						raise ValueError(f'Could not modify data {data_attr}'
+							f'with {modify_attr} because the name {key} does '
+							f'not exist in {data_attr}.')
 
-			modified_entry_ids = set()
-			for i, row in enumerate(data):
-				if row[id_col_name] in id_to_modified_cols:
-					modified_cols = id_to_modified_cols[row[id_col_name]]
-					for col_name in data[i]:
-						if col_name in modified_cols:
-							data[i][col_name] = modified_cols[col_name]
-					modified_entry_ids.add(row[id_col_name])
+					data[key] = value
 
-			# Check for entries in modification data that do not exist in
-			# original data
-			id_diff = set(id_to_modified_cols.keys()).symmetric_difference(
-				modified_entry_ids)
-			if id_diff:
-				raise ValueError(f'Could not modify data {data_attr} with '
-					f'{modify_attr} because of one or more entries in '
-					f'{modify_attr} that do not exist in {data_attr} '
-					f'(nonexistent entries: {id_diff}).')
+			# If modifying a table file, replace rows
+			else:
+				id_col_name = list(data_to_modify[0].keys())[0]
+
+				id_to_modified_cols = {}
+				for row in data_to_modify:
+					id_to_modified_cols[row[id_col_name]] = row
+
+				# Modify any matching rows with identical IDs
+				if list(data[0].keys())[0] != id_col_name:
+					raise ValueError(f'Could not modify data {data_attr} with '
+						f'{modify_attr} because the names of the first columns '
+						f'do not match.')
+
+				modified_entry_ids = set()
+				for i, row in enumerate(data):
+					if row[id_col_name] in id_to_modified_cols:
+						modified_cols = id_to_modified_cols[row[id_col_name]]
+						for col_name in data[i]:
+							if col_name in modified_cols:
+								data[i][col_name] = modified_cols[col_name]
+						modified_entry_ids.add(row[id_col_name])
+
+				# Check for entries in modification data that do not exist in
+				# original data
+				id_diff = set(id_to_modified_cols.keys()).symmetric_difference(
+					modified_entry_ids)
+				if id_diff:
+					raise ValueError(f'Could not modify data {data_attr} with '
+						f'{modify_attr} because of one or more entries in '
+						f'{modify_attr} that do not exist in {data_attr} '
+						f'(nonexistent entries: {id_diff}).')
 
 	def _check_new_gene_ids(self, nested_attr):
 		"""


### PR DESCRIPTION
This PR modifies the mass fraction of rRNAs when the `remove_rrff` ParCa variant option is set to `True`, to have the wildtype and the `remove_rrff` variant have roughly the same rRNA counts. Before this PR, the `remove_rrff` variant had higher rRNA counts because the rRNAs were lighter after the removal of the rrff 5S ribosomal RNA gene, which may have contributed to the variant having higher ribosome counts. This change will help us compare the two simulations in a more equal setting.