### PR TITLE
Add stable-rrna ParCa variant to make mature rRNAs stable

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -1135,12 +1135,17 @@ class Transcription(object):
 		is_16S_rRNA = self.cistron_data['is_16S_rRNA'][mature_rna_cistron_indexes]
 		is_5S_rRNA = self.cistron_data['is_5S_rRNA'][mature_rna_cistron_indexes]
 
-		# Set degradation rates of rRNAs to the average reported degradation
-		# rates of mRNAs
-		# Note: rRNAs complexed into ribosomal subunits will not degrade, so
-		# this will only significantly affect excess rRNAs
 		rna_deg_rates = np.zeros(n_mature_rnas)
-		rna_deg_rates[is_rRNA] = np.log(2) / self.average_mRNA_cistron_half_life.asNumber(units.s)
+		if sim_data.stable_rrna:
+			# If stable rRNA option is on, set degradation rates of mature rRNAs
+			# to the values calculated from the half-life in sim_data.constants
+			rna_deg_rates[is_rRNA] = np.log(2) / sim_data.constants.stable_RNA_half_life.asNumber(units.s)
+		else:
+			# Default: Set degradation rates of mature rRNAs to the average
+			# reported degradation rates of mRNAs
+			# Note: rRNAs complexed into ribosomal subunits will not degrade, so
+			# this will only significantly affect excess rRNAs
+			rna_deg_rates[is_rRNA] = np.log(2) / self.average_mRNA_cistron_half_life.asNumber(units.s)
 
 		# Set degradation rates of tRNAs to the values calculated from the
 		# half-life in sim_data.constants

--- a/reconstruction/ecoli/knowledge_base_raw.py
+++ b/reconstruction/ecoli/knowledge_base_raw.py
@@ -165,8 +165,9 @@ class DataStore(object):
 class KnowledgeBaseEcoli(object):
 	""" KnowledgeBaseEcoli """
 
-	def __init__(self, operons_on: bool, remove_rrna_operons: bool, remove_rrff: bool, new_genes_option: str="off"):
+	def __init__(self, operons_on: bool, remove_rrna_operons: bool, remove_rrff: bool, stable_rrna: bool, new_genes_option: str="off"):
 		self.operons_on = operons_on
+		self.stable_rrna = stable_rrna
 		self.new_genes_option = new_genes_option
 
 		if not operons_on and remove_rrna_operons:

--- a/reconstruction/ecoli/simulation_data.py
+++ b/reconstruction/ecoli/simulation_data.py
@@ -39,6 +39,7 @@ class SimulationDataEcoli(object):
 
 	def initialize(self, raw_data, basal_expression_condition="M9 Glucose minus AAs"):
 		self.operons_on = raw_data.operons_on
+		self.stable_rrna = raw_data.stable_rrna
 
 		self._add_condition_data(raw_data)
 		self.condition = "basal"

--- a/runscripts/fireworks/fw_queue.py
+++ b/runscripts/fireworks/fw_queue.py
@@ -96,6 +96,8 @@ Modeling options:
 	REMOVE_RRFF (int, "0"): if nonzero, remove the rrfF gene the simulation.
 		If OPERONS is set to "on", this also removes the rrfF gene from the
 		rrnD rRNA operon.
+	STABLE_RRNA (int, "0"): if nonzero, the mature rRNA molecules are set to be
+		stable (half-life of 48 hours)
 	VARIABLE_ELONGATION_TRANSCRIPTION (int, "1"): if nonzero, use variable
 		transcription elongation rates for each gene
 	VARIABLE_ELONGATION_TRANSLATION (int, "0"): if nonzero, use variable
@@ -299,6 +301,7 @@ assert OPERONS in constants.EXTENDED_OPERON_OPTIONS, f'{OPERONS=} needs to be in
 NEW_GENES = get_environment("NEW_GENES", constants.DEFAULT_NEW_GENES_OPTION)
 REMOVE_RRNA_OPERONS = bool(int(get_environment("REMOVE_RRNA_OPERONS", DEFAULT_SIMULATION_KWARGS["remove_rrna_operons"])))
 REMOVE_RRFF = bool(int(get_environment("REMOVE_RRFF", DEFAULT_SIMULATION_KWARGS["remove_rrff"])))
+STABLE_RRNA = bool(int(get_environment("STABLE_RRNA", DEFAULT_SIMULATION_KWARGS["stable_rrna"])))
 VARIABLE_ELONGATION_TRANSCRIPTION = bool(int(get_environment("VARIABLE_ELONGATION_TRANSCRIPTION", DEFAULT_SIMULATION_KWARGS["variable_elongation_transcription"])))
 VARIABLE_ELONGATION_TRANSLATION = bool(int(get_environment("VARIABLE_ELONGATION_TRANSLATION", DEFAULT_SIMULATION_KWARGS["variable_elongation_translation"])))
 TRANSLATION_SUPPLY = bool(int(get_environment("TRANSLATION_SUPPLY", DEFAULT_SIMULATION_KWARGS["translationSupply"])))
@@ -459,6 +462,7 @@ class WorkflowBuilder:
 			"new_genes": NEW_GENES,
 			"remove_rrna_operons": REMOVE_RRNA_OPERONS,
 			"remove_rrff": REMOVE_RRFF,
+			"stable_rrna": STABLE_RRNA,
 			"time": SUBMISSION_TIME,
 			"python": sys.version.splitlines()[0],
 			"total_gens": N_GENS,
@@ -525,6 +529,7 @@ class WorkflowBuilder:
 				new_genes=NEW_GENES,
 				remove_rrna_operons=REMOVE_RRNA_OPERONS,
 				remove_rrff=REMOVE_RRFF,
+				stable_rrna=STABLE_RRNA,
 				output=os.path.join(KB_DIRECTORY, constants.SERIALIZED_RAW_DATA)),
 			"InitRawData",
 			priority=12)

--- a/runscripts/manual/runParca.py
+++ b/runscripts/manual/runParca.py
@@ -74,6 +74,7 @@ class RunParca(scriptBase.ScriptBase):
 			'new_genes': args.new_genes,
 			'remove_rrna_operons': args.remove_rrna_operons,
 			'remove_rrff': args.remove_rrff,
+			'stable_rrna': args.stable_rrna,
 			'time': args.time,
 			'python': sys.version.splitlines()[0],
 		}

--- a/validation/ecoli/scripts/rnaDegRates.py
+++ b/validation/ecoli/scripts/rnaDegRates.py
@@ -44,6 +44,7 @@ raw_data = KnowledgeBaseEcoli(
 	operons_on=False,
 	remove_rrna_operons=False,
 	remove_rrff=False,
+	stable_rrna=False,
 	)  # type: Any
 
 modelRates = {}

--- a/wholecell/fireworks/firetasks/initRawData.py
+++ b/wholecell/fireworks/firetasks/initRawData.py
@@ -17,6 +17,7 @@ class InitRawDataTask(FiretaskBase):
 		'new_genes',
 		'remove_rrna_operons',
 		'remove_rrff',
+		'stable_rrna',
 		]
 
 	def run_task(self, fw_spec):
@@ -31,6 +32,7 @@ class InitRawDataTask(FiretaskBase):
 			new_genes_option=new_gene_option,
 			remove_rrna_operons=self.get('remove_rrna_operons', False),
 			remove_rrff=self.get('remove_rrff', False),
+			stable_rrna=self.get('stable_rrna', False),
 			)
 
 		print(f"{time.ctime()}: Saving raw_data")

--- a/wholecell/fireworks/firetasks/parca.py
+++ b/wholecell/fireworks/firetasks/parca.py
@@ -35,6 +35,7 @@ class ParcaTask(FiretaskBase):
 		'variable_elongation_translation',
 		'remove_rrna_operons',
 		'remove_rrff',
+		'stable_rrna',
 		]
 
 	def _get_default(self, key):
@@ -59,6 +60,7 @@ class ParcaTask(FiretaskBase):
 				new_genes=self.get('new_genes'),
 				remove_rrna_operons=self.get('remove_rrna_operons', False),
 				remove_rrff=self.get('remove_rrff', False),
+				stable_rrna=self.get('stable_rrna', False),
 				output=raw_data_file),
 
 			FitSimDataTask(

--- a/wholecell/sim/simulation.py
+++ b/wholecell/sim/simulation.py
@@ -53,6 +53,7 @@ DEFAULT_SIMULATION_KWARGS = dict(
 	inheritedStatePath = None,
 	remove_rrna_operons = False,
 	remove_rrff = False,
+	stable_rrna = False,
 	variable_elongation_transcription=True,
 	variable_elongation_translation = False,
 	raise_on_time_limit = False,

--- a/wholecell/utils/scriptBase.py
+++ b/wholecell/utils/scriptBase.py
@@ -58,6 +58,7 @@ PARCA_KEYS = (
 	'variable_elongation_translation',
 	'remove_rrna_operons',
 	'remove_rrff',
+	'stable_rrna',
 	)
 
 SIM_KEYS = (
@@ -410,6 +411,8 @@ class ScriptBase(metaclass=abc.ABCMeta):
 		self.define_parameter_bool(parser, 'remove_rrff', False,
 		    help="Remove the rrfF gene. If operon option is set to 'on',"
 		         " removes the rrfF gene from the rrnD operon.")
+		self.define_parameter_bool(parser, 'stable_rrna', False,
+			help="Make the mature rRNA molecules stable.")
 
 		self.define_parameter_bool(parser, 'debug_parca', False,
 			help='Make Parca calculate only one arbitrarily-chosen transcription'


### PR DESCRIPTION
This PR adds a `stable-rrna` option for the ParCa to make the mature rRNAs have stable half-lives (48 hours), instead of having half-lives equal to the average measured half-lives of mRNAs. I had to make this a ParCa variant instead of a simulation variant because the bulk of the calculations for the Km values of these RNAs happens within the ParCa using the first-order degradation rate constants calculated from the half-lives.