### PR TITLE
Move back RnaMaturation in process order

### DIFF
--- a/models/ecoli/sim/simulation.py
+++ b/models/ecoli/sim/simulation.py
@@ -76,12 +76,12 @@ class EcoliSimulation(Simulation):
 			ChromosomeReplication,
 			ProteinDegradation,
 			RnaDegradation,
-			RnaMaturation,
 			Complexation,
 		),
 		(
 			TranscriptElongation,
 			PolypeptideElongation,
+			RnaMaturation,
 		),
 		(
 			ChromosomeStructure,


### PR DESCRIPTION
This PR moves back the `RnaMaturation` process to the same tier order as `ChromosomeStructure`. I think this will solve the daily build failure we had last night by not having this process share resources with the degradation processes.