### PR TITLE
Move up RnaMaturation in process order

### DIFF
--- a/models/ecoli/sim/simulation.py
+++ b/models/ecoli/sim/simulation.py
@@ -65,6 +65,7 @@ class EcoliSimulation(Simulation):
 		(
 			Equilibrium,
 			TwoComponentSystem,
+			RnaMaturation,
 		),
 		# Must run before TranscriptInitiation
 		(
@@ -81,8 +82,8 @@ class EcoliSimulation(Simulation):
 		(
 			TranscriptElongation,
 			PolypeptideElongation,
-			RnaMaturation,
 		),
+		# Must run after TranscriptElongation and PolypeptideElongation
 		(
 			ChromosomeStructure,
 		),


### PR DESCRIPTION
This PR moves up the `RnaMaturation` process in the process execution order so that it runs alongside `Equilibrium` and `TwoComponentSystems`. I *think* this will resolve all of the issues with the daily builds we've been seeing recently.