### PR TITLE
Fix issues with the ribosome components plot

### DIFF
--- a/models/ecoli/analysis/multigen/ribosome_components.py
+++ b/models/ecoli/analysis/multigen/ribosome_components.py
@@ -32,14 +32,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		s50_5s_rRNA_ids = sim_data.molecule_groups.s50_5s_rRNA
 		s50_full_complex_id = [sim_data.molecule_ids.s50_full_complex]
 
-		# Read free counts of all components
+		# Read free counts of rRNAs
 		time = read_stacked_columns(cell_paths, 'Main', 'time')
-		(s30_protein_counts, s30_16s_rRNA_counts, s50_protein_counts,
-			s50_23s_rRNA_counts, s50_5s_rRNA_counts
+		(s30_16s_rRNA_counts, s50_23s_rRNA_counts, s50_5s_rRNA_counts
 			) = read_stacked_bulk_molecules(
 			cell_paths,
-			(s30_protein_ids, s30_16s_rRNA_ids, s50_protein_ids,
-			s50_23s_rRNA_ids, s50_5s_rRNA_ids))
+			(s30_16s_rRNA_ids, s50_23s_rRNA_ids, s50_5s_rRNA_ids))
 
 		# Read counts of free 30S and 50S subunits
 		(s30_full_complex_counts, s50_full_complex_counts
@@ -56,16 +54,34 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 				cell_paths, 'UniqueMoleculeCounts', 'uniqueMoleculeCounts',
 				)[:, active_ribosome_index]
 
+		# Read counts of free and complexed ribosomal proteins (this includes
+		# ribosomal proteins in inactive ribosomal subunits and active
+		# ribosomes)
+		simOutDir = os.path.join(cell_paths[0], 'simOut')
+		monomer_counts_reader = TableReader(
+			os.path.join(simOutDir, 'MonomerCounts'))
+		monomer_ids = monomer_counts_reader.readAttribute('monomerIds')
+		monomer_id_to_index = {
+			monomer_id: i for (i, monomer_id) in enumerate(monomer_ids)
+			}
+		s30_protein_indexes = np.array([
+			monomer_id_to_index[protein_id] for protein_id in s30_protein_ids
+			])
+		s50_protein_indexes = np.array([
+			monomer_id_to_index[protein_id] for protein_id in s50_protein_ids
+			])
+		monomer_counts = read_stacked_columns(
+			cell_paths, 'MonomerCounts', 'monomerCounts',
+			)
+		s30_protein_counts = monomer_counts[:, s30_protein_indexes]
+		s50_protein_counts = monomer_counts[:, s50_protein_indexes]
+
 		# Calculate total counts of all components
-		s30_limiting_protein_counts = (
-			s30_protein_counts.min(axis=1)
-			+ s30_full_complex_counts + active_ribosome_counts)
+		s30_limiting_protein_counts = s30_protein_counts.min(axis=1)
 		s30_16s_rRNA_total_counts = (
 			s30_16s_rRNA_counts.sum(axis=1)
 			+ s30_full_complex_counts + active_ribosome_counts)
-		s50_limiting_protein_counts = (
-			s50_protein_counts.min(axis=1)
-			+ s50_full_complex_counts + active_ribosome_counts)
+		s50_limiting_protein_counts = s50_protein_counts.min(axis=1)
 		s50_23s_rRNA_total_counts = (
 			s50_23s_rRNA_counts.sum(axis=1)
 			+ s50_full_complex_counts + active_ribosome_counts)
@@ -73,8 +89,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			s50_5s_rRNA_counts.sum(axis=1)
 			+ s50_full_complex_counts + active_ribosome_counts)
 
+		# Calculate total counts of both subunits
+		s30_total_counts = s30_full_complex_counts + active_ribosome_counts
+		s50_total_counts = s50_full_complex_counts + active_ribosome_counts
+
 		# Plot timetraces of all component counts
-		plt.figure(figsize=(10, 3))
+		plt.figure(figsize=(10, 5))
 
 		# 30S components
 		ax1 = plt.subplot(2, 1, 1)
@@ -82,6 +102,8 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			label='limiting r-protein', c='#cccccc', ls='--', lw=2.5)
 		ax1.plot(time / 60, s30_16s_rRNA_total_counts, clip_on=False,
 			label='16S rRNA', c='C0')
+		ax1.plot(time / 60, s30_total_counts, clip_on=False,
+			label='30S subunit', c='#000000', ls='--', lw=0.5)
 		ax1.set_ylabel('30S component\ncounts')
 		ax1.spines["top"].set_visible(False)
 		ax1.spines["right"].set_visible(False)
@@ -101,6 +123,8 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			label='23S rRNA', c='C1')
 		ax2.plot(time / 60, s50_5s_rRNA_total_counts, clip_on=False,
 			label='5S rRNA', c='C2')
+		ax2.plot(time / 60, s50_total_counts, clip_on=False,
+			label='50S subunit', c='#000000', ls='--', lw=0.5)
 		ax2.set_xlabel('Time (min)')
 		ax2.set_ylabel('50S component\ncounts')
 		ax2.spines["top"].set_visible(False)


### PR DESCRIPTION
This PR fixes some issues we had in the initial version of the multigen `ribosome_components` plot. The original plot used the sum of free ribosomal proteins, ribosomal subunits, and active ribosomes to calculate the total counts of each ribosomal protein, but this count did not include the counts of ribosomal proteins complexed into intermediate protein complexes that are formed during the complexation of ribosomal subunits. In the revised plot we use the `MonomerCounts` table to account for all complexed instances of each ribosomal subunit. We also add the counts of full 30S and 50S subunits to the plot to make it easier to check the sanity of these plots (the dashed black lines should follow the minimum of the other lines for both plots). Example plot shown below:

![ribosome_components](https://github.com/CovertLab/wcEcoli/assets/32276711/5f61c198-c5e5-401a-8e44-308504d6212b)


