### PR TITLE
Limit number of monomers plotted in ribosome_crowding plot

### DIFF
--- a/models/ecoli/analysis/multigen/ribosome_crowding.py
+++ b/models/ecoli/analysis/multigen/ribosome_crowding.py
@@ -33,13 +33,12 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			cell_paths, 'RibosomeData', 'target_prob_translation_per_transcript')
 		actual_prob_translation_per_transcript = read_stacked_columns(
 			cell_paths, 'RibosomeData', 'actual_prob_translation_per_transcript')
-		mRNA_is_overcrowded = read_stacked_columns(cell_paths, 'RibosomeData',
-			'mRNA_is_overcrowded')
 
 		# Get indexes of proteins corresponding to mRNAs that were overcrowded
 		# at some point in the sim
-		overcrowded_monomer_indexes = np.where(mRNA_is_overcrowded.sum(
-			axis=0))[0]
+		overcrowded_monomer_indexes = np.where(
+			(target_prob_translation_per_transcript
+			 - actual_prob_translation_per_transcript).max(axis=0) > 0)[0]
 		n_overcrowded_monomers = len(overcrowded_monomer_indexes)
 
 		# Determine the gene ids corresponding to these proteins
@@ -59,12 +58,14 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		plt.figure(figsize=(6, 1.5*n_overcrowded_monomers))
 
 		for i, monomer_index in enumerate(overcrowded_monomer_indexes):
-			ax = plt.subplot(n_overcrowded_monomers, 1, i + 1)
-			ax.plot(time_min, target_prob_translation_per_transcript[:,
-							  monomer_index], label='target')
-			ax.plot(time_min, actual_prob_translation_per_transcript[:,
-							  monomer_index], label='actual')
+			target_prob_this_monomer = target_prob_translation_per_transcript[
+				:, monomer_index]
+			actual_prob_this_monomer = actual_prob_translation_per_transcript[
+				:, monomer_index]
 
+			ax = plt.subplot(n_overcrowded_monomers, 1, i + 1)
+			ax.plot(time_min, target_prob_this_monomer, label='target')
+			ax.plot(time_min, actual_prob_this_monomer, label='actual')
 			ax.set_ylabel(f'{overcrowded_gene_ids[i]}\ntranslation probs')
 
 			if i == 0:

--- a/models/ecoli/analysis/single/ribosome_crowding.py
+++ b/models/ecoli/analysis/single/ribosome_crowding.py
@@ -30,13 +30,12 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			'target_prob_translation_per_transcript')
 		actual_prob_translation_per_transcript = ribosome_reader.readColumn(
 			'actual_prob_translation_per_transcript')
-		mRNA_is_overcrowded = ribosome_reader.readColumn(
-			'mRNA_is_overcrowded')
 
 		# Get indexes of proteins corresponding to mRNAs that were overcrowded
 		# at some point in the sim
-		overcrowded_monomer_indexes = np.where(mRNA_is_overcrowded.sum(
-			axis=0))[0]
+		overcrowded_monomer_indexes = np.where(
+			(target_prob_translation_per_transcript
+			 - actual_prob_translation_per_transcript).max(axis=0) > 0)[0]
 		n_overcrowded_monomers = len(overcrowded_monomer_indexes)
 
 		# Determine the gene ids corresponding to these proteins
@@ -52,18 +51,19 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			monomer_ids[monomer_index])) for monomer_index in
 			overcrowded_monomer_indexes]
 
-		n_overcrowded_monomers = len(overcrowded_monomer_indexes)
 		if n_overcrowded_monomers > 0:
 			# Plot the target vs actual rna synthesis probabilites of these mRNAs
 			plt.figure(figsize=(6, 1.5*n_overcrowded_monomers))
 
 			for i, monomer_index in enumerate(overcrowded_monomer_indexes):
-				ax = plt.subplot(n_overcrowded_monomers, 1, i + 1)
-				ax.plot(time_min, target_prob_translation_per_transcript[:,
-								  monomer_index], label='target')
-				ax.plot(time_min, actual_prob_translation_per_transcript[:,
-								  monomer_index], label='actual')
+				target_prob_this_monomer = target_prob_translation_per_transcript[
+				:, monomer_index]
+				actual_prob_this_monomer = actual_prob_translation_per_transcript[
+				:, monomer_index]
 
+				ax = plt.subplot(n_overcrowded_monomers, 1, i + 1)
+				ax.plot(time_min, target_prob_this_monomer, label='target')
+				ax.plot(time_min, actual_prob_this_monomer, label='actual')
 				ax.set_ylabel(f'{overcrowded_gene_ids[i]}\ntranslation probs')
 
 				if i == 0:


### PR DESCRIPTION
This PR limits the number of monomers plotted in the single and multigen `ribosome_crowding.py` plot such that only those with significant maximum differences between the actual and target probabilities. This should fix the daily build failure we had earlier today.