### PR TITLE
Fix rRNA location variant

### DIFF
--- a/models/ecoli/sim/variants/rrna_location.py
+++ b/models/ecoli/sim/variants/rrna_location.py
@@ -37,6 +37,8 @@ def rrna_location(sim_data, index):
 		replichore_lengths = sim_data.process.replication.replichore_lengths
 
 		def flip_coordinates(orig_coordinates, length):
+			# Note: this assumes the transcription direction of all rRNA genes
+			# and transcripts are facing away from the origin
 			if orig_coordinates >= 0:
 				return replichore_lengths[0] - orig_coordinates - length
 			else:

--- a/models/ecoli/sim/variants/rrna_location.py
+++ b/models/ecoli/sim/variants/rrna_location.py
@@ -7,12 +7,14 @@ Modifies:
 
 Expected variant indices:
 	0: control
-	1: symmetrically flip the chromosomal positions of all rRNA-encoding geness
+	1: symmetrically flip the chromosomal positions of all rRNA-encoding genes
 	such that most of them lie closer to terC than oriC (Note: there may be
 	some genes that physically overlap as a result of this change)
 """
 
 import numpy as np
+
+from wholecell.utils import units
 
 CONTROL_OUTPUT = dict(
 	shortName = "control",
@@ -22,20 +24,32 @@ CONTROL_OUTPUT = dict(
 
 def rrna_location(sim_data, index):
 	if index == 1:
-		is_rrna = sim_data.process.transcription.rna_data['is_rRNA']
-		coordinate = sim_data.process.transcription.rna_data[
+		rna_is_rrna = sim_data.process.transcription.rna_data['is_rRNA']
+		rna_coordinates = sim_data.process.transcription.rna_data[
 			"replication_coordinate"]
+		rna_lengths = sim_data.process.transcription.rna_data['length'].asNumber(
+			units.nt)
+		gene_is_rrna = sim_data.process.transcription.cistron_data['is_rRNA']
+		gene_coordinates = sim_data.process.transcription.cistron_data[
+			"replication_coordinate"]
+		gene_lengths = sim_data.process.transcription.cistron_data['length'].asNumber(
+			units.nt)
 		replichore_lengths = sim_data.process.replication.replichore_lengths
 
-		def flip_coordinates(orig_coordinates):
+		def flip_coordinates(orig_coordinates, length):
 			if orig_coordinates >= 0:
-				return replichore_lengths[0] - orig_coordinates
+				return replichore_lengths[0] - orig_coordinates - length
 			else:
-				return -replichore_lengths[1] - orig_coordinates
+				return -replichore_lengths[1] - orig_coordinates + length
 
-		# Flip coordinates of all rRNA genes
-		for i in np.where(is_rrna)[0]:
-			coordinate[i] = flip_coordinates(coordinate[i])
+		# Flip coordinates of all rRNA transcription units and genes
+		for i in np.where(rna_is_rrna)[0]:
+			rna_coordinates[i] = flip_coordinates(
+				rna_coordinates[i], rna_lengths[i])
+
+		for i in np.where(gene_is_rrna)[0]:
+			gene_coordinates[i] = flip_coordinates(
+				gene_coordinates[i], gene_lengths[i])
 
 		return dict(
 			shortName = "rrna_relocated",


### PR DESCRIPTION
This PR fixes an error in the implementation of the rRNA location variant, where the locations of the transcription units were flipped but the locations of the rRNA genes were not, leading to some errors in some plots generated from these sims.