### PR TITLE
Add media options for rRNA variants

### DIFF
--- a/models/ecoli/sim/variants/rrna_location.py
+++ b/models/ecoli/sim/variants/rrna_location.py
@@ -1,6 +1,6 @@
 """
 Variant to compare the impacts of changing the locations of rRNA genes on the
-chromosome.
+chromosome in multiple media conditions.
 
 Modifies:
 	sim_data.process.transcription.rna_data["replication_coordinate"]
@@ -10,6 +10,8 @@ Expected variant indices:
 	1: symmetrically flip the chromosomal positions of all rRNA-encoding genes
 	such that most of them lie closer to terC than oriC (Note: there may be
 	some genes that physically overlap as a result of this change)
+	2: same as 1, in rich media conditions
+	3: same as 1, in minimal-to-rich media shift conditions
 """
 
 import numpy as np
@@ -23,7 +25,7 @@ CONTROL_OUTPUT = dict(
 
 
 def rrna_location(sim_data, index):
-	if index == 1:
+	if index > 0:
 		rna_is_rrna = sim_data.process.transcription.rna_data['is_rRNA']
 		rna_coordinates = sim_data.process.transcription.rna_data[
 			"replication_coordinate"]
@@ -53,9 +55,32 @@ def rrna_location(sim_data, index):
 			gene_coordinates[i] = flip_coordinates(
 				gene_coordinates[i], gene_lengths[i])
 
+		# Change media conditions for indexes 2 and 3
+		condition_id = sim_data.condition
+		if index == 2:
+			condition_labels = sim_data.ordered_conditions
+			condition_id = condition_labels[1]  # Index for rich media condition
+			sim_data.condition = condition_id
+			sim_data.external_state.current_timeline_id = condition_id
+			sim_data.external_state.saved_timelines[condition_id] = [
+				(0, sim_data.conditions[condition_id]["nutrients"])
+				]
+		elif index == 3:
+			saved_timelines = sim_data.external_state.saved_timelines
+			timeline_ids = sorted(saved_timelines)
+			condition_id = timeline_ids[28]  # Index for minimal-to-rich media shift
+			sim_data.external_state.current_timeline_id = condition_id
+
+			# Get possible condition from starting nutrients for proper
+			# initialization
+			nutrients = saved_timelines[condition_id][0][1]
+			conditions = [cond for cond in sim_data.condition_active_tfs
+				if sim_data.conditions[cond]['nutrients'] == nutrients]
+			sim_data.condition = conditions[0]
+
 		return dict(
-			shortName = "rrna_relocated",
-			desc = "Simulation with relocated rRNA genes",
+			shortName = f"rrna_relocated_{condition_id}",
+			desc = f"Simulation with relocated rRNA genes in {condition_id}",
 			), sim_data
 
 	else:

--- a/models/ecoli/sim/variants/rrna_operon_knockout.py
+++ b/models/ecoli/sim/variants/rrna_operon_knockout.py
@@ -12,13 +12,9 @@ Modifies:
 
 Expected variant indices:
 	0: control
-	1-7: knockout of one rRNA operon
-	8-28: knockout of two rRNA operons
-	29-63: knockout of three rRNA operons
-	64-98: knockout of four rRNA operons
-	99-119: knockout of five rRNA operons
-	120-126: knockout of six rRNA operons
-	127: knockout of all seven rRNA operons
+	1-6: knockout of one to six rRNA operons in minimal media conditions
+	7-12: knockout of one to six rRNA operons in rich media conditions
+	13-18: knockout of one to six rRNA operons in minimal-to-rich shift conditions
 """
 
 import numpy as np
@@ -31,21 +27,18 @@ CONTROL_OUTPUT = dict(
 
 def rrna_operon_knockout(sim_data, index):
 	if index > 0:
-		def int_to_bool_array(i):
-			return np.array([bool(i & (1 << n)) for n in range(7)])
+		n_rrna_to_ko = index % 6
+		if n_rrna_to_ko == 0:
+			n_rrna_to_ko = 6
 
-		# Build arrays for every combination of rRNAs to knock out
-		rrna_ko_array = np.array([
-			int_to_bool_array(i) for i in range(1, 128)
-			])
-
-		# Sort by number of rRNAs being knocked out
-		rrna_ko_array = rrna_ko_array[np.argsort(rrna_ko_array.sum(axis=1)), :]
+		# Build boolean array for rRNAs to knock out
+		rrna_ko_array = np.zeros(7, dtype=bool)
+		rrna_ko_array[:n_rrna_to_ko] = True
 
 		# Get genes to knock out for this variant
 		rRNA_operons_to_ko = [
 			sim_data.molecule_groups.rRNA_operons[i] for i in
-			np.where(rrna_ko_array[index - 1, :])[0]]
+			np.where(rrna_ko_array)[0]]
 		genes_to_ko = []
 		for rRNA_operon in rRNA_operons_to_ko:
 			genes_to_ko.extend(sim_data.molecule_groups.__dict__[rRNA_operon])
@@ -60,9 +53,34 @@ def rrna_operon_knockout(sim_data, index):
 		sim_data.adjust_final_expression(
 			rna_indexes_to_ko, np.zeros_like(rna_indexes_to_ko))
 
+		condition_index = (index - 1)//6
+
+		# Change media conditions for condition indexes 1 and 2
+		condition_id = sim_data.condition
+		if condition_index == 1:
+			condition_labels = sim_data.ordered_conditions
+			condition_id = condition_labels[1]  # Index for rich media condition
+			sim_data.condition = condition_id
+			sim_data.external_state.current_timeline_id = condition_id
+			sim_data.external_state.saved_timelines[condition_id] = [
+				(0, sim_data.conditions[condition_id]["nutrients"])
+				]
+		elif condition_index == 2:
+			saved_timelines = sim_data.external_state.saved_timelines
+			timeline_ids = sorted(saved_timelines)
+			condition_id = timeline_ids[28]  # Index for minimal-to-rich media shift
+			sim_data.external_state.current_timeline_id = condition_id
+
+			# Get possible condition from starting nutrients for proper
+			# initialization
+			nutrients = saved_timelines[condition_id][0][1]
+			conditions = [cond for cond in sim_data.condition_active_tfs
+				if sim_data.conditions[cond]['nutrients'] == nutrients]
+			sim_data.condition = conditions[0]
+
 		return dict(
-			shortName = f"{'_'.join(rRNA_operons_to_ko)}_rrna_knockout",
-			desc = f"Simulation with the {', '.join(rRNA_operons_to_ko)} rRNA operons knocked out"
+			shortName = f"{'_'.join(rRNA_operons_to_ko)}_rrna_knockout_{condition_id}",
+			desc = f"Simulation with the {', '.join(rRNA_operons_to_ko)} rRNA operons knocked out in {condition_id}"
 			), sim_data
 
 	else:

--- a/models/ecoli/sim/variants/rrna_orientation.py
+++ b/models/ecoli/sim/variants/rrna_orientation.py
@@ -1,5 +1,6 @@
 """
-Variant to compare the impacts of reversing the orientation of rRNA genes.
+Variant to compare the impacts of reversing the orientation of rRNA genes in
+multiple media conditions.
 
 Modifies:
 	sim_data.process.transcription.rna_data["is_forward"]
@@ -7,7 +8,10 @@ Modifies:
 
 Expected variant indices:
 	0: control
-	1: reverse orientation of all rRNA-encoding genes
+	1: reverse orientation of all rRNA-encoding genes, minimal media
+	2: reverse orientation of all rRNA-encoding genes, rich media
+	3: reverse orientation of all rRNA-encoding genes, minimal-to-rich media
+		shift
 """
 
 import numpy as np
@@ -20,7 +24,7 @@ CONTROL_OUTPUT = dict(
 
 
 def rrna_orientation(sim_data, index):
-	if index == 1:
+	if index > 0:
 		is_rrna = sim_data.process.transcription.rna_data['is_rRNA']
 		is_forward = sim_data.process.transcription.rna_data['is_forward']
 		coordinate = sim_data.process.transcription.rna_data[
@@ -32,9 +36,32 @@ def rrna_orientation(sim_data, index):
 			length[is_rrna], is_forward[is_rrna])
 		is_forward[is_rrna] = ~is_forward[is_rrna]
 
+		# Change media conditions for indexes 2 and 3
+		condition_id = sim_data.condition
+		if index == 2:
+			condition_labels = sim_data.ordered_conditions
+			condition_id = condition_labels[1]  # Index for rich media condition
+			sim_data.condition = condition_id
+			sim_data.external_state.current_timeline_id = condition_id
+			sim_data.external_state.saved_timelines[condition_id] = [
+				(0, sim_data.conditions[condition_id]["nutrients"])
+				]
+		elif index == 3:
+			saved_timelines = sim_data.external_state.saved_timelines
+			timeline_ids = sorted(saved_timelines)
+			condition_id = timeline_ids[28]  # Index for minimal-to-rich media shift
+			sim_data.external_state.current_timeline_id = condition_id
+
+			# Get possible condition from starting nutrients for proper
+			# initialization
+			nutrients = saved_timelines[condition_id][0][1]
+			conditions = [cond for cond in sim_data.condition_active_tfs
+				if sim_data.conditions[cond]['nutrients'] == nutrients]
+			sim_data.condition = conditions[0]
+
 		return dict(
-			shortName = "rrna_orientation_reversed",
-			desc = "Simulation with the orientations of all rRNA genes reversed"
+			shortName = f"rrna_orientation_reversed_{condition_id}",
+			desc = f"Simulation with the orientations of all rRNA genes reversed in {condition_id}"
 			), sim_data
 
 	else:

--- a/models/ecoli/sim/variants/timelines.py
+++ b/models/ecoli/sim/variants/timelines.py
@@ -6,7 +6,7 @@ Modifies:
 	sim_data.external_state.current_timeline_id
 
 Expected variant indices (dependent on sorted order from reconstruction/ecoli/flat/condition/timelines_def.tsv):
-	0-26
+	0-28
 """
 
 def timelines(sim_data, index):

--- a/reconstruction/ecoli/flat/condition/timelines_def.tsv
+++ b/reconstruction/ecoli/flat/condition/timelines_def.tsv
@@ -28,3 +28,4 @@
 "000025_cut_aa"	"0 minimal_plus_amino_acids, 1200 minimal"
 "000026_add_and_cut_aa"	"0 minimal, 3600 minimal_plus_amino_acids, 14400 minimal"
 "000027_cut_and_add_aa"	"0 minimal_plus_amino_acids, 18000 minimal, 36000 minimal_plus_amino_acids"
+"000028_add_aa_long"	"0 minimal, 24000 minimal_plus_amino_acids"

--- a/runscripts/rrna_paper/paper_runs.sh
+++ b/runscripts/rrna_paper/paper_runs.sh
@@ -25,92 +25,101 @@ SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
+
 ## Set B - All rRNA genes are transcribed as monocistronic transcription units
 # Set B1 - glucose minimal media
-DESC="SET B1 16 gens 32 seed monocistronic rRNA TUs with glucose minimal media" \
+DESC="SET B1 16 gens 32 seeds monocistronic rRNA TUs with glucose minimal media" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
 REMOVE_RRNA_OPERONS=1 \
-SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
 # Set B2 - rich media
-DESC="SET B2 16 gens 32 seed monocistronic rRNA TUs with glucose minimal media" \
+DESC="SET B2 16 gens 32 seeds monocistronic rRNA TUs with rich media" \
 VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
 REMOVE_RRNA_OPERONS=1 \
-SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
 # Set B3 - shift from minimal to rich media
-DESC="SET B3 24 gens 32 seed monocistronic rRNA TUs with glucose minimal media" \
+DESC="SET B3 24 gens 32 seeds monocistronic rRNA TUs with shift from minimal to rich media" \
 VARIANT="timelines" FIRST_VARIANT_INDEX=28 LAST_VARIANT_INDEX=28 \
 REMOVE_RRNA_OPERONS=1 \
-SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=64 \
+SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
-## Set C - rRNA operon knockouts, glucose minimal media
-# Remove one rRNA operon
-# TODO: simplify variant to include one per # of operons and include nutrients
-DESC="SET C 8 gens 1 seed 6 rRNA operons with glucose minimal media" \
-VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+
+## Set C - rRNA operon knockouts
+# Set C1 - glucose minimal media
+DESC="SET C1 16 gens 32 seeds rRNA operon knockouts with glucose minimal media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=6 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
-# Remove two rRNA operons
-DESC="SET C 8 gens 1 seed 5 rRNA operons with glucose minimal media" \
-VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=8 LAST_VARIANT_INDEX=8 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+# Set C2 - rich media
+DESC="SET C2 16 gens 32 seeds rRNA operon knockouts with rich media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=7 LAST_VARIANT_INDEX=12 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
-# Remove three rRNA operons
-DESC="SET C 8 gens 1 seed 4 rRNA operons with glucose minimal media" \
-VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=29 LAST_VARIANT_INDEX=29 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+# Set C3 - shift from minimal to rich media
+DESC="SET C3 24 gens 32 seeds rRNA operon knockouts with shift from minimal to rich media" \
+VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=13 LAST_VARIANT_INDEX=18 \
+SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
-# Remove four rRNA operons
-DESC="SET C 8 gens 1 seed 3 rRNA operons with glucose minimal media" \
-VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=64 LAST_VARIANT_INDEX=64 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
-RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fireworks/fw_queue.py
 
-# Remove five rRNA operons
-DESC="SET C 8 gens 1 seed 2 rRNA operons with glucose minimal media" \
-VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=99 LAST_VARIANT_INDEX=99 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
-RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fireworks/fw_queue.py
-
-# Remove six rRNA operons
-DESC="SET C 8 gens 1 seed 1 rRNA operon with glucose minimal media" \
-VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=120 LAST_VARIANT_INDEX=120 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
-RUN_AGGREGATE_ANALYSIS=0 \
-python runscripts/fireworks/fw_queue.py
-
-## Set D - flipped locations of rRNA operons, glucose minimal media
-# Change the chromosomal location of rRNA operons
-# TODO: reconfigure variant to include different nutrient conditions
-DESC="SET D 8 gens 1 seed flipped rRNA locations with glucose minimal media" \
+## Set D - Flip chromosomal locations of rRNA operons
+# Set D1 - glucose minimal media
+DESC="SET D1 16 gens 32 seeds flipped rRNA locations with glucose minimal media" \
 VARIANT="rrna_location" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
-SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
-## Set E - flipped orientations of rRNA operons, glucose minimal media
-# Change the orientation of rRNA operons
-# TODO: reconfigure variant to include different nutrient conditions
-DESC="SET E 16 gens 64 seed flipped rRNA orientations with glucose minimal media" \
-VARIANT="rrna_orientation" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
-SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
+# Set D2 - rich media
+DESC="SET D2 16 gens 32 seeds flipped rRNA locations with rich media" \
+VARIANT="rrna_location" FIRST_VARIANT_INDEX=2 LAST_VARIANT_INDEX=2 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
+
+# Set D3 - shift from minimal to rich media
+DESC="SET D3 24 gens 32 seeds flipped rRNA locations with shift from minimal to rich media" \
+VARIANT="rrna_location" FIRST_VARIANT_INDEX=3 LAST_VARIANT_INDEX=3 \
+SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+
+## Set E - Flip the orientation of rRNA operons
+# Set E1 - glucose minimal media
+DESC="SET E1 16 gens 32 seeds flipped rRNA orientations with glucose minimal media" \
+VARIANT="rrna_orientation" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Set E2 - rich media
+DESC="SET E2 16 gens 32 seeds flipped rRNA orientations with rich media" \
+VARIANT="rrna_orientation" FIRST_VARIANT_INDEX=2 LAST_VARIANT_INDEX=2 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Set E3 - shift from minimal to rich media
+DESC="SET E3 24 gens 32 seeds flipped rRNA orientations with shift from minimal to rich media" \
+VARIANT="rrna_orientation" FIRST_VARIANT_INDEX=3 LAST_VARIANT_INDEX=3 \
+SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
 
 ## Set F - Remove the extra 5S gene (rrfF)
 # Set F1 - glucose minimal media

--- a/runscripts/rrna_paper/paper_runs.sh
+++ b/runscripts/rrna_paper/paper_runs.sh
@@ -3,25 +3,56 @@
 lpad reset
 make clean compile
 
-## Set A - WT, glucose minimal media
-# No changes to rRNA operons
-DESC="SET A 16 gens 64 seed WT with glucose minimal media" \
+## Set A - WT, no changes to rRNA operons
+# Set A1 - glucose minimal media
+DESC="SET A1 16 gens 32 seeds WT with glucose minimal media" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
-SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
-## Set B - no rRNA operons, glucose minimal media
-# All rRNA genes are transcribed as single-gene transcription units
-DESC="SET B 16 gens 64 seed single gene rRNA tus with glucose minimal media" \
+# Set A2 - rich media
+DESC="SET A2 16 gens 32 seeds WT with rich media" \
+VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Set A3 - shift from minimal to rich media
+DESC="SET A3 24 gens 32 seeds WT with shift from minimal to rich media" \
+VARIANT="timelines" FIRST_VARIANT_INDEX=28 LAST_VARIANT_INDEX=28 \
+SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+## Set B - All rRNA genes are transcribed as monocistronic transcription units
+# Set B1 - glucose minimal media
+DESC="SET B1 16 gens 32 seed monocistronic rRNA TUs with glucose minimal media" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
 REMOVE_RRNA_OPERONS=1 \
 SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
+# Set B2 - rich media
+DESC="SET B2 16 gens 32 seed monocistronic rRNA TUs with glucose minimal media" \
+VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
+REMOVE_RRNA_OPERONS=1 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Set B3 - shift from minimal to rich media
+DESC="SET B3 24 gens 32 seed monocistronic rRNA TUs with glucose minimal media" \
+VARIANT="timelines" FIRST_VARIANT_INDEX=28 LAST_VARIANT_INDEX=28 \
+REMOVE_RRNA_OPERONS=1 \
+SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=64 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
 ## Set C - rRNA operon knockouts, glucose minimal media
 # Remove one rRNA operon
+# TODO: simplify variant to include one per # of operons and include nutrients
 DESC="SET C 8 gens 1 seed 6 rRNA operons with glucose minimal media" \
 VARIANT="rrna_operon_knockout" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
 SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
@@ -65,6 +96,7 @@ python runscripts/fireworks/fw_queue.py
 
 ## Set D - flipped locations of rRNA operons, glucose minimal media
 # Change the chromosomal location of rRNA operons
+# TODO: reconfigure variant to include different nutrient conditions
 DESC="SET D 8 gens 1 seed flipped rRNA locations with glucose minimal media" \
 VARIANT="rrna_location" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
 SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
@@ -73,18 +105,35 @@ python runscripts/fireworks/fw_queue.py
 
 ## Set E - flipped orientations of rRNA operons, glucose minimal media
 # Change the orientation of rRNA operons
+# TODO: reconfigure variant to include different nutrient conditions
 DESC="SET E 16 gens 64 seed flipped rRNA orientations with glucose minimal media" \
 VARIANT="rrna_orientation" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
 SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=64 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 
-## Set F - remove extra 5S gene, glucose minimal media
-# Remove the extra 5S gene (rrfF)
-DESC="SET F 8 gens 1 seed remove extra 5S with glucose minimal media" \
+## Set F - Remove the extra 5S gene (rrfF)
+# Set F1 - glucose minimal media
+DESC="SET F1 16 gens 32 seed remove extra 5S with glucose minimal media" \
 VARIANT="wildtype" FIRST_VARIANT_INDEX=0 LAST_VARIANT_INDEX=0 \
 REMOVE_RRFF=1 \
-SINGLE_DAUGHTERS=1 N_GENS=8 N_INIT_SIMS=1 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Set F2 - rich media
+DESC="SET F2 16 gens 32 seed remove extra 5S with rich media" \
+VARIANT="condition" FIRST_VARIANT_INDEX=1 LAST_VARIANT_INDEX=1 \
+REMOVE_RRFF=1 \
+SINGLE_DAUGHTERS=1 N_GENS=16 N_INIT_SIMS=32 \
+RUN_AGGREGATE_ANALYSIS=0 \
+python runscripts/fireworks/fw_queue.py
+
+# Set F3 - shift from minimal to rich media
+DESC="SET F3 24 gens 32 seed remove extra 5S with shift from minimal to rich media" \
+VARIANT="timelines" FIRST_VARIANT_INDEX=28 LAST_VARIANT_INDEX=28 \
+REMOVE_RRFF=1 \
+SINGLE_DAUGHTERS=1 N_GENS=24 N_INIT_SIMS=32 \
 RUN_AGGREGATE_ANALYSIS=0 \
 python runscripts/fireworks/fw_queue.py
 


### PR DESCRIPTION
This PR adds options to use the rRNA variants to run in different media conditions, namely rich media and minimal-to-rich shift conditions. For all of them I simply adopted a system where a nonzero variant index also determines which media conditions the specific rRNA variants would run in. The `paper_runs.sh` runscript was updated to make use of these new variants.