### PR TITLE
fix coverage error and a bunch of warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ __pycache__
 
 # Coverage file #
 #################
-.coverage
+.coverage*
 coverage.xml
 
 # Nosetests and Pytest #

--- a/models/ecoli/analysis/analysisPlot.py
+++ b/models/ecoli/analysis/analysisPlot.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import abc
 import os
 import pickle
-from typing import Tuple
+from typing import Any, Tuple
 
 import matplotlib as mp
 from matplotlib import pyplot as plt
@@ -48,6 +48,12 @@ class AnalysisPlot(metaclass=abc.ABCMeta):
 		self.cpus = parallelization.cpus(cpus)
 		self._axeses = {}
 		self.ap = None
+
+	@staticmethod
+	def read_pickle_file(path: str) -> Any:
+		"""Read a pickle file from its file path."""
+		with open(path, 'rb') as f:
+			return pickle.load(f)
 
 	@staticmethod
 	def read_sim_data_file(sim_path: str) -> SimulationDataEcoli:

--- a/models/ecoli/analysis/cohort/centralCarbonMetabolismCorrelationTimeCourse.py
+++ b/models/ecoli/analysis/cohort/centralCarbonMetabolismCorrelationTimeCourse.py
@@ -22,8 +22,8 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 
 		# Get all cells in each seed
 
-		validation_data = pickle.load(open(validationDataFile, "rb"))
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		validation_data = self.read_pickle_file(validationDataFile)
+		sim_data = self.read_pickle_file(simDataFile)
 
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py
+++ b/models/ecoli/analysis/cohort/centralCarbonMetabolismScatter.py
@@ -23,14 +23,14 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		# Get all cells
 		allDir = self.ap.get_cells()
 
-		validation_data = pickle.load(open(validationDataFile, "rb"))
+		validation_data = self.read_pickle_file(validationDataFile)
 		toyaReactions = validation_data.reactionFlux.toya2010fluxes["reactionID"]
 		toyaFluxes = validation_data.reactionFlux.toya2010fluxes["reactionFlux"]
 		toyaStdev = validation_data.reactionFlux.toya2010fluxes["reactionFluxStdev"]
 		toyaFluxesDict = dict(zip(toyaReactions, toyaFluxes))
 		toyaStdevDict = dict(zip(toyaReactions, toyaStdev))
 
-		sim_data = pickle.load(open(simDataFile, 'rb'))
+		sim_data = self.read_pickle_file(simDataFile)
 		cellDensity = sim_data.constants.cell_density
 
 		modelFluxes = {}

--- a/models/ecoli/analysis/cohort/doubling_times_histogram_all.py
+++ b/models/ecoli/analysis/cohort/doubling_times_histogram_all.py
@@ -56,7 +56,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			generation = list(range(FIRST_GENERATION, n_gens))
 			)
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		doubling_times_minutes = []
 

--- a/models/ecoli/analysis/cohort/expression_dynamics.py
+++ b/models/ecoli/analysis/cohort/expression_dynamics.py
@@ -30,7 +30,7 @@ def align_yaxis(ax1, v1, ax2, v2):
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Check if basal sim
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		if sim_data.condition != "basal":
 			print("Skipping - plot only runs for basal sim.")
 			return

--- a/models/ecoli/analysis/cohort/growthDynamics.py
+++ b/models/ecoli/analysis/cohort/growthDynamics.py
@@ -21,7 +21,7 @@ def mm2inch(value):
 
 class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 	def do_plot(self, variantDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		genomeLength = len(sim_data.process.replication.genome_sequence)
 
 

--- a/models/ecoli/analysis/cohort/kinetics_flux_comparison.py
+++ b/models/ecoli/analysis/cohort/kinetics_flux_comparison.py
@@ -30,7 +30,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		# Get all cells
 		allDir = self.ap.get_cells()
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		targetFluxList = []
 		actualFluxList = []

--- a/models/ecoli/analysis/cohort/proteinCopyNumberDistribution.py
+++ b/models/ecoli/analysis/cohort/proteinCopyNumberDistribution.py
@@ -37,7 +37,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			sim_dirs_grouped_by_gen.append(self.ap.get_cells(generation = [gen_idx]))
 
 		# Load simDataFile and get constants
-		sim_data = pickle.load(open(simDataFile, 'rb'))
+		sim_data = self.read_pickle_file(simDataFile)
 		cell_density = sim_data.constants.cell_density
 		ids_translation = sim_data.process.translation.monomer_data["id"]
 		n_proteins = len(ids_translation)

--- a/models/ecoli/analysis/cohort/proteinFoldChangeVsTranscriptionFrequency.py
+++ b/models/ecoli/analysis/cohort/proteinFoldChangeVsTranscriptionFrequency.py
@@ -22,7 +22,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		return
 
 		# Get all ids reqiured
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		ids_complexation = sim_data.process.complexation.molecule_names # Complexe of proteins, and protein monomers
 		ids_complexation_complexes = sim_data.process.complexation.ids_complexes # Only complexes
 		ids_equilibrium = sim_data.process.equilibrium.molecule_names # Complexes of proteins + small molecules, small molecules, protein monomers

--- a/models/ecoli/analysis/cohort/rnaCopyNumberDistribution.py
+++ b/models/ecoli/analysis/cohort/rnaCopyNumberDistribution.py
@@ -37,7 +37,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			sim_dirs_grouped_by_gen.append(self.ap.get_cells(generation = [gen_idx]))
 
 		# Load simDataFile
-		simData = pickle.load(open(simDataFile, 'rb'))
+		simData = self.read_pickle_file(simDataFile)
 
 		# Get IDs for RNA from simData
 		ids_rna = simData.process.transcription.rna_data["id"]

--- a/models/ecoli/analysis/cohort/transcriptFrequency.py
+++ b/models/ecoli/analysis/cohort/transcriptFrequency.py
@@ -28,7 +28,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 			print("Skipping -- transcriptFrequency only runs for multiple seeds")
 			return
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get mRNA data
 		rnaIds = sim_data.process.transcription.rna_data["id"]

--- a/models/ecoli/analysis/cohort/transcriptionGenomeCoverage.py
+++ b/models/ecoli/analysis/cohort/transcriptionGenomeCoverage.py
@@ -18,7 +18,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		return
 
 		# Get IDs of mRNAs
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rnaIds = sim_data.process.transcription.rna_data["id"]
 		isMRna = sim_data.process.transcription.rna_data['is_mRNA']
 		basalExpression = sim_data.process.transcription.rna_expression["basal"]

--- a/models/ecoli/analysis/cohort/transcriptionGenomeCoverageSecondHalf.py
+++ b/models/ecoli/analysis/cohort/transcriptionGenomeCoverageSecondHalf.py
@@ -18,7 +18,7 @@ class Plot(cohortAnalysisPlot.CohortAnalysisPlot):
 		return
 
 		# Get IDs of mRNAs
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rnaIds = sim_data.process.transcription.rna_data["id"]
 		isMRna = sim_data.process.transcription.rna_data['is_mRNA']
 		basalExpression = sim_data.process.transcription.rna_expression["basal"]

--- a/models/ecoli/analysis/multigen/carRegulation.py
+++ b/models/ecoli/analysis/multigen/carRegulation.py
@@ -20,7 +20,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDirs = self.ap.get_cells()
 
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		nAvogadro = sim_data.constants.n_avogadro
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/multigen/centralCarbonMetabolismCorrelationTimeCourse.py
+++ b/models/ecoli/analysis/multigen/centralCarbonMetabolismCorrelationTimeCourse.py
@@ -18,8 +18,8 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		validation_data = pickle.load(open(validationDataFile, "rb"))
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		validation_data = self.read_pickle_file(validationDataFile)
+		sim_data = self.read_pickle_file(simDataFile)
 
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/multigen/centralCarbonMetabolismScatter.py
+++ b/models/ecoli/analysis/multigen/centralCarbonMetabolismScatter.py
@@ -22,14 +22,14 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		# Get all cells
 		cell_paths = self.ap.get_cells()
 
-		validation_data = pickle.load(open(validationDataFile, "rb"))
+		validation_data = self.read_pickle_file(validationDataFile)
 		toyaReactions = validation_data.reactionFlux.toya2010fluxes["reactionID"]
 		toyaFluxes = validation_data.reactionFlux.toya2010fluxes["reactionFlux"]
 		toyaStdev = validation_data.reactionFlux.toya2010fluxes["reactionFluxStdev"]
 		toyaFluxesDict = dict(zip(toyaReactions, toyaFluxes))
 		toyaStdevDict = dict(zip(toyaReactions, toyaStdev))
 
-		sim_data = pickle.load(open(simDataFile, 'rb'))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		modelFluxes = {}
 		toyaOrder = []

--- a/models/ecoli/analysis/multigen/environmental_shift_fluxes.py
+++ b/models/ecoli/analysis/multigen/environmental_shift_fluxes.py
@@ -28,7 +28,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		# Get all cells
 		allDir = self.ap.get_cells()
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rxnStoich = sim_data.process.metabolism.reaction_stoich
 
 		reactants = [

--- a/models/ecoli/analysis/multigen/functionalUnits.py
+++ b/models/ecoli/analysis/multigen/functionalUnits.py
@@ -31,7 +31,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		# Check if cache from rnaVsProteinPerCell.py exists
 		if os.path.exists(os.path.join(plotOutDir, "rnaVsProteinPerCell_alltimesteps.cPickle")):
-			rnaVsProteinPerCell = pickle.load(open(os.path.join(plotOutDir, "rnaVsProteinPerCell_alltimesteps.cPickle"), "rb"))
+			rnaVsProteinPerCell = self.read_pickle_file(os.path.join(plotOutDir, "rnaVsProteinPerCell_alltimesteps.cPickle"))
 			avgProteinCounts_forAllCells = rnaVsProteinPerCell["protein"]
 			monomersInManyComplexes_avgProteins_dict = rnaVsProteinPerCell["monomersInManyComplexes"]
 
@@ -47,7 +47,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		# Check if cache from figure5B_E_F_G.py exist
 		if os.path.exists(os.path.join(plotOutDir, "figure5B.pickle")):
-			figure5B_data = pickle.load(open(os.path.join(plotOutDir, "figure5B.pickle"), "rb"))
+			figure5B_data = self.read_pickle_file(os.path.join(plotOutDir, "figure5B.pickle"))
 			colors = figure5B_data["colors"]
 			mrnaIds = figure5B_data["id"].tolist()
 		else:
@@ -58,7 +58,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDir = self.ap.get_cells()
 
 		# Load sim data
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rnaIds = sim_data.process.transcription.rna_data["id"][sim_data.relation.cistron_to_monomer_mapping] # orders rna IDs to match monomer IDs
 
 		# Make views for monomers

--- a/models/ecoli/analysis/multigen/functionalUnitsFC.py
+++ b/models/ecoli/analysis/multigen/functionalUnitsFC.py
@@ -13,7 +13,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Check if cache from rnaVsProteinPerCell.py exists
 		if os.path.exists(os.path.join(plotOutDir, "rnaVsProteinPerCell_alltimesteps.cPickle")):
-			rnaVsProteinPerCell = pickle.load(open(os.path.join(plotOutDir, "rnaVsProteinPerCell_alltimesteps.cPickle"), "rb"))
+			rnaVsProteinPerCell = self.read_pickle_file(os.path.join(plotOutDir, "rnaVsProteinPerCell_alltimesteps.cPickle"))
 			avgProteinCounts_forAllCells = rnaVsProteinPerCell["protein"]
 			avgProteinCounts_perCell = avgProteinCounts_forAllCells / float(32)
 		else:
@@ -22,7 +22,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		# Check if cache from figure5B_E_F_G.py exist
 		if os.path.exists(os.path.join(plotOutDir, "figure5B.pickle")):
-			figure5B_data = pickle.load(open(os.path.join(plotOutDir, "figure5B.pickle"), "rb"))
+			figure5B_data = self.read_pickle_file(os.path.join(plotOutDir, "figure5B.pickle"))
 			colors = figure5B_data["colors"]
 			mrnaIds = figure5B_data["id"].tolist()
 		else:
@@ -31,7 +31,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		# Check if cache functionalUnits.py exist
 		if os.path.exists(os.path.join(plotOutDir, "functionalUnits.cPickle")):
-			functionalUnits_data = pickle.load(open(os.path.join(plotOutDir, "functionalUnits.cPickle"), "rb"))
+			functionalUnits_data = self.read_pickle_file(os.path.join(plotOutDir, "functionalUnits.cPickle"))
 			minProteinCounts = functionalUnits_data["minProteinCounts"]
 			monomersInManyComplexes_dict = functionalUnits_data["monomersInvolvedInManyComplexes_dict"]
 		else:
@@ -41,13 +41,13 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		# Check if cache ratioFinalToInitialCountMultigen.pickle from figure5_c.py (cohort analysis) exists
 		cohortPlotOutDir = "out/SET_A/20170407.100507.741102__SET_A_32_gens_8_seeds_basal_with_growth_noise_and_D_period/wildtype_000000/plotOut/" # todo, generalize
 		if os.path.exists(os.path.join(cohortPlotOutDir, "ratioFinalToInitialCountMultigen.pickle")):
-			ratioFinalToInitialCountMultigen = pickle.load(open(os.path.join(plotOutDir,"ratioFinalToInitialCountMultigen.pickle"), "rb"))
+			ratioFinalToInitialCountMultigen = self.read_pickle_file(os.path.join(plotOutDir,"ratioFinalToInitialCountMultigen.pickle"))
 		else:
 			print("Requires ratioFinalToInitialCountMultigen.pickle from figure5_c.py")
 			return
 
 		# Load sim data
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rnaIds = sim_data.process.transcription.rna_data["id"][sim_data.relation.cistron_to_monomer_mapping] # orders rna IDs to match monomer IDs
 		rnaIds = rnaIds.tolist()
 		ids_complexation = sim_data.process.complexation.molecule_names # Complexe of proteins, and protein monomers

--- a/models/ecoli/analysis/multigen/growthAffectingPolymerases.py
+++ b/models/ecoli/analysis/multigen/growthAffectingPolymerases.py
@@ -23,7 +23,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		for gen_idx in range(self.ap.n_generation):
 			firstCellLineage.append(self.ap.get_cells(generation = [gen_idx])[0])
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		## Get expected doubling time ##
 		expected_doubling_time = sim_data.doubling_time

--- a/models/ecoli/analysis/multigen/kineticsFluxComparison.py
+++ b/models/ecoli/analysis/multigen/kineticsFluxComparison.py
@@ -36,7 +36,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDir = self.ap.get_cells()
 		# allDir = self.ap.get_cells(generation = [0, 1, 2])
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		allTargetFluxList = []
 		allActualFluxList = []

--- a/models/ecoli/analysis/multigen/limitedEnzymeUgd.py
+++ b/models/ecoli/analysis/multigen/limitedEnzymeUgd.py
@@ -19,7 +19,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		# Get all cells
 		allDir = self.ap.get_cells()
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		enzymeComplexId = "CPLX0-8098[c]"
 		enzymeMonomerId = "UGD-MONOMER[c]"
 		enzyme_rna_cistron_id = "G7091_RNA"

--- a/models/ecoli/analysis/multigen/massShift.py
+++ b/models/ecoli/analysis/multigen/massShift.py
@@ -13,7 +13,7 @@ NUM_SKIP_TIMESTEPS_AT_GEN_CHANGE = 1
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		T_ADD_AA = None
 		T_CUT_AA = None

--- a/models/ecoli/analysis/multigen/mene_limitations.py
+++ b/models/ecoli/analysis/multigen/mene_limitations.py
@@ -45,7 +45,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		allDir = self.ap.get_cells(seed = [0])
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		cellDensity = sim_data.constants.cell_density
 
 		cistron_ids = sim_data.process.transcription.cistron_data["id"]

--- a/models/ecoli/analysis/multigen/probProteinExistAndDouble.py
+++ b/models/ecoli/analysis/multigen/probProteinExistAndDouble.py
@@ -17,7 +17,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		return
 
 		# Get all ids reqiured
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get all cells
 		allDir = self.ap.get_cells()

--- a/models/ecoli/analysis/multigen/proteinAvgCountVsBurstSize.py
+++ b/models/ecoli/analysis/multigen/proteinAvgCountVsBurstSize.py
@@ -14,7 +14,7 @@ CLOSE_TO_DOUBLE = 0.1
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all ids required
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get all cells
 		allDir = self.ap.get_cells()

--- a/models/ecoli/analysis/multigen/proteinCountVsFoldChange.py
+++ b/models/ecoli/analysis/multigen/proteinCountVsFoldChange.py
@@ -13,7 +13,7 @@ CLOSE_TO_DOUBLE = 0.1
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all ids reqiured
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get all cells
 		allDir = self.ap.get_cells()

--- a/models/ecoli/analysis/multigen/proteinCountsValidation.py
+++ b/models/ecoli/analysis/multigen/proteinCountsValidation.py
@@ -17,8 +17,8 @@ from models.ecoli.analysis import multigenAnalysisPlot
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
-		validation_data = pickle.load(open(validationDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
+		validation_data = self.read_pickle_file(validationDataFile)
 
 		monomer_ids = sim_data.process.translation.monomer_data["id"]
 		schmidt_ids = validation_data.protein.schmidt2015Data["monomerId"]

--- a/models/ecoli/analysis/multigen/proteinExistVsBurstSize.py
+++ b/models/ecoli/analysis/multigen/proteinExistVsBurstSize.py
@@ -14,7 +14,7 @@ CLOSE_TO_DOUBLE = 0.1
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all ids reqiured
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get all cells
 		allDir = self.ap.get_cells()

--- a/models/ecoli/analysis/multigen/proteinFoldChangeVsRnaDeg.py
+++ b/models/ecoli/analysis/multigen/proteinFoldChangeVsRnaDeg.py
@@ -18,7 +18,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 
 		# Get all ids reqiured
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get all cells
 		allDir = self.ap.get_cells()

--- a/models/ecoli/analysis/multigen/proteinFoldChangeVsTranscriptionEvents.py
+++ b/models/ecoli/analysis/multigen/proteinFoldChangeVsTranscriptionEvents.py
@@ -14,7 +14,7 @@ CLOSE_TO_DOUBLE = 0.1
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all ids reqiured
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get all cells
 		allDir = self.ap.get_cells()

--- a/models/ecoli/analysis/multigen/proteinFoldChangeVsTranslationEff.py
+++ b/models/ecoli/analysis/multigen/proteinFoldChangeVsTranslationEff.py
@@ -14,7 +14,7 @@ CLOSE_TO_DOUBLE = 0.1
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get all ids reqiured
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Get all cells
 		allDir = self.ap.get_cells()

--- a/models/ecoli/analysis/multigen/rRNA_operon_expression.py
+++ b/models/ecoli/analysis/multigen/rRNA_operon_expression.py
@@ -19,7 +19,7 @@ COLORS = ['C0', 'C1', 'C2', 'royalblue']
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
     def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-        sim_data = pickle.load(open(simDataFile, "rb"))
+        sim_data = self.read_pickle_file(simDataFile)
         transcription = sim_data.process.transcription
         is_rRNA_cistron = transcription.cistron_data['is_rRNA']
         cistron_rRNA_ids = transcription.cistron_data['id'][is_rRNA_cistron]

--- a/models/ecoli/analysis/multigen/replication.py
+++ b/models/ecoli/analysis/multigen/replication.py
@@ -15,7 +15,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		genomeLength = len(sim_data.process.replication.genome_sequence)
 
 

--- a/models/ecoli/analysis/multigen/ribosomeProduction.py
+++ b/models/ecoli/analysis/multigen/ribosomeProduction.py
@@ -22,7 +22,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		for gen_idx in range(self.ap.n_generation):
 			firstCellLineage.append(self.ap.get_cells(generation = [gen_idx])[0])
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		## Get expected doubling time ##
 		expected_doubling_time = sim_data.doubling_time

--- a/models/ecoli/analysis/multigen/ribosomeUsage.py
+++ b/models/ecoli/analysis/multigen/ribosomeUsage.py
@@ -26,7 +26,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			firstCellLineage.append(self.ap.get_cells(generation = [gen_idx])[0])
 
 		# Get sim data from cPickle file
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		# Create new figure and set size
 		fig = plt.figure()

--- a/models/ecoli/analysis/multigen/rnaVsProteinPerCell.py
+++ b/models/ecoli/analysis/multigen/rnaVsProteinPerCell.py
@@ -38,7 +38,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 
 		# Check if cache from figure5B_E_F_G.py exist
 		if os.path.exists(os.path.join(plotOutDir, "figure5B.pickle")):
-			figure5B_data = pickle.load(open(os.path.join(plotOutDir, "figure5B.pickle"), "rb"))
+			figure5B_data = self.read_pickle_file(os.path.join(plotOutDir, "figure5B.pickle"))
 			colors = figure5B_data["colors"]
 			mrnaIds = figure5B_data["id"].tolist()
 		else:
@@ -49,7 +49,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDir = self.ap.get_cells()
 
 		# Load sim data
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rnaIds = sim_data.process.transcription.rna_data["id"][sim_data.relation.cistron_to_monomer_mapping] # orders rna IDs to match monomer IDs
 
 		# Make views for monomers

--- a/models/ecoli/analysis/multigen/rna_decay_03_high.py
+++ b/models/ecoli/analysis/multigen/rna_decay_03_high.py
@@ -27,7 +27,7 @@ from models.ecoli.analysis import multigenAnalysisPlot
 
 class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 	def do_plot(self, seedOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		all_cistron_ids = sim_data.process.transcription.cistron_data["id"].tolist()
 
 		cistron_ids = [

--- a/models/ecoli/analysis/multigen/subgenerationalTranscription.py
+++ b/models/ecoli/analysis/multigen/subgenerationalTranscription.py
@@ -38,8 +38,8 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 			print("Skipping -- figure5B only runs for multigen")
 			return
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
-		validation_data = pickle.load(open(validationDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
+		validation_data = self.read_pickle_file(validationDataFile)
 
 		# Get mRNA cistrons data
 		cistron_ids = sim_data.process.transcription.cistron_data["id"]
@@ -94,7 +94,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		mRNA_cistron_ids_ordered = mRNA_cistron_ids[indexingOrder]
 
 		## Commented code is used when PLOT_GENES_OF_INTEREST is True
-		# raw_data = pickle.load(open("out/SET_A_000000/rawData.cPickle", "rb"))
+		# raw_data = self.read_pickle_file("out/SET_A_000000/rawData.cPickle")
 		# geneIdToGeneSymbol = {x["id"]: x["symbol"] for x in raw_data.genes}
 		# geneSymbolsOrdered = [geneIdToGeneSymbol[x] for x in geneIdsOrdered]
 		# pickle.dump({"geneId": geneIdsOrdered, "geneSymbol": geneSymbolsOrdered}, open(os.path.join(plotOutDir, "figure5B_genes.pickle"), "wb"))

--- a/models/ecoli/analysis/multigen/transcriptionEvents.py
+++ b/models/ecoli/analysis/multigen/transcriptionEvents.py
@@ -21,7 +21,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDir = self.ap.get_cells()
 
 		# Get mRNA data
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		isMRna = sim_data.process.transcription.rna_data['is_mRNA']
 		mRnaIndexes = np.where(isMRna)[0]
 

--- a/models/ecoli/analysis/multigen/transcriptionFrequency.py
+++ b/models/ecoli/analysis/multigen/transcriptionFrequency.py
@@ -26,7 +26,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDir = self.ap.get_cells()
 
 		# Get mRNA data
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rnaIds = sim_data.process.transcription.rna_data["id"]
 		isMRna = sim_data.process.transcription.rna_data['is_mRNA']
 		mRnaIds = np.where(isMRna)[0]

--- a/models/ecoli/analysis/multigen/transcriptionFrequencyOrdered.py
+++ b/models/ecoli/analysis/multigen/transcriptionFrequencyOrdered.py
@@ -21,11 +21,11 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		# Get all cells
 		allDir = self.ap.get_cells()
 
-		validation_data = pickle.load(open(validationDataFile, "rb"))
+		validation_data = self.read_pickle_file(validationDataFile)
 		essential_cistrons = validation_data.essential_genes.essential_cistrons
 
 		# Get mRNA cistron data
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		cistron_ids = sim_data.process.transcription.cistron_data["id"]
 		is_mRNA = sim_data.process.transcription.cistron_data['is_mRNA']
 		mRNA_cistron_indexes = np.where(is_mRNA)[0]

--- a/models/ecoli/analysis/multigen/transcriptionGenomeCoverage.py
+++ b/models/ecoli/analysis/multigen/transcriptionGenomeCoverage.py
@@ -22,7 +22,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDir = self.ap.get_cells()
 
 		# Get IDs of mRNAs
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		rnaIds = sim_data.process.transcription.rna_data["id"]
 		isMRna = sim_data.process.transcription.rna_data['is_mRNA']
 		degRate = sim_data.process.transcription.rna_data['deg_rate']

--- a/models/ecoli/analysis/multigen/trpRegulation.py
+++ b/models/ecoli/analysis/multigen/trpRegulation.py
@@ -20,7 +20,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDirs = self.ap.get_cells()
 
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		nAvogadro = sim_data.constants.n_avogadro
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/multigen/trpSynthaseCapacityVsUsage.py
+++ b/models/ecoli/analysis/multigen/trpSynthaseCapacityVsUsage.py
@@ -20,7 +20,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDirs = self.ap.get_cells()
 
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		trpIdx = sim_data.molecule_groups.amino_acids.index("TRP[c]")
 
 		plt.figure(figsize = (8.5, 11))

--- a/models/ecoli/analysis/multigen/tyrRegulation.py
+++ b/models/ecoli/analysis/multigen/tyrRegulation.py
@@ -20,7 +20,7 @@ class Plot(multigenAnalysisPlot.MultigenAnalysisPlot):
 		allDirs = self.ap.get_cells()
 
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		nAvogadro = sim_data.constants.n_avogadro
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/single/KmOptimization.py
+++ b/models/ecoli/analysis/single/KmOptimization.py
@@ -11,7 +11,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		width = 1
 

--- a/models/ecoli/analysis/single/KmRNAdecayComparison.py
+++ b/models/ecoli/analysis/single/KmRNAdecayComparison.py
@@ -16,7 +16,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		KmFirstOrderDecay = sim_data.process.rna_decay.Km_first_order_decay
 		KmNonLinearDecay = np.concatenate((

--- a/models/ecoli/analysis/single/aaCounts.py
+++ b/models/ecoli/analysis/single/aaCounts.py
@@ -14,7 +14,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, 'rb'))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		aaIDs = sim_data.molecule_groups.amino_acids
 		(aaCounts,) = read_bulk_molecule_counts(simOutDir, (aaIDs,))

--- a/models/ecoli/analysis/single/aaExchangeFluxes.py
+++ b/models/ecoli/analysis/single/aaExchangeFluxes.py
@@ -12,7 +12,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Amino acid IDs
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		aaIDs = sim_data.molecule_groups.amino_acids
 
 		# Amino acid exchanges fluxes

--- a/models/ecoli/analysis/single/centralCarbonMetabolism.py
+++ b/models/ecoli/analysis/single/centralCarbonMetabolism.py
@@ -23,8 +23,8 @@ AVERAGE_COLOR_OPPOSITE_SIGN = 'red'
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		validation_data = pickle.load(open(validationDataFile, "rb"))
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		validation_data = self.read_pickle_file(validationDataFile)
+		sim_data = self.read_pickle_file(simDataFile)
 
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/single/centralCarbonMetabolismCorrelationTimeCourse.py
+++ b/models/ecoli/analysis/single/centralCarbonMetabolismCorrelationTimeCourse.py
@@ -18,8 +18,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		validation_data = pickle.load(open(validationDataFile, "rb"))
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		validation_data = self.read_pickle_file(validationDataFile)
+		sim_data = self.read_pickle_file(simDataFile)
 
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/single/centralCarbonMetabolismScatter.py
+++ b/models/ecoli/analysis/single/centralCarbonMetabolismScatter.py
@@ -43,8 +43,10 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			Fluxes and standard deviations are numpy arrays with units
 			FLUX_UNITS.
 		"""
-		validation_data = self.read_pickle_file(validation_data_file)
-		sim_data = self.read_pickle_file(sim_data_file)
+		with open(validation_data_file, 'rb') as f:
+			validation_data = pickle.load(f)
+		with open(sim_data_file, 'rb') as f:
+			sim_data = pickle.load(f)
 		cell_density = sim_data.constants.cell_density
 
 		mass_listener = TableReader(os.path.join(sim_out_dir, "Mass"))

--- a/models/ecoli/analysis/single/centralCarbonMetabolismScatter.py
+++ b/models/ecoli/analysis/single/centralCarbonMetabolismScatter.py
@@ -43,8 +43,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			Fluxes and standard deviations are numpy arrays with units
 			FLUX_UNITS.
 		"""
-		validation_data = pickle.load(open(validation_data_file, "rb"))
-		sim_data = pickle.load(open(sim_data_file, "rb"))
+		validation_data = self.read_pickle_file(validation_data_file)
+		sim_data = self.read_pickle_file(sim_data_file)
 		cell_density = sim_data.constants.cell_density
 
 		mass_listener = TableReader(os.path.join(sim_out_dir, "Mass"))

--- a/models/ecoli/analysis/single/concentrationDeviation.py
+++ b/models/ecoli/analysis/single/concentrationDeviation.py
@@ -36,7 +36,7 @@ def round_to_1(x):
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		nAvogadro = sim_data.constants.n_avogadro
 		cellDensity = sim_data.constants.cell_density
 		homeostaticRangeObjFractionHigher = sim_data.constants.metabolism_homeostatic_range_obj_fraction_higher

--- a/models/ecoli/analysis/single/dntpCounts.py
+++ b/models/ecoli/analysis/single/dntpCounts.py
@@ -14,7 +14,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, 'rb'))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		dntpIDs = sim_data.molecule_groups.dntps
 		(dntpCounts,) = read_bulk_molecule_counts(simOutDir, (dntpIDs,))

--- a/models/ecoli/analysis/single/equilibriumComparison.py
+++ b/models/ecoli/analysis/single/equilibriumComparison.py
@@ -21,7 +21,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		stoichMatrix = sim_data.process.equilibrium.stoich_matrix().astype(np.int64)
 		ratesFwd = sim_data.process.equilibrium.rates_fwd

--- a/models/ecoli/analysis/single/expected_mechanistic_vs_real_uptake.py
+++ b/models/ecoli/analysis/single/expected_mechanistic_vs_real_uptake.py
@@ -13,7 +13,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 
 		# Amino acid IDs
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		aa_ids = sim_data.molecule_groups.amino_acids
 
 		# Amino acid exchanges fluxes

--- a/models/ecoli/analysis/single/glucoseMassYield.py
+++ b/models/ecoli/analysis/single/glucoseMassYield.py
@@ -18,7 +18,7 @@ GROWTH_UNITS = units.fg / units.s
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		fbaResults = TableReader(os.path.join(simOutDir, "FBAResults"))
 		externalExchangeFluxes = fbaResults.readColumn("externalExchangeFluxes")

--- a/models/ecoli/analysis/single/kineticsFluxComparison.py
+++ b/models/ecoli/analysis/single/kineticsFluxComparison.py
@@ -32,7 +32,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	_suppress_numpy_warnings = True
 
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, 'rb'))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		mainListener = TableReader(os.path.join(simOutDir, "Main"))
 		initialTime = mainListener.readAttribute("initialTime")

--- a/models/ecoli/analysis/single/mRnaHalfLives.py
+++ b/models/ecoli/analysis/single/mRnaHalfLives.py
@@ -20,7 +20,7 @@ MEAN_RNA_COUNT_THRESHOLD = 3
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get the expected degradation rates from KB
-		sim_data = pickle.load(open(simDataFile, 'rb'))
+		sim_data = self.read_pickle_file(simDataFile)
 		is_mRNA = sim_data.process.transcription.rna_data['is_mRNA']
 		expected_degradation_rate_constants = np.array(
 			sim_data.process.transcription.rna_data['deg_rate'][is_mRNA].asNumber()

--- a/models/ecoli/analysis/single/mrnaVsProteinCounts.py
+++ b/models/ecoli/analysis/single/mrnaVsProteinCounts.py
@@ -20,7 +20,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get the names of rnas from the KB
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 
 		protein_ids = sim_data.process.translation.monomer_data["id"]

--- a/models/ecoli/analysis/single/proteinCounts.py
+++ b/models/ecoli/analysis/single/proteinCounts.py
@@ -20,7 +20,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get the names of proteins from the KB
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		monomerCounts = TableReader(os.path.join(simOutDir, "MonomerCounts"))
 		avgCounts = monomerCounts.readColumn("monomerCounts").mean(axis=0)

--- a/models/ecoli/analysis/single/proteinCountsValidation.py
+++ b/models/ecoli/analysis/single/proteinCountsValidation.py
@@ -19,8 +19,8 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile,
 			validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
-		validation_data = pickle.load(open(validationDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
+		validation_data = self.read_pickle_file(validationDataFile)
 
 		sim_monomer_ids = sim_data.process.translation.monomer_data["id"]
 		wisniewski_ids = validation_data.protein.wisniewski2014Data["monomerId"]

--- a/models/ecoli/analysis/single/rRNA_operon_expression.py
+++ b/models/ecoli/analysis/single/rRNA_operon_expression.py
@@ -18,7 +18,7 @@ COLORS = ['C0', 'C1', 'C2', 'royalblue']
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		transcription = sim_data.process.transcription
 		is_rRNA_cistron = transcription.cistron_data['is_rRNA']
 		cistron_rRNA_ids = transcription.cistron_data['id'][is_rRNA_cistron]

--- a/models/ecoli/analysis/single/replication.py
+++ b/models/ecoli/analysis/single/replication.py
@@ -16,7 +16,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		genomeLength = len(sim_data.process.replication.genome_sequence)
 

--- a/models/ecoli/analysis/single/ribosome30SCounts.py
+++ b/models/ecoli/analysis/single/ribosome30SCounts.py
@@ -21,7 +21,7 @@ FONT = {
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		proteinIds = sim_data.molecule_groups.s30_proteins
 		cistron_ids = [sim_data.process.translation.monomer_data['cistron_id'][np.where(sim_data.process.translation.monomer_data['id'] == pid)[0][0]] for pid in proteinIds]
 		rRnaIds = sim_data.molecule_groups.s30_16s_rRNA

--- a/models/ecoli/analysis/single/ribosome50SCounts.py
+++ b/models/ecoli/analysis/single/ribosome50SCounts.py
@@ -21,7 +21,7 @@ FONT = {
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		proteinIds = sim_data.molecule_groups.s50_proteins
 		cistron_ids = [sim_data.process.translation.monomer_data['cistron_id'][np.where(sim_data.process.translation.monomer_data['id'] == pid)[0][0]] for pid in proteinIds]
 		rRnaIds = sim_data.molecule_groups.s50_23s_rRNA

--- a/models/ecoli/analysis/single/rnaDegradationCounts.py
+++ b/models/ecoli/analysis/single/rnaDegradationCounts.py
@@ -20,7 +20,7 @@ FONT = {
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		ntp_ids = ['ATP[c]', 'CTP[c]', 'GTP[c]', 'UTP[c]']
 		endoRnaseIds = sim_data.process.rna_decay.endoRNase_ids

--- a/models/ecoli/analysis/single/rnaseCounts.py
+++ b/models/ecoli/analysis/single/rnaseCounts.py
@@ -16,7 +16,7 @@ from wholecell.analysis.analysis_tools import read_bulk_molecule_counts
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 
 		endoRnaseIds = sim_data.process.rna_decay.endoRNase_ids
 		exoRnaseIds = sim_data.molecule_groups.exoRNases

--- a/models/ecoli/analysis/single/tRnaCounts.py
+++ b/models/ecoli/analysis/single/tRnaCounts.py
@@ -16,7 +16,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Get the names of rnas from the KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		transcription = sim_data.process.transcription
 		uncharged_trna_ids = transcription.uncharged_trna_names
 		charged_trna_ids = transcription.charged_trna_names

--- a/models/ecoli/analysis/single/template.py
+++ b/models/ecoli/analysis/single/template.py
@@ -16,10 +16,8 @@ from wholecell.io.tablereader import TableReader
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
-		with open(simDataFile, 'rb') as f:
-			sim_data = pickle.load(f)
-		with open(validationDataFile, 'rb') as f:
-			validation_data = pickle.load(f)
+		sim_data = self.read_pickle_file(simDataFile)
+		validation_data = self.read_pickle_file(validationDataFile)
 
 		# Listeners used
 		main_reader = TableReader(os.path.join(simOutDir, 'Main'))

--- a/models/ecoli/analysis/single/trpRegulation.py
+++ b/models/ecoli/analysis/single/trpRegulation.py
@@ -17,7 +17,7 @@ from models.ecoli.analysis import singleAnalysisPlot
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 		# Load data from KB
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		nAvogadro = sim_data.constants.n_avogadro
 		cellDensity = sim_data.constants.cell_density
 

--- a/models/ecoli/analysis/single/twoComponentSystem.py
+++ b/models/ecoli/analysis/single/twoComponentSystem.py
@@ -19,7 +19,7 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
 
-		sim_data = pickle.load(open(simDataFile, "rb"))
+		sim_data = self.read_pickle_file(simDataFile)
 		TCS_IDS = []
 		moleculeTypeOrder = ["HK", "PHOSPHO-HK", "LIGAND", "HK-LIGAND", "PHOSPHO-HK-LIGAND", "RR", "PHOSPHO-RR"]
 		moleculeTypeColor = ["b", "b", "orange", "g", "g", "r", "r"]

--- a/models/ecoli/analysis/variant/growthConditionComparison.py
+++ b/models/ecoli/analysis/variant/growthConditionComparison.py
@@ -30,7 +30,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		doublingPerHourDict = {}
 
 		variantSimDataFile = self.ap.get_variant_kb(self.ap.get_variants()[0])
-		sim_data = pickle.load(open(variantSimDataFile, "rb"))
+		sim_data = self.read_pickle_file(variantSimDataFile)
 		nAvogadro = sim_data.constants.n_avogadro.asNumber()
 		chromMass = (sim_data.getter.get_mass(sim_data.molecule_ids.full_chromosome) / sim_data.constants.n_avogadro).asNumber()
 

--- a/models/ecoli/analysis/variant/growth_condition_comparison_validation.py
+++ b/models/ecoli/analysis/variant/growth_condition_comparison_validation.py
@@ -138,7 +138,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 
         # Extract validation data and strip the units while numerically
         # converting to the plotted units
-        validation_data = pickle.load(open(validationDataFile, "rb"))
+        validation_data = self.read_pickle_file(validationDataFile)
         db_table = validation_data.macromolecular_growth_rate_modulation
         val_table = dict()
         for idx in range(len(plotted_variables)):
@@ -162,7 +162,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
         test_cell = ap.get_cells(variant=[variants[0]])[0]
         simOutDir = os.path.join(test_cell, "simOut")
         try:
-            sim_data = pickle.load(open(self.ap.get_variant_kb(variants[0]), 'rb'))
+            sim_data = self.read_pickle_file(self.ap.get_variant_kb(variants[0]))
         except Exception as e:
             print("Couldn't load sim_data object. Exiting.", e)
             return

--- a/models/ecoli/analysis/variant/meneSensitivity.py
+++ b/models/ecoli/analysis/variant/meneSensitivity.py
@@ -29,7 +29,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			return
 
 		# Get constants from wildtype variant
-		sim_data = pickle.load(open(self.ap.get_variant_kb(4), "rb")) # 4 is the wildtype variant
+		sim_data = self.read_pickle_file(self.ap.get_variant_kb(4))  # 4 is the wildtype variant
 		cellDensity = sim_data.constants.cell_density
 		nAvogadro = sim_data.constants.n_avogadro
 

--- a/models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py
+++ b/models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py
@@ -47,7 +47,8 @@ def analyze_variant(args):
 	n_sims = 0
 
 	# Load sim_data attributes for the given variant
-	sim_data = self.read_pickle_file(ap.get_variant_kb(variant))
+	with open(ap.get_variant_kb(variant), 'rb') as f:
+		sim_data = pickle.load(f)
 	cell_density = sim_data.constants.cell_density
 	n_avogadro = sim_data.constants.n_avogadro
 	lambdas = sim_data.process.metabolism.kinetic_objective_weight

--- a/models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py
+++ b/models/ecoli/analysis/variant/metabolism_kinetic_objective_weight.py
@@ -47,7 +47,7 @@ def analyze_variant(args):
 	n_sims = 0
 
 	# Load sim_data attributes for the given variant
-	sim_data = pickle.load(open(ap.get_variant_kb(variant), 'rb'))
+	sim_data = self.read_pickle_file(ap.get_variant_kb(variant))
 	cell_density = sim_data.constants.cell_density
 	n_avogadro = sim_data.constants.n_avogadro
 	lambdas = sim_data.process.metabolism.kinetic_objective_weight
@@ -189,7 +189,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			return
 
 		# Load validation data
-		validation_data = pickle.load(open(validationDataFile, 'rb'))
+		validation_data = self.read_pickle_file(validationDataFile)
 		toya_reactions = validation_data.reactionFlux.toya2010fluxes['reactionID']
 		toya_fluxes = np.array([x.asNumber(DCW_FLUX_UNITS) for x in validation_data.reactionFlux.toya2010fluxes['reactionFlux']])
 		outlier_filter = [False if rxn in OUTLIER_REACTIONS else True for rxn in toya_reactions]

--- a/models/ecoli/analysis/variant/tfFit.py
+++ b/models/ecoli/analysis/variant/tfFit.py
@@ -44,7 +44,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		targetToTfType = {}
 
 		for variant, simDir in zip(variants, all_cells):
-			sim_data = pickle.load(open(self.ap.get_variant_kb(variant), "rb"))
+			sim_data = self.read_pickle_file(self.ap.get_variant_kb(variant))
 
 			delta_prob = sim_data.process.transcription_regulation.delta_prob
 

--- a/models/ecoli/analysis/variant/tfFitComparison.py
+++ b/models/ecoli/analysis/variant/tfFitComparison.py
@@ -34,7 +34,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 
 		for variant, simDir in zip(variants, all_cells):
 
-			sim_data = pickle.load(open(self.ap.get_variant_kb(variant), "rb"))
+			sim_data = self.read_pickle_file(self.ap.get_variant_kb(variant))
 			tfList = ["basal (no TF)"] + sorted(sim_data.tf_to_active_inactive_conditions)
 			simOutDir = os.path.join(simDir, "simOut")
 			tf = tfList[(variant + 1) // 2]

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,11 +80,11 @@ matplotlib==3.7.1
 mock==5.0.2
 mypy==1.3.0
 pandas==2.0.1
-Pillow==9.5.0
+Pillow==10.1.0
 plotly==5.14.1
 pymongo[ocsp]==4.3.3
 pytest==7.3.1
-pytest-cov==4.0.0
+pytest-cov==4.1.0
 PyYAML==6.0
 requests==2.29.0  # update to 2.30 when docker is ready for urllib3 2.0
 ruamel.yaml==0.17.26
@@ -118,7 +118,7 @@ charset-normalizer==3.1.0
 click==8.1.3
 cons==0.4.5
 contourpy==1.0.7
-coverage==7.2.5
+coverage==7.3.2
 cycler==0.11.0
 dash-core-components==2.0.0
 dash-html-components==2.0.0

--- a/runscripts/debug/load_sim_data.py
+++ b/runscripts/debug/load_sim_data.py
@@ -38,8 +38,10 @@ else:
 raw_data_filename = constants.SERIALIZED_RAW_DATA
 sim_data_filename = constants.SERIALIZED_SIM_DATA_FILENAME
 
-raw_data = pickle.load(open(os.path.join(data_dir, raw_data_filename), 'rb'))
-sim_data = pickle.load(open(os.path.join(data_dir, sim_data_filename), 'rb'))
+with open(os.path.join(data_dir, raw_data_filename), 'rb') as f:
+	raw_data = pickle.load(f)
+with open(os.path.join(data_dir, sim_data_filename), 'rb') as f:
+	sim_data = pickle.load(f)
 print('Loaded {} from {}'.format(sim_data_filename, data_dir))
 
 # Shortcuts for easier access or tab complete

--- a/runscripts/jenkins/setup-environment.sh
+++ b/runscripts/jenkins/setup-environment.sh
@@ -10,7 +10,7 @@ if [ -d "${PYENV_ROOT}" ]; then
 fi
 
 ### Edit this line to make this branch use another pyenv like wcEcoli3-staging
-pyenv local wcEcoli3-staging
+pyenv local wcEcoli3
 pyenv activate
 
 make clean compile

--- a/runscripts/jenkins/setup-environment.sh
+++ b/runscripts/jenkins/setup-environment.sh
@@ -10,7 +10,7 @@ if [ -d "${PYENV_ROOT}" ]; then
 fi
 
 ### Edit this line to make this branch use another pyenv like wcEcoli3-staging
-pyenv local wcEcoli3
+pyenv local wcEcoli3-staging
 pyenv activate
 
 make clean compile

--- a/wholecell/loggers/shell.py
+++ b/wholecell/loggers/shell.py
@@ -210,6 +210,10 @@ class Shell(wholecell.loggers.logger.Logger):
 
 		self.write("\n")
 
+		if self.log_file:
+			self.log_file.close()
+			self.log_file = None
+
 	def write(self, text):
 		sys.stdout.write(text)
 		if self.log_file:


### PR DESCRIPTION
* Update the `coverage` library (and `pytest-cov`, too) to fix
  `FileNotFoundError: [Errno 2] No such file or directory: '/[...]/.coverage.jerrys-mbp.lan.68589.696537-journal'` and
  `CoverageWarning: Couldn't use data file '/[...]/.coverage.jerrys-mbp.lan.68587.663756-journal': file is not a database`.
* `.gitignore` the `.coverage*` output files that `coverage` now writes.
* Analysis classes and `shell.py`: Close files to fix lots of ResourceWarnings.
* Update the Pillow library to fix a "High severity" vulnerability although we don't use it in a risky way.

(My procedure for updating the pip requirements is to edit `runscripts/jenkins/setup-environment.sh` to make the PR build use pyenv `wcEcoli3-staging`, update that pyenv, then before merging to master, update pyenv `wcEcoli3` and revert `runscripts/jenkins/setup-environment.sh`.)