### PR TITLE
Use wildtype replication coordinates to calculate ppGpp-adjusted expression levels

### DIFF
--- a/reconstruction/ecoli/dataclasses/process/transcription.py
+++ b/reconstruction/ecoli/dataclasses/process/transcription.py
@@ -844,6 +844,7 @@ class Transcription(object):
 				('tRNA_mw', 'f8'),
 				('Km_endoRNase', 'f8'),
 				('replication_coordinate', 'int64'),
+				('wt_replication_coordinate', 'int64'),
 				('is_forward', 'bool'),
 				('is_mRNA', 'bool'),
 				('is_miscRNA', 'bool'),
@@ -866,6 +867,7 @@ class Transcription(object):
 		rna_data['tRNA_mw'] = tRNA_mws
 		rna_data['Km_endoRNase'] = np.zeros(len(rna_ids_with_compartments))  # Set later in ParCa
 		rna_data['replication_coordinate'] = replication_coordinate
+		rna_data['wt_replication_coordinate'] = replication_coordinate
 		rna_data['is_forward'] = is_forward
 		rna_data['is_mRNA'] = is_mRNA
 		rna_data['is_miscRNA'] = is_miscRNA
@@ -887,6 +889,7 @@ class Transcription(object):
 			'tRNA_mw': units.g / units.mol,
 			'Km_endoRNase': units.mol / units.L,
 			'replication_coordinate': None,
+			'wt_replication_coordinate': None,
 			'is_forward': None,
 			'is_mRNA': None,
 			'is_miscRNA': None,
@@ -1924,7 +1927,11 @@ class Transcription(object):
 		growth = max(cast(float, y), 0.0)
 		tau = np.log(2) / growth / 60
 		loss = growth + self.rna_data['deg_rate'].asNumber(1 / units.s)
-		n_avg_copy = copy_number(tau, self.rna_data['replication_coordinate'])
+		# Use the wildtype replication coordinates that were used to calculate
+		# exp_free and exp_ppgpp, instead of coordinates that can be adjusted
+		# via variants
+		n_avg_copy = copy_number(
+			tau, self.rna_data['wt_replication_coordinate'])
 
 		# Return values
 		factor = loss / n_avg_copy


### PR DESCRIPTION
This PR makes changes to the `synth_prob_from_ppgpp` function that we use to calculate ppGpp-adjusted synthesis probabilities for each gene. Before the change, this function used the `replication_coordinate` value in `rna_data` to normalize the calculated synthesis probabilities by the expected average copy number of the gene. This was problematic for variants where the `replication_coordinate` value was adjusted for some of the genes, because the pre-normalized synthesis probabilities are calculated by the ParCa using the pre-variant wildtype coordinates, while in this function the values in `replication_coordinate` are the values adjusted by the variant. With the changes, we have another column in the `rna_data` struct array that saves the wildtype coordinates, which the `synth_prob_from_ppgpp` function now uses to calculate per-copy synthesis probabilities.