### PR TITLE
Add comparison analysis for rRNA transcription completion rates

### DIFF
--- a/models/ecoli/analysis/comparison/__init__.py
+++ b/models/ecoli/analysis/comparison/__init__.py
@@ -26,6 +26,7 @@ ACTIVE = [
 	"rrna_gene_copy_numbers.py",
 	"rrna_gene_rnap_densities.py",
 	"rrna_to_ribosome_yield.py",
+	"rrna_transcription_completion_rate.py",
 	"tRNA_cistron_expression.py",
 ]
 

--- a/models/ecoli/analysis/comparison/rrna_transcription_completion_rate.py
+++ b/models/ecoli/analysis/comparison/rrna_transcription_completion_rate.py
@@ -1,0 +1,150 @@
+"""
+Comparison plot to compare the completion rates of rRNA transcription events.
+Plots the number of completed rRNA transcription events vs the number of rRNA
+transcription events that were prematurely terminated by collisions with
+replication forks.
+"""
+
+import os
+from typing import Tuple
+
+from matplotlib import pyplot as plt
+import matplotlib.gridspec as gridspec
+# noinspection PyUnresolvedReferences
+import numpy as np
+
+from models.ecoli.analysis import comparisonAnalysisPlot
+from models.ecoli.analysis.AnalysisPaths import AnalysisPaths
+from reconstruction.ecoli.simulation_data import SimulationDataEcoli
+from validation.ecoli.validation_data import ValidationDataEcoli
+from wholecell.analysis.analysis_tools import (exportFigure,
+	read_stacked_columns)
+# noinspection PyUnresolvedReferences
+from wholecell.io.tablereader import TableReader
+
+
+TU_ID_TO_RRNA_OPERON_ID = {
+	'TU0-1181[c]': 'rrnA',
+	'TU0-1182[c]': 'rrnB',
+	'TU0-1183[c]': 'rrnC',
+	'TU0-1191[c]': 'rrnD',
+	'TU0-1186[c]': 'rrnE',
+	'TU0-1187[c]': 'rrnG',
+	'TU0-1189[c]': 'rrnH',
+	}
+
+class Plot(comparisonAnalysisPlot.ComparisonAnalysisPlot):
+	def do_plot(self, reference_sim_dir, plotOutDir, plotOutFileName, input_sim_dir, unused, metadata):
+		ap1, sim_data1, _ = self.setup(reference_sim_dir)
+		ap2, sim_data2, _ = self.setup(input_sim_dir)
+
+		def read_sims(ap, sim_data):
+			# Get cell paths
+			cell_paths = ap.get_cells(
+				generation=np.arange(0, ap.n_generation),
+				only_successful=True)
+			n_cells = len(cell_paths)
+
+			# Get rna ID attributes from reference cell path
+			reference_cell_path = cell_paths[0]
+			sim_out_dir = os.path.join(reference_cell_path, 'simOut')
+			transcript_elongation_reader = TableReader(
+				os.path.join(sim_out_dir, 'TranscriptElongationListener'))
+			te_rna_ids = transcript_elongation_reader.readAttribute('rnaIds')
+			rnap_data_reader = TableReader(
+				os.path.join(sim_out_dir, 'RnapData'))
+			rd_rna_ids = rnap_data_reader.readAttribute('rnaIds')
+
+			# Get indexes of rRNA operons in both listeners
+			te_rrna_indexes = np.array([
+				te_rna_ids.index(key) for key in TU_ID_TO_RRNA_OPERON_ID.keys()
+				])
+			rd_rna_indexes = np.array([
+				rd_rna_ids.index(key) for key in TU_ID_TO_RRNA_OPERON_ID.keys()
+				])
+
+			# Get number of completed and failed rRNA transcript events
+			completed_events = read_stacked_columns(
+				cell_paths, 'TranscriptElongationListener',
+				'countRnaSynthesized', ignore_exception=True,
+				remove_first=True, fun=lambda x: x[:, te_rrna_indexes]
+				)
+			incomplete_events = read_stacked_columns(
+				cell_paths, 'RnapData',
+				'incomplete_transcription_event', ignore_exception=True,
+				remove_first=True, fun=lambda x: x[:, te_rrna_indexes]
+				)
+
+			n_complete = completed_events.sum(axis=0) / n_cells
+			n_incomplete = incomplete_events.sum(axis=0) / n_cells
+
+			return n_complete, n_incomplete
+
+		n1_complete, n1_incomplete = read_sims(ap1, sim_data1)
+		n2_complete, n2_incomplete = read_sims(ap2, sim_data2)
+
+		fig = plt.figure(figsize=(9, 3))
+		gs = fig.add_gridspec(1, 2, width_ratios=(6.5, 1))
+
+		# Plot bar plots for each rRNA operon
+		ax0 = fig.add_subplot(gs[0, 0])
+		for i, (c1, c2, ic1, ic2) in enumerate(
+				zip(n1_complete, n2_complete, n1_incomplete, n2_incomplete)):
+			ax0.bar(
+				1.5 * i - 0.25, c1, width=0.5, alpha=0.5, color='#555555')
+			ax0.bar(
+				1.5 * i - 0.25, ic1, width=0.5, alpha=0.5, color='C3',
+				bottom=c1)
+			ax0.bar(
+				1.5 * i + 0.25, c2, width=0.5, alpha=0.8, color='#555555')
+			ax0.bar(
+				1.5 * i + 0.25, ic2, width=0.5, alpha=0.8, color='C3',
+				bottom=c2)
+
+		ax0.set_xticks(1.5 * np.arange(7))
+		ax0.set_xticklabels([v for v in TU_ID_TO_RRNA_OPERON_ID.values()])
+		ax0.set_xlim([-0.8, 9.8])
+		ax0.set_ylabel('Numbers of transcription events')
+		ax0.spines['top'].set_visible(False)
+		ax0.spines['right'].set_visible(False)
+
+		# Plot bar plots for totals across all rRNA operons
+		ax1 = fig.add_subplot(gs[0, 1])
+
+		ax1.bar(
+			-0.25, n1_complete.sum(), width=0.5, alpha=0.5, color='#555555',
+			label='complete / reference')
+		ax1.bar(
+			-0.25, n1_incomplete.sum(), width=0.5, alpha=0.5, color='C3',
+			bottom=n1_complete.sum(), label='incomplete / reference')
+		ax1.bar(
+			0.25, n2_complete.sum(), width=0.5, alpha=0.8, color='#555555',
+			label='complete / input')
+		ax1.bar(
+			0.25, n2_incomplete.sum(), width=0.5, alpha=0.8, color='C3',
+			bottom=n2_complete.sum(), label='incomplete / input')
+
+		ax1.set_xticks([0])
+		ax1.set_xticklabels(['all operons'])
+		ax1.set_xlim([-0.8, 0.8])
+		ax1.spines['top'].set_visible(False)
+		ax1.spines['right'].set_visible(False)
+
+		ax1.legend(loc='center left', bbox_to_anchor=(1, 0.5), prop={'size': 8})
+
+		plt.tight_layout()
+		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
+		plt.close('all')
+
+
+	def setup(self, inputDir: str) -> Tuple[
+			AnalysisPaths, SimulationDataEcoli, ValidationDataEcoli]:
+		"""Return objects used for analyzing multiple sims."""
+		ap = AnalysisPaths(inputDir, variant_plot=True)
+		sim_data = self.read_sim_data_file(inputDir)
+		validation_data = self.read_validation_data_file(inputDir)
+		return ap, sim_data, validation_data
+
+
+if __name__ == "__main__":
+	Plot().cli()

--- a/models/ecoli/listeners/rnap_data.py
+++ b/models/ecoli/listeners/rnap_data.py
@@ -44,6 +44,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 		self.didInitialize = 0
 		self.terminationLoss = 0
 		self.rnaInitEvent = np.zeros(self.nRnaSpecies, np.int64)
+		self.incomplete_transcription_event = np.zeros(self.nRnaSpecies, np.int64)
 		self.rna_init_event_per_cistron = np.zeros(self.n_cistrons, np.int64)
 		self.didStall = 0
 
@@ -104,6 +105,7 @@ class RnapData(wholecell.listeners.listener.Listener):
 		subcolumns = {
 			'rnaInitEvent': 'rnaIds',
 			'rna_init_event_per_cistron': 'cistron_ids',
+			'incomplete_transcription_event': 'rnaIds',
 			}
 
 		tableWriter.writeAttributes(
@@ -132,16 +134,17 @@ class RnapData(wholecell.listeners.listener.Listener):
 			active_rnap_on_stable_RNA_indexes=self.partial_stable_RNA_RNAP_indexes,
 			active_rnap_n_bound_ribosomes=self.active_rnap_n_bound_ribosomes,
 			actualElongations = self.actualElongations,
+			codirectional_collision_coordinates=self.codirectional_collision_coordinates,
 			didTerminate = self.didTerminate,
 			didInitialize = self.didInitialize,
 			didStall = self.didStall,
-			terminationLoss = self.terminationLoss,
-			rnaInitEvent = self.rnaInitEvent,
-			rna_init_event_per_cistron = self.rna_init_event_per_cistron,
+			headon_collision_coordinates=self.headon_collision_coordinates,
+			incomplete_transcription_event = self.incomplete_transcription_event,
 			n_total_collisions=self.n_total_collisions,
 			n_headon_collisions=self.n_headon_collisions,
 			n_codirectional_collisions=self.n_codirectional_collisions,
 			n_removed_ribosomes=self.n_removed_ribosomes,
-			headon_collision_coordinates=self.headon_collision_coordinates,
-			codirectional_collision_coordinates=self.codirectional_collision_coordinates,
+			terminationLoss = self.terminationLoss,
+			rnaInitEvent = self.rnaInitEvent,
+			rna_init_event_per_cistron = self.rna_init_event_per_cistron,
 			)

--- a/models/ecoli/processes/chromosome_structure.py
+++ b/models/ecoli/processes/chromosome_structure.py
@@ -322,6 +322,9 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 		removed_RNAs_mask = np.isin(
 			RNA_RNAP_indexes, RNAP_unique_indexes[removed_RNAPs_mask])
 
+		# Initialize counts of incomplete transcription events
+		incomplete_transcription_event = np.zeros(self.n_TUs)
+
 		# Remove RNAPs and RNAs that have collided with replisomes
 		if n_total_collisions > 0:
 			self.active_RNAPs.delByIndexes(np.where(removed_RNAPs_mask)[0])
@@ -338,6 +341,8 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 
 			if n_initiated_sequences > 0:
 				incomplete_rna_indexes = RNA_TU_indexes[removed_RNAs_mask]
+				incomplete_transcription_event = np.bincount(
+					incomplete_rna_indexes, minlength=self.n_TUs)
 
 				incomplete_sequences = buildSequences(
 					self.rna_sequences,
@@ -380,6 +385,13 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 					self.ppi.countInc(n_ppi_added)
 				else:
 					self.ppi.countDec(-n_ppi_added)
+
+			assert n_initiated_sequences == incomplete_transcription_event.sum()
+
+		# Write to listener
+		self.writeToListener(
+			'RnapData', 'incomplete_transcription_event',
+			incomplete_transcription_event)
 
 		# Get mask for ribosomes that are bound to nonexisting mRNAs
 		remaining_RNA_unique_indexes = RNA_unique_indexes[


### PR DESCRIPTION
This PR adds a new comparison analysis script that compares the completion rates of transcription of rRNA operons. I needed to add a new column to the `RnapData` listener to keep track of the number of transcription events that ended prematurely due to collisions with the replication forks. Example plot output is shown below. I'm not a big fan of the color scheme I ended up using, so this might change in the future.

![rrna_transcription_completion_rate](https://github.com/CovertLab/wcEcoli/assets/32276711/cfc64583-9f43-4387-be2a-894597444ae7)
