### PR TITLE
Update list of removed TUs for remove-rrna-operons variant

### DIFF
--- a/reconstruction/ecoli/flat/rrna_options/remove_rrna_operons/transcription_units_removed.tsv
+++ b/reconstruction/ecoli/flat/rrna_options/remove_rrna_operons/transcription_units_removed.tsv
@@ -49,6 +49,7 @@
 "TU00027"	"Transcription unit type not supported (mRNA-miscRNA)"
 "TU00029"	"Transcription unit type not supported (mRNA-miscRNA)"
 "TU182"	"Transcription unit type not supported (mRNA-miscRNA)"
+"TU0-198710"	"Transcription unit type not supported (mRNA-miscRNA)"
 "TU0-14510"	"Non-canonical rRNA transcription unit"
 "TU0-14524"	"Non-canonical rRNA transcription unit"
 "TU0-14528"	"Non-canonical rRNA transcription unit"


### PR DESCRIPTION
This PR adds another TU to the list of TUs to remove for the `remove-rrna-operons` variant to keep it in sync with the latest EcoCyc update.