### PR TITLE
Debug “Blas libraries are not found” warnings. [TODO: Fix #1419]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: compile, clean, recompile
 
 compile:
+	echo make-compile pyenv: "$(pyenv version)"
+	pip list | grep 'numpy\|scipy'
+	runscripts/debug/numpy_benchmark.py
 	python setup.py build_ext --inplace
 	rm -fr build
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ clean:
 	find . -name "*.so" -exec rm -fr {} +
 	rm -fr build
 	rm -fr launcher_20* block_20*
+	echo make-clean pyenv: "$(pyenv version)"
+	pip list | grep 'numpy\|scipy'
 	if [ "`aesara-cache | xargs du -sm | cut -f1`" -gt 30 ]; then \
 		echo "Clearing the aesara-cache since it's larger than threshold."; \
 		aesara-cache clear; \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 	rm -fr launcher_20* block_20*
 	pyenv version
 	pip list | grep 'numpy\|scipy'
-	aesara-cache purge
+	aesara-cache clear
 	aesara-cache
 
 # Delete just the *.so libraries then (re)compile them.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: compile, clean, recompile
 
 compile:
-	echo make-compile pyenv: "$(pyenv version)"
+	pyenv version
 	pip list | grep 'numpy\|scipy'
 	runscripts/debug/numpy_benchmark.py
 	python setup.py build_ext --inplace
@@ -20,12 +20,10 @@ clean:
 	find . -name "*.so" -exec rm -fr {} +
 	rm -fr build
 	rm -fr launcher_20* block_20*
-	echo make-clean pyenv: "$(pyenv version)"
+	pyenv version
 	pip list | grep 'numpy\|scipy'
-	if [ "`aesara-cache | xargs du -sm | cut -f1`" -gt 30 ]; then \
-		echo "Clearing the aesara-cache since it's larger than threshold."; \
-		aesara-cache clear; \
-	fi
+	aesara-cache purge
+	aesara-cache
 
 # Delete just the *.so libraries then (re)compile them.
 # This is useful when switching to a different Python virtualenv.

--- a/runscripts/jenkins/ecoli-pull-request-tests.sh
+++ b/runscripts/jenkins/ecoli-pull-request-tests.sh
@@ -5,8 +5,12 @@ set -e
 ### another pyenv for testing (eg. wcEcoli3-staging). Revert the change before
 ### merging the PR into master to prevent changing it for other Jenkins builds.
 ### ---------------------------------------------------------------------------
+echo eprt1
 source runscripts/jenkins/setup-environment.sh
 
+echo eprt2
 echo pyenv version: $(pyenv version)
 
+echo eprt3
 pytest --cov=wholecell --cov-report xml --junitxml=unittests.xml
+echo eprt4

--- a/runscripts/jenkins/ecoli-pull-request-tests.sh
+++ b/runscripts/jenkins/ecoli-pull-request-tests.sh
@@ -9,8 +9,13 @@ echo eprt1
 source runscripts/jenkins/setup-environment.sh
 
 echo eprt2
-echo pyenv version: $(pyenv version)
+echo eprt2 pyenv: "$(pyenv version)"
+pip list | grep 'numpy\|scipy'
+runscripts/debug/numpy_benchmark.py
 
 echo eprt3
 pytest --cov=wholecell --cov-report xml --junitxml=unittests.xml
+
 echo eprt4
+echo eprt4 pyenv: "$(pyenv version)"
+runscripts/debug/numpy_benchmark.py

--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -14,11 +14,13 @@ echo epr3
 echo y | lpad reset
 
 echo epr4
+# `fw_queue.py` gets some BLAS warnings.
 DESC="2 generations completion test." OPERONS=on WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 \
 	PARALLEL_PARCA=1 COMPRESS_OUTPUT=0 PLOTS=ACTIVE BUILD_CAUSALITY_NETWORK=1 RAISE_ON_TIME_LIMIT=1 \
 	PYTHONWARNINGS=default python runscripts/fireworks/fw_queue.py
 
 echo epr5
+# `run-fireworks.sh` gets some BLAS warnings.
 bash runscripts/jenkins/run-fireworks.sh
 
 echo epr6

--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -13,15 +13,25 @@ sh runscripts/jenkins/fireworks-config.sh "pr$EXECUTOR_NUMBER"
 echo epr3
 echo y | lpad reset
 
+echo epr3 pyenv: "$(pyenv version)"
+pip list | grep 'numpy\|scipy'
+runscripts/debug/numpy_benchmark.py
+
 echo epr4
 # `fw_queue.py` gets some BLAS warnings.
 DESC="2 generations completion test." OPERONS=on WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 \
 	PARALLEL_PARCA=1 COMPRESS_OUTPUT=0 PLOTS=ACTIVE BUILD_CAUSALITY_NETWORK=1 RAISE_ON_TIME_LIMIT=1 \
 	PYTHONWARNINGS=default python runscripts/fireworks/fw_queue.py
 
+echo epr4 pyenv: "$(pyenv version)"
+runscripts/debug/numpy_benchmark.py
+
 echo epr5
 # `run-fireworks.sh` gets some BLAS warnings.
 bash runscripts/jenkins/run-fireworks.sh
+
+echo epr5 pyenv: "$(pyenv version)"
+runscripts/debug/numpy_benchmark.py
 
 echo epr6
 runscripts/jenkins/runscript-checks.sh

--- a/runscripts/jenkins/ecoli-pull-request.sh
+++ b/runscripts/jenkins/ecoli-pull-request.sh
@@ -5,17 +5,25 @@ set -e
 ### another pyenv for testing (eg. wcEcoli3-staging). Revert the change before
 ### merging the PR into master to prevent changing it for other Jenkins builds.
 ### ---------------------------------------------------------------------------
+echo epr1
 source runscripts/jenkins/setup-environment.sh
+echo epr2
 sh runscripts/jenkins/fireworks-config.sh "pr$EXECUTOR_NUMBER"
 
+echo epr3
 echo y | lpad reset
 
+echo epr4
 DESC="2 generations completion test." OPERONS=on WC_ANALYZE_FAST=1 SINGLE_DAUGHTERS=1 N_GENS=2 MASS_DISTRIBUTION=0 \
 	PARALLEL_PARCA=1 COMPRESS_OUTPUT=0 PLOTS=ACTIVE BUILD_CAUSALITY_NETWORK=1 RAISE_ON_TIME_LIMIT=1 \
 	PYTHONWARNINGS=default python runscripts/fireworks/fw_queue.py
 
+echo epr5
 bash runscripts/jenkins/run-fireworks.sh
 
+echo epr6
 runscripts/jenkins/runscript-checks.sh
 
+echo epr7
 rm -fr out/*
+echo epr8

--- a/runscripts/jenkins/setup-environment.sh
+++ b/runscripts/jenkins/setup-environment.sh
@@ -1,16 +1,25 @@
 set -e
 
+echo se1
 export PYTHONPATH=$PWD
+echo se2
 module load wcEcoli/python3
 
 if [ -d "${PYENV_ROOT}" ]; then
+    echo se3
     export PATH="${PYENV_ROOT}/bin:${PATH}"
+    echo se4
     eval "$(pyenv init -)"
+    echo se5
     eval "$(pyenv virtualenv-init -)"
 fi
 
 ### Edit this line to make this branch use another pyenv like wcEcoli3-staging
+echo se6
 pyenv local wcEcoli3
+echo se7
 pyenv activate
 
+echo se8
 make clean compile
+echo se9

--- a/runscripts/jenkins/setup-environment.sh
+++ b/runscripts/jenkins/setup-environment.sh
@@ -4,6 +4,7 @@ echo se1
 export PYTHONPATH=$PWD
 echo se2
 module load wcEcoli/python3
+module list
 
 if [ -d "${PYENV_ROOT}" ]; then
     echo se3
@@ -12,6 +13,7 @@ if [ -d "${PYENV_ROOT}" ]; then
     eval "$(pyenv init -)"
     echo se5
     eval "$(pyenv virtualenv-init -)"
+    echo pyenv: "$(pyenv version)"
 fi
 
 ### Edit this line to make this branch use another pyenv like wcEcoli3-staging
@@ -21,5 +23,6 @@ echo se7
 pyenv activate
 
 echo se8
+# `make compile` gets some BLAS warnings.
 make clean compile
 echo se9

--- a/runscripts/jenkins/setup-environment.sh
+++ b/runscripts/jenkins/setup-environment.sh
@@ -22,6 +22,10 @@ pyenv local wcEcoli3
 echo se7
 pyenv activate
 
+echo se7 pyenv: "$(pyenv version)"
+pip list | grep 'numpy\|scipy'
+runscripts/debug/numpy_benchmark.py
+
 echo se8
 # `make compile` gets some BLAS warnings.
 make clean compile

--- a/runscripts/jenkins/setup-environment.sh
+++ b/runscripts/jenkins/setup-environment.sh
@@ -27,6 +27,12 @@ pip list | grep 'numpy\|scipy'
 runscripts/debug/numpy_benchmark.py
 
 echo se8
-# `make compile` gets some BLAS warnings.
-make clean compile
+PYTHONWARNINGS=default python -c 'from distutils.core import setup'
+
 echo se9
+# `make` gets some BLAS warnings.
+make clean
+
+echo se10
+make compile
+echo se11


### PR DESCRIPTION
* echo positions in `runscripts/jenkins/ecoli-pull-request*.sh` to narrow down the source(s) of the “Blas libraries are not found” warnings.
