### PR TITLE
Style guide

### DIFF
--- a/docs/dev-tools.md
+++ b/docs/dev-tools.md
@@ -286,6 +286,12 @@ source code, and many other features for working with Python code.
 See [this PyCharm debugger tutorial video](https://youtu.be/QJtWxm12Eo0) or
 [this PyCharm debugger tutorial webpage](https://www.jetbrains.com/help/pycharm/debugging-your-first-python-application.html).
 
+#### Code style settings
+
+The checked-in file `.idea/codeStyles/Project.xml` should set up TAB
+indentations, line margins, and a few other code formatting styles.
+Otherwise do it manually.
+
 #### Mismatched package names
 
 PyCharm's inspector gives false-positive error messages like:
@@ -294,17 +300,7 @@ PyCharm's inspector gives false-positive error messages like:
 
 because it assumes imported module names (`Bio`) match their PyPI package names
 (`biopython`) except for a specific list of exceptions. The built-in exceptions
-list doesn't include `stochastic-arrow`, `biopython`, etc., but we can add them.
-
-**The fix:** Each time you install a PyCharm release, run the following shell command,
-then restart PyCharm:  
-
-> \[NOTE: So far, this script only works on macOS and maybe only for PyCharm Pro
-installed by JetBrains Toolbox. It won't work with snap-installed PyCharm since
-snap installs on a readonly file system. To support other installations,
-enhance the script for where `python.jar` or `python-ce.jar` gets installed.]
-
-    runscripts/tools/augment-pycharm-package-list.sh
+list doesn't include `stochastic-arrow`, `biopython`, etc.
 
 See [You Track issue #PY-27985](https://youtrack.jetbrains.com/issue/PY-27985).
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -101,8 +101,8 @@ and whether to:
   avoid certain kinds of problems. The wcEcoli project doesn't follow this recommendation
   but it might be sensible to move in that direction.
   It's conventional and convenient to import names from `typing`
-  (`from typing import Any, cast`) and some other modules, and a case could be made to treat
-  classes as scopes like modules in this sense.
+  (`from typing import Any, cast`), `collections.abc`, and some other modules,
+  and a case could be made to treat classes as scopes like modules in this sense.
 
 * Mostly use **absolute imports**. Occasionally it's worth using an explicit relative import,
   esp. when an absolute import is unnecessarily verbose:
@@ -198,7 +198,7 @@ and whether to:
   # Put no space in function application or object indexing.
   spam(1) < spam(2)
   dct['key'] += lst[index]
-  
+
   # Don't line up the `=` on multiple lines of assignment statements.
   # Maintaining it costs work and merge conflicts.
   x = 1
@@ -213,6 +213,8 @@ and whether to:
   # Use spaces or parentheses to help convey precedence.
   # Put zero or one space on each side of a binary operator (except indentation).
   hypot2 = x*x + y*y
+
+  x: int = 333
   ```
 
 * Avoid compound statements on one line.
@@ -237,7 +239,7 @@ and whether to:
    camelCase  # it's OK to match the existing style but it's good to change it to snake case
 
    _internal_name
-   __mangled_class_attribute_name
+   __mangled_class_attribute_name  # https://peps.python.org/pep-0008/#designing-for-inheritance
    
    module_name
    package  # underscores are discouraged
@@ -284,6 +286,10 @@ See https://google.github.io/styleguide/pyguide.html
 * A function must have a docstring, unless it's: not externally visible, short, and obvious.
   Explain what you need to know to call it.
 * Classes should have docstrings.
+* `TODO: Investigate optimizations`. Searchable "TODO" comment. Mention an Issue number if any.
+  (The older style was `TODO(username):`, naming who to ask for more information.)
+* Use `assert` in unit tests and to check internal correctness. For a mistake at the API level,
+  raise an exception. Raise built-in exception classes like `ValueError` when it makes sense.
 
 
 ## Pythonic Style
@@ -323,14 +329,14 @@ def f(x=None):
   correctly.
 
 ### Exceptions
-* Use the bare `except:` clause only when just printing/logging the traceback and in
-  debugging tools.
+* Use the bare `except:` clause only when just printing/logging the traceback and
+  re-raising the exception, or in a debugging tool.
 * Limit a `try` clause to a narrow range of code so it only doesn't bury totally
   unexpected exceptions.
 * Use a `with` statement or `try`/`finally` to ensure cleanup gets done, like closing a file.
 * Any kind of failure should raise an explicit exception.
 * Derive exceptions from `Exception` rather than `BaseException` unless catching this
-  exception is almost always the wrong thing to do, like `KeyboardInterrupt`.
+  exception is almost always the wrong thing to do, like `KeyboardInterrupt` and `SystemExit`.
 * When raising exceptions, aim to answer "What went wrong?" rather than just
   indicating "A problem occurred."
 
@@ -349,7 +355,7 @@ type hints on functions and occasionally on variables when the type checker can'
 E.g. mypy can't infer the element type when you create an empty collection. In a difficult case,
 you can punt by using type `Any` which can assign to or from anything.
 
-([These Google Slides](https://docs.google.com/presentation/d/1xwVHjpQsRTGLdaIpPDNjKPQFtp7mBNfn7oTWK4Kct30/edit?usp=drivesdk)
+([These Slides](https://docs.google.com/presentation/d/1xwVHjpQsRTGLdaIpPDNjKPQFtp7mBNfn7oTWK4Kct30/edit?usp=drivesdk)
 review our past plan for adding type hints to aid the migration to Python 3.)
 
 You can type a list of strings as `list[str]` or `List[str]`, and similar for other

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,91 +1,136 @@
 # Style Guide
 
-_These guidelines are condensed from the PEP8 and Google style guides here, along with our decisions. -- Jerry_
+_These guidelines are condensed from the PEP8 and Google style guides and our team decisions. -- Jerry_
 
 * See [PEP8](https://www.python.org/dev/peps/pep-0008/)
 * See [Google's Python style guide](https://google.github.io/styleguide/pyguide.html)
 * See our [March 12, 2018 meeting slides](https://docs.google.com/presentation/d/1pf6GQmMwbUoeASmNk1bmjYZ-PteJ0tSFH0v6P6vd5eE/edit#slide=id.g313d94100c_0_55) with notes on the tradeoffs between alternatives.
 
-## Note: The project has transitioned to Python 3.
+
+**What's a style guide?** Recommendations on coding alternatives like naming style, code layout,
+docstring format, and common code patterns.
+
+**Purpose:**
+* Avoid some classes of bugs.
+* Increase code readability, familiarity, and portability.
+* Reduce work when merging code changes.
+* Make it easier to collaborate.
+
+But don't overdo consistency. There are cases for exceptions.
+
+This doc (and the 2018 meeting slides) should summarize the team's decisions on
+each PEP8 guideline to:
+* Expected (point it out in code reviews), or
+* Soft target (don't sweat it in code reviews), or
+* Not adopted.
+
+and whether to:
+* Adopt it for new code.
+* Plan to change existing code gradually or rapidly.
 
 
-# Style Guides
+## wcEcoli Style Guidelines from PEP8 ... with adjustments
 
-Style guides make recommendations among programming alternatives like [imports](https://docs.google.com/presentation/d/1pf6GQmMwbUoeASmNk1bmjYZ-PteJ0tSFH0v6P6vd5eE/edit#slide=id.g313d94100c_0_107), [docstrings](https://docs.google.com/presentation/d/1pf6GQmMwbUoeASmNk1bmjYZ-PteJ0tSFH0v6P6vd5eE/edit#slide=id.g313d94100c_0_123), [common patterns](https://docs.google.com/presentation/d/1pf6GQmMwbUoeASmNk1bmjYZ-PteJ0tSFH0v6P6vd5eE/edit#slide=id.g313d94100c_0_117), [names](https://docs.google.com/presentation/d/1pf6GQmMwbUoeASmNk1bmjYZ-PteJ0tSFH0v6P6vd5eE/edit#slide=id.g313d94100c_0_151), and [layout](https://docs.google.com/presentation/d/1pf6GQmMwbUoeASmNk1bmjYZ-PteJ0tSFH0v6P6vd5eE/edit#slide=id.g313d94100c_0_131). The purpose is to reduce the likelihood of some bugs, increase code readability and familiarity, and make it easier for programmers to collaborate and merge code. But don't overdo consistency.
+### Misc
 
-For each guideline, we could decide to:
-1. Set an expectation. Point it out in code reviews.
-2. Soft target. Don't sweat it in code reviews.
-3. Don't adopt it.
+* Use **UTF-8 text encoding** (otherwise the source file needs an encoding declaration).
 
-and we can plan to:
-1. Adopt it for new code.
-2. Plan to change existing code gradually or rapidly.
+* Module content order:
+
+  ```python
+  """Module docstring."""
+  __future__ imports
+  __all__ = ['a', 'b', 'c']  # and other "dunder" settings like __version__ and __author__
+  imports
+  code
+  ```
+
+* Aim for **docstrings** on all public modules, functions, classes, and methods.
+  * `"""Docstrings should use triple quotes."""` whether it's one line or many; `"""` or `'''`.
+    (The `"""` that ends a multiline docstring is supposed to go on a line by itself for some
+    reason.)
+  * A function docstring should start with an imperative sentence like "Plot all the things.".
+  * Add docstrings to existing classes and functions while working on the code.
+    A short introduction can be a big help over nothing.
+  * Comments and docstrings that contradict the code are worse than no comments.
+  * Write complete sentences.
+  * Tip: If a docstring contains LaTeX code, make it a raw docstring:
+
+    ```python
+    r"""Fits the values of alpha and r such that the computed RNA synthesis
+    probabilities converge to the measured RNA synthesis probabilities.
+    
+    v_{synth, j} = \alpha_j + \sum_{i} P_{T,i}*r_{ij}
+    """
+    ```
+
+* Comments are usually complete sentences. The first word should be capitalized unless it's
+  an identifier that begins with a lower case letter.
 
 
-## PEP8 Style Guidelines -- with a few adjustments
+### Indentation
 
-* **Indentation:** Stick with TABs in this project.
-  * Set your editor's TAB stops to 4 spaces.
-  * Python assumes TAB stops are at 8 spaces unless told otherwise.
-  * Python 3 disallows mixing the use of tab and space indentation.
-  * Set a nightly build script or a check-in script to flag SPACE indentation. It could use `python -t sourcefile.py`, or `tabnanny` which is less lenient but still allows mixtures that Python allows, or just search for any SPACE in indentation (although it's normal to use TABs followed by some SPACEs, esp. for odd indentation to line up with a `(` or for half-TAB indentation when tab stops are 8 spaces):
+* Stick with TABs in this project.
+* Set your editor's TAB stops to 4 spaces.
+* Python assumes TAB stops are at 8 spaces unless told otherwise.
+* Python rejects mixing tab and space indentation in a file.
+* PEP8 recommends 4 spaces per indentation level for _shared code_.  
+  (In years of early experience, TABs caused endless problems for [shared code](http://bugs.python.org/issue7012#msg93280). -- Tim Peters)  
+  (Thou shalt indent with four spaces. No more, no less. Four shall be the number of spaces thou shalt indent, and the number of thy indenting shall be four. Eight shalt thou not indent, nor either indent thou two, excepting that thou then proceed to four. Tabs are right out. -- Georg Brandl)
 
-        find . -name "*.py" -o -name "*.pyx" | xargs grep '^\s* '
 
-    although this will include indentation in multi-line comments and strings and indentation that aligns a continuation line with the previous line's `(` or `[`.
+### Imports
 
-  * (PEP8 recommends 4 spaces per indentation level but that's primarily for _shared code_.)
+* **Imports at the top of the file.** Definitely don't put `import` in repeatedly-executed code.
 
-* Use 7-bit ASCII text in Python 2. It will be interpreted as valid UTF-8 in Python 3. Otherwise the file needs an encoding declaration.
-
-* The **line length** soft target is 79 columns; harder target at 99 columns; no hard limit. The same limit for comments and docstrings.
-  * A standard line length aids editor window layout and diff displays, but bio simulations might have many long names. It's annoying to stay within a hard limit but very useful to have a shared target.
-  * (PEP8 recommends 79 columns, but 72 for comments and docstrings.)
-  * A shell script to check for very long lines in source files:
-
-        find . -name '*.py' -exec awk '{ if (length($0) > max) max = length($0) } END { if (max > 199) print max, FILENAME }' {} \;
-
-* Use absolute imports or explicit relative imports:
-
-      from . import sibling
-      from path.to.mypkg import sibling
-      from .sibling import example
-
-* Put **imports at the top of the file.** Certainly don't do `import` in repeatedly-executed code.
-
-  Occasionally there are good reasons to break this rule, like `import pdb`.
+  Occasionally there are reasons to break this rule, like `import pdb` or a
+  slow-loading import in rarely-used code.
 
 * Import separate modules on separate lines.
 
-* **Avoid wildcard imports** (`from <module> import *`).
-  * Never `import *` within a class or a function. That generates slow code and it won't compile in Python 3.
+* **Import order:** standard library imports, blank line, third party imports, blank line, local imports.  
+   Alphabetizing each group by module name is a bit nicer and reduces code merge work.
 
-* Use `if x is None:` or `if x is not None:` rather than `==` or `!=`, and likewise for other singletons like enum values (see pip enum34). It states a simpler aim. It's faster, esp. if it avoids calling a custom `__eq__()` method, and it might avoid exceptions or incorrect results in `__eq__(None)`.
+* **Avoid wildcard imports** (`from <module> import *`) since those make it unclear what names
+  are present in the namespace, confusing readers and some tools. It's reasonable
+  when republishing an internal interface as part of a public API (for example, overwriting a
+  pure Python implementation of an interface with the definitions from an optional accelerator
+  module and exactly which definitions will be overwritten isn’t known in advance).
 
-* Prefer to use Python's **implied line continuation** inside parentheses, brackets and braces over a backslash for line continuation.
+* There are recommendations to import only modules rather than names from modules to
+  avoid certain kinds of problems. The wcEcoli project doesn't follow this recommendation
+  but it might be sensible to move in that direction.
+  It's conventional and convenient to import names from `typing`
+  (`from typing import Any, cast`) and some other modules, and a case could be made to treat
+  classes as scopes like modules in this sense.
 
-* Write **docstrings** for all public modules, functions, classes, and methods.
+* Mostly use **absolute imports**. Occasionally it's worth using an explicit relative import,
+  esp. when an absolute import is unnecessarily verbose:
 
-  A function docstring should start with an imperative sentence like "Plot all the things.".
-
-  Add docstrings to existing classes and functions while working on the code. A short introduction can be a big help vs. nothing.
-
-  Comments and docstrings that contradict the code are worse than no comments.
-
-* Reevaluate what is `public` vs. `_private`.
+      from . import sibling
+      from path.to.mypkg import sibling
+      from .sibling.submodule import example
 
 
-* **Line continuation**
+### Lines
 
-  preferred:
+* **Line length:** soft target at 79 columns; harder target at 99 columns; no hard limit. Ditto for comments and docstrings (unlike PEP8).
+  * A standard line length aids editor window layout and diff displays, but bio simulations might have many long names. It's annoying to stay within a hard limit but useful to have a shared target.
+  * (PEP8 recommends 79 columns for code and 72 for comments and docstrings.)
+
+* Prefer Python's **implied line continuation** inside parentheses, brackets and braces over a
+  backslash for line continuation. Backslashes get broken by invisible white space at the end
+  of a line.
+* Avoid trailing whitespace on a line -- it breaks backslash line continutations.
+
+* Prefer this indentation for function parameters:
 
       def long_function_name(
               var_one, var_two, var_three,
               var_four):
           print(var_one)
 
-  preferred:
+  or maybe put the closing parenthesis on a separate line:
 
       def long_function_name(
               var_one, var_two, var_three,
@@ -93,73 +138,91 @@ and we can plan to:
               ):
           print(var_one)
 
-  PEP8 alternative:
+  or the PEP8 alternative:
 
       foo = long_function_name(var_one, var_two,
                                var_three, var_four)
 
-  PyCharm is configurable but it implements the first indentation style by default, and using its Refactor command to rename "long_function_name" will automatically adjust the indentation of the continuation lines.
+  not:
 
-* Import order: standard library imports, blank line, third party imports, blank line, local imports. It's nice to alphabetize each group by module name.
+      def long_function_name(var_one, var_two,
+              var_three, var_four):
+          print(var_one)
 
-* Module content order:
+  PyCharm is configurable but it implements the first indentation style by default, and using
+  its Refactor command to rename `long_function_name()` will re-indent the continuation lines.
 
-      """Module docstring."""
-      __future__ imports
-      __all__ = ['a', 'b', 'c']  # and other "dunder" settings like __version__ and __author__
-      imports
-      code
+* One blank line between method definitions. (PEP8 calls for two blank lines between top-level
+  definitions but we aren't adhering to that.) An additional blank line is OK to separate sections.
 
-* `"""Docstrings in triple quotes."""` whether it's one line or many; whether `"""` or `'''`. The `"""` that ends a multiline docstring should be on a line by itself.
+* Prefer a line break before a binary operator rather than after.
+  This math tradition is clearer:
+  ```python
+  income = (gross_wages
+          + taxable_interest
+          + (dividends - qualified_dividends)
+          - ira_deduction
+          - student_loan_interest)
+  ```
+* Do likewise with whitespace between lines of a multiline string.
+  ```python
+  self.define_option(parser, 'timestamp', str, fp.timestamp(),
+      help='Timestamp for this workflow. It gets combined with the'
+           ' Workflow ID to form the workflow name. Set this if you want'
+           ' to upload new steps for an existing workflow. Default ='
+           ' the current local date-time.')
+  ```
 
-* Two blank lines between top-level definitions. One blank line between method definitions. An additional blank line is OK to separate sections.
 
-* Prefer to put a line break before a binary operator, but after is also OK.
+### Spaces
 
-* Put at least one space before an inline comment, then `#␣` (that's one space after the `#`). (PEP8 says at least two spaces before the `#`, but use your judgement.)
+* Put at least one space before an inline comment, preferably two, and one after: `␣␣#␣`. (PEP8 says at least two spaces before the `#`.)
 
-* Spacing like this (see [PEP8](https://www.python.org/dev/peps/pep-0008/) for more info):
+* Spaces in expressions (see [PEP8](https://www.python.org/dev/peps/pep-0008/) for more info):
 
-      # Put no spaces immediately within `()`, `[]`, or `{}`.
-      spam(ham[1], {eggs: 2, salsa: 10})
-      
-      # Put a space between `,` `;` or `:` and any following item.
-      demo = (0,) + (2, 3)
-      if x == 4:
-          print x, y; x, y = y, x
-      
-      # Put no space in a simple slice expression, but parentheses to clarify complicated slice precedence
-      # or construct a slice object or put subexpressions into variables.
-      ham[1:9], ham[1:9:3], ham[:9:3], ham[1::3], ham[1:9:]
-      ham[(lower+offset):(upper+offset)]
-      
-      # Put no space in function application or object indexing.
-      spam(1) < spam(2)
-      dct['key'] += lst[index]
-      
-      # Don't line up the `=` on multiple lines of assignment statements.
-      x = 1
-      long_variable = (3, 10)
-      
-      # Spaces around keyword `=` are OK, unlike in PEP8, which recommends them only
-      # when there's a Python 3 parameter annotation.
-      c = magic(real=1.0, imag=10.5)
-      c = magic(real = 1.0, imag = 10.5)
-      def munge(input: AnyStr, sep: AnyStr = None, limit=1000): ...
-      
-      # Use spaces or parentheses to help convey precedence.
-      # Put zero or one space on both sides of a binary operator (except indentation).
-      hypot2 = x*x + y*y
-
-  Avoid trailing whitespace -- a backslash followed by a space and a newline does not count as a line continuation marker.
+  ```python
+  # No spaces immediately within `()`, `[]`, or `{}`.
+  spam(ham[1], {eggs: 2, salsa: 10})
+  
+  # A space between `,` `;` or `:` and any following item.
+  demo = (0,) + (2, 3)
+  if x == 4:
+      print x, y; x, y = y, x
+  
+  # No space in a simple slice expression, but parentheses to clarify
+  # complicated slice precedence, or construct a slice object, or put
+  # subexpressions into variables.
+  ham[1:9], ham[1:9:3], ham[:9:3], ham[1::3], ham[1:9:]
+  ham[(lower+offset):(upper+offset)]
+  
+  # Put no space in function application or object indexing.
+  spam(1) < spam(2)
+  dct['key'] += lst[index]
+  
+  # Don't line up the `=` on multiple lines of assignment statements.
+  # Maintaining it costs work and merge conflicts.
+  x = 1
+  long_variable = (3, 10)
+  
+  # Spaces around kwarg `=` are OK, unlike in PEP8, which recommends them only
+  # with a type annotation.
+  c = magic(real=1.0, imag=10.5)
+  c = magic(real = 1.0, imag = 10.5)
+  def munge(input: AnyStr, sep: AnyStr = None, limit=1000): ...
+  
+  # Use spaces or parentheses to help convey precedence.
+  # Put zero or one space on each side of a binary operator (except indentation).
+  hypot2 = x*x + y*y
+  ```
 
 * Avoid compound statements on one line.
 
-      if foo == 'blah': do_something()
+  ```python
+  if foo == 'blah': do_something()
+  ```
 
-* Comments are usually complete sentences. The first word should be capitalized unless it's an identifier that begins with a lower case letter.
 
-* Stylize **names** like this:
+### Naming style
 
    ```python
    ClassName
@@ -171,182 +234,151 @@ and we can plan to:
    decorator_name
    
    local_var_name, global_var_name, instance_var_name, function_parameter_name
-   camelCase  # OK to match the existing style
-   
-   __mangled_class_attribute_name
+   camelCase  # it's OK to match the existing style but it's good to change it to snake case
+
    _internal_name
+   __mangled_class_attribute_name
    
    module_name
    package  # underscores are discouraged
    ```
 
-    * Public names (like a class used as a decorator) follow conventions for usage rather than implementation.
-    * Use a trailing `_` to avoid conflicting with a Python keyword like `yield_`, `complex_`, or `max_`.
-    * Don't invent `__double_leading_and_trailing_underscore__` special names.
-    * Always use `self` for the first argument of an instance method and `cls` for the first argument of a class method.
-    * Don't use `l`, `O`, or `I` for single character variable names.
-    * Don't make exceptions for scientific conventions like `Kcat` and math conventions like matrix `M`, and any name is better than a single letter.
-    * Avoid using properties for expensive operations. The attribute notation suggests it's cheap.
-    * Use the verb to distinguish methods like `get_value()` from `compute_value()`.
-
-* Documented interfaces are considered public unless the documentation says they're provisional or internal. Undocumented interfaces are assumed to be internal.
-
-* The `__all__` attribute is useful for introspection.
-
-Programming tips:
-
-* `if x is not None` is more readable than `if not x is None`.
-* When implementing ordering operations with rich comparisons, it's best to implement all six operations or use the `functools.total_ordering()` decorator to fill them out.
-* Use `def f(x): return 2*x` instead of `f = lambda x: 2*x` for more helpful stack traces.
-* Derive exceptions from Exception rather than BaseException unless catching it is almost always the wrong thing to do.
-* When designing and raising exceptions aim to answer the question "What went wrong?" rather than only indicating "A problem occurred."
-* In Python 2, use `raise ValueError('message')` instead of `raise ValueError, 'message'` (which is not legal in Python 3).
-* Use the bare `except:` clause only when printing/logging the traceback.
-* Use the form `except Exception as exc:` to bind the exception name.
-* Limit a `try` clause to a narrow range of code so it only doesn't bury totally unexpected exceptions.
-* Use a `with` statement or try/finally to ensure cleanup gets done. For a file-like object that that doesn't support the `with` statement, use `with contextlib.closing(urllib.urlopen("https://www.python.org/")):`.
-* In a function, make either all or none of the `return` statements return an explicit value.
-  * Furthermore, have a consistent return type. Make a class instance, tuple, `namedtuple`, or dictionary to handle a union of different cases.
-  * Any kind of failure should raise an explicit exception.
-
-* Use string methods instead of the string module. They're faster and have the same API as Unicode strings.
-* String `.startswith()` and `.endswith()` are less error prone than string slicing.
-* Use e.g. `isinstance(obj, int)` instead of `type(obj) is type(1)` to check an object's type.
-  * Better yet, avoid checking types except to catch common errors. It's cleaner to call different function for distinct input patterns or use O-O dispatch.
-
-* Use `' '.join()` rather than looping over `a_string += stuff` to combine strings since `join()` takes linear time rather than O(_n_^2) time.
-
+* Use a trailing `_` to avoid a name conflict with a Python keyword or global function e.g.
+  `id_`, `yield_`, `complex_`, or `max_`.
+* Public names follow the convention for how it's used rather than how it's implemented, e.g.
+  a class used as a decorator or like a callable function.
+* Always use `self` for the first argument of an instance method and `cls` for the first
+  argument of a class method.
+* Don't use `l`, `O`, or `I` for a single letter variable name because they're hard to
+  distinguish in some fonts.
+* Don't invent `__dunder__` names.
+* It's recommended to not make exceptions for scientific naming like `Kcat` and math
+  naming like matrix `M`, but wcEcoli doesn't stick to this recommendation.
+* Avoid using properties for expensive operations. The notation `obj.property` suggests
+  it's low cost. For expensive operations, use methods, say, `obj.get_something()`
+  or `obj.compute_something()`.
 
 
 ## From Google's Python Style Guide
 
 See https://google.github.io/styleguide/pyguide.html
 
-* Use pylint and/or PyCharm inspections.
-* Import packages and modules only, not names from modules.
-* Use full pathnames to import a module; no relative imports to help prevent importing a package twice.
-* Avoid global variables.
-* Use the operator module e.g. `operator.mul` over `lambda x, y: x * y`. There's also `operator.itemgetter(*items)`, `operator.attrgetter(*attrs)`, and `operator.methodcaller(name[, args...])`.
-* Don't use mutable objects as default values in a function or method definition.
-* Use Python falsy tests for empty sequences and 0, e.g. `if sequence:` rather than `if len(sequence):` or `if len(sequence) > 0:`, but not for testing if a value is (not) `None`.
+* Don't put code at the top level that you don't want to run when the file is imported, unit
+  tested, or pydoc'd.
+* Avoid mutable global state (including global variables), metaclasses,
+  bytecode access, dynamic inheritance, object reparenting, reflection, modifying
+  system internals, and `__del__` methods implementing customized cleanup (except
+  standard library features like `enum` that use them internally),
+  (at least without very compelling reasons).
+* Don't use mutable objects as default values of a function or method.
+* Import only packages and modules, not names from modules.
+* Run the pylint and/or PyCharm inspections.
+* Use full pathnames to import a module. Avoid relative imports to help prevent importing a package twice.
+* Prefer the operator module e.g. `operator.mul` over `lambda x, y: x * y`. There's also `operator.itemgetter(*items)`, `operator.attrgetter(*attrs)`, and `operator.methodcaller(name[, args...])`.
+* Use Python falsey tests for empty sequences and 0, e.g. `if sequence:` rather than `if len(sequence):` or `if len(sequence) > 0:`, but not for testing if a value is (not) `None`.
   * But don't write `if value:` to test for a non-empty string. That can be confusing.
-* Avoid (or minimize) features such as metaclasses, access to bytecode, on-the-fly compilation, dynamic inheritance, object reparenting, import hacks, reflection, modification of system internals, etc. [at least without compelling reasons].
-* Use extra parentheses instead of backslash line continuation.
-* Don't use parentheses in return statements or conditional statements except for implied line continuation or tuples.
-  * Prefer explicit tuple parentheses, definitely for 1-element tuples. `(x,) = func()` not `x, = func()`. `for (i, x) in enumerate(...):`.
+* Don't use parentheses in return statements or conditional statements except for implied line continuation.
   * PyCharm recommends `return x, y` over `return (x, y)`.
-  * There's a case to make for always using parentheses for tuple construction and tuple unpacking, but we haven't set a guideline for that.
 
 * Write a docstring as a summary sentence, a blank line, then the rest.
-* A function must have a docstring, unless it's: not externally visible, short, and obvious. Explain what you need to know to call it.
+* A function must have a docstring, unless it's: not externally visible, short, and obvious.
+  Explain what you need to know to call it.
 * Classes should have docstrings.
-* Don't put code at the top level that you don't want to run when the file is imported, unit tested, or pydoc'd.
 
 
+## Pythonic Style
 
-## Other Recommendations
+```python
+if x is None: ...  # better than `if x == None:`
+if x is not None: ...
+def f(x): return 2 * x  # allows type hints & better stack traces than `f = lambda x: 2 * x
+isinstance(obj, int)  # better than `type(obj) is int`
+' '.join(a_sequence)  # faster than a loop of incremental string concatenation
+if sequence: ...  # preferred over `if len(sequence):`
+def f(x=None):
+  x = x or []   # solid, unlike a mutable default argument `def f(x=[]):`
+  return x, x * 2, x * 3
+```
 
-* Prefer to write floating point literals like `1.0` or `0.1` for clarity rather than `1.` or `.1`, but NumPy uses `1.` and `0.1` so we're not ruling that out.
+* Use `if x is None:` or `if x is not None:` rather than `==` or `!=`. Ditto for
+  enums and other singletons. It's faster, esp. if it avoids calling a custom
+  `__eq__()` method, and it might avoid exceptions or incorrect results in `__eq__(None)`.
+* Avoid manually testing data types. Prefer object-oriented dispatch or `functools`
+  features like `singledispatch`, or at least `isinstance()` since it handles subtypes
+  and protocols.
+* All or none of a function's `return` statements should return a value, usually of a
+  consistent type. You can use a `dict` or a class instance to handle a union of cases.
+* Prefer `str` methods over the `string` module. They're faster.
+* Use `' '.join()` rather than looping over `a_string += stuff` to combine strings since
+  `join()` takes linear time whereas repeated string concatenation can take O(_n_^2) time
+  (unless a particular CPython optimization kicks in).
 
-* A function should return consistent types rather than different types in different cases. Construct a dict or object or tuple to handle a union of cases. This makes it easier to understand and use.
+* When implementing ordering operations with rich comparisons, it's best to implement all
+  six operations or use `@functools.total_ordering()` to fill them out.
+* Use `def f(x): return 2 * x` instead of `f = lambda x: 2 * x` to get more helpful
+  stack traces and allow type hints.
+* Prefer f-string or `str.format(...)` over printf-style `%`-formatting because
+  [`%`-formatting has quirks](https://docs.python.org/3/library/stdtypes.html?highlight=sprintf#printf-style-string-formatting)
+  that lead to common errors such as failing to display tuples and dictionaries
+  correctly.
 
-* Prefer `format_string.format(...)` over `format_string % ...` because [printf-style % formatting has](https://docs.python.org/3/library/stdtypes.html?highlight=sprintf#printf-style-string-formatting) "a variety of quirks that lead to a number of common errors (such as failing to display tuples and dictionaries correctly)". `.format()` is a bit more readable and it offers some nice additional features. (See: More info on [the 4 ways to format strings in Python](https://dbader.org/blog/python-string-formatting).)
+### Exceptions
+* Use the bare `except:` clause only when just printing/logging the traceback and in
+  debugging tools.
+* Limit a `try` clause to a narrow range of code so it only doesn't bury totally
+  unexpected exceptions.
+* Use a `with` statement or `try`/`finally` to ensure cleanup gets done, like closing a file.
+* Any kind of failure should raise an explicit exception.
+* Derive exceptions from `Exception` rather than `BaseException` unless catching this
+  exception is almost always the wrong thing to do, like `KeyboardInterrupt`.
+* When raising exceptions, aim to answer "What went wrong?" rather than just
+  indicating "A problem occurred."
 
 
 # Type hints
 
-Python type hints can help catch bugs, improve code documentation (what to pass in this argument?),
-and aid development tools such as PyCharm's code completion and refactoring. They can also provide input to
-foreign language bridges like Jython to Java, DB query mapping, and RPC parameter marshalling. Reports
-are that developers love it when their coworkers add type hints.
+Python type hints can help catch bugs, improve code documentation,
+and aid dev tools such as PyCharm's code completion and refactoring.
+They can also provide input to tools like RPC parameter marshalling.
 
-Python will remain dynamically typed. Type hints will not become mandatory even by convention.
+Type hints will not become mandatory in Python even by convention.
 
-The key advice is to use them to tease apart bytes vs. unicode since that's the core gotcha in the
-transition to Python 3.
+Type declarations are a good place to use the 80/20 rule: Do the easy 20% of the work to find 80% of
+the type bugs. Complicated type expressions get challenging to read and write. Mainly, put
+type hints on functions and occasionally on variables when the type checker can't figure it out.
+E.g. mypy can't infer the element type when you create an empty collection. In a difficult case,
+you can punt by using type `Any` which can assign to or from anything.
 
-This is a good place to apply the 80/20 rule. Roughly speaking, do the easy 20% of the work to find 80% of
-the type bugs. Complicated typing cases can get very complicated in programming languages. So mainly put
-type hints on functions and occasionally on variables when the type checker can't figure it out, e.g. mypy
-can't infer the element type when you create an empty collection, but pytype can figure it out by looking
-ahead to the code that adds elements. In a difficult case, you can punt by using type `Any` which can
-assign to or from anything.
+([These Google Slides](https://docs.google.com/presentation/d/1xwVHjpQsRTGLdaIpPDNjKPQFtp7mBNfn7oTWK4Kct30/edit?usp=drivesdk)
+review our past plan for adding type hints to aid the migration to Python 3.)
 
-See [these Google Slides](https://docs.google.com/presentation/d/1xwVHjpQsRTGLdaIpPDNjKPQFtp7mBNfn7oTWK4Kct30/edit?usp=drivesdk)
-for our plan overview for migrating to Python 3 and adding type hints.
+You can type a list of strings as `list[str]` or `List[str]`, and similar for other
+standard collection types. The capitalized names were created to retrofit type hints into Python 2.
+They're unnecessary in Python 3.9+ (wcEcoli is on Python 3.11) but there's no need to change
+existing code.
 
-Until we finish the transition to Python 3, use Python 2+3 compatible type hint syntax like the
-following examples.
-
-
-## Examples
 
 ```python
-def emphasize(message, suffix=''):
-  # type: (str, str) -> str
-  """Construct an emphatic message. Docstring comes after the function type hint."""
-  return message + '!' + suffix
-```
-
-In the example above, `suffix` is an optional argument to the caller but it's always a `str` to the
-type checker, so we declare it as an ordinary `str` here. `Optional[str]` means "str or None" as in
-the following example:
-
-```python
-from typing import Optional
-
-def title(name, suffix=None):
-  # type: (str, Optional[str]) -> str
+def emphasize(message: str, suffix: str = ''):
   """Construct an emphatic message."""
-  return name + ('' if suffix is None else ' ' + suffix)
-```
-
-```python
-from typing import Dict
-
-def headline(
-        text,           # type: str
-        width=80,       # type: int
-        fill_char="-",  # type: str
-    ):                  # type: (...) -> str
-    for x, y in points:  # type: float, float
-        something = g(x, y)  # type: ignore
-    return "This is a way to handle lots of arguments."
-
-def f(x, *args, **kwargs):
-    # type: (str, *float, **str) -> Dict[str]
-    """For *args, give the type of an arg value, not the tuple.
-    For **kwargs, give the type of an arg value, not the dict.
-    """
-    return kwargs
-
-class C(object):
-    def __init__(self, p):
-        # type: (float) -> None
-        """Don't give a type for self or cls. __init__() return type is None."""
-        self.p = p
-
-    def circumference(self, radius):
-        # type: (float) -> float  # account for all args _except_ `self` or `cls`
-        version = (2, 7, 14)  # type: tuple
-        return 2 * math.pi * radius
+  # Note that `suffix` is an optional argument to the caller but it's always a
+  # `str` to the type checker, so declare it as `str`, not `Optional[str]` (which
+  # means `str | None`).
+  return message + '!' + suffix
 ```
 
 
 ## The Typing module
 
-To retrofit static typing tools to existing versions of Python 2, the designers added
+To retrofit static typing analysis to existing releases of Python 2, mypy designers added:
 * the type hint comment syntax,
 * [the "typing" module](https://docs.python.org/3/library/typing.html) on [PyPI](https://pypi.org)
-  containing types like `List` and `Dict` with uppercase names so they don't have to patch the
-  existing classes `list` and `dict`,
+  containing types like `List` with uppercase names so they didn't have to patch
+  existing classes like `list`,
 * `.pyi` "stub files" to add type definitions onto existing Python libraries and native libraries,
-* the [Typeshed](https://github.com/python/typeshed) repository for "stub" files
-  (it's bundled with PyCharm, mypy, and pytype)
+* the [Typeshed](https://github.com/python/typeshed) repository for type "stub" files.
 
-You can use class names like `dict`, `list`, and `tuple`, but that won't specify the content types.
-
-* `None`: the value None (this is easier than writing `NoneType`)
+* `None`: the value None (easier than writing `NoneType`)
 * `Any`: any type; assigns to or from anything
 * `Dict[str, float]`: a dict of str to float, that is floats keyed with strings
 * `Mapping[str, float]`: an abstract mapping; accepts a `dict`, `OrderedDict`, or other
@@ -355,14 +387,22 @@ You can use class names like `dict`, `list`, and `tuple`, but that won't specify
 * `Optional[str]`: a str or None
 * `Callable[[str, List[int]], int]`: a function or anything else you can call given a str and a
 list of ints, returning an int
-* `Union[str, int]`: accepts either a str or an int
+* `str | int`: accepts either a str or an int, aka `Union[str, int]` in code that predates Python 3.10
 * `Sequence[float]`: any sequence of floats that supports `.__len__()` and `.__getitem__()`
 * `Iterable[float]`: any iterable collection of floats; accepts a `list`, `tuple`, 
-* `Text`: a unicode string in both Python 2 and 3
-* `AnyStr`: any kind of text or byte string but doesn't allow different kinds of strings to mix
+
+* It should work to write numpy type hints like `np.ndarray` and `np.ndarray[int]`.
+
+  ```python
+  import numpy as np
+  
+  def f(a):
+      # type: (np.ndarray[float]) -> np.ndarray[int]
+      return np.asarray(a, dtype=int)
+  ```
 
 
-## Tools
+### Tools
 
 [PyCharm](https://www.jetbrains.com/help/pycharm/type-hinting-in-product.html) checks types interactively
 while you edit. You can also run a particular kind of inspection (such as "Type checker")
@@ -380,66 +420,52 @@ and the `ecoli-small` CI tests. To run it:
 write them out as stub files or proposed type hints in the source code.
 
 
-## Types for Numpy
-
-With the type stubs now in numpy, it should work to write type hints like `np.ndarray`,
-`np.ndarray[int]`, and `np.ndarray[Any]`.
-
-```python
-import numpy as np
-
-def f(a):
-    # type: (np.ndarray[float]) -> np.ndarray[int]
-    return np.asarray(a, dtype=int)
-```
-
-
-## Tips
+### Tips
 
 * When a method overrides a superclass method, it inherits the type hints. You needn't
 repeat them but if you do, they must match.
-* Call `reveal_type(xxx)` to ask the type checker to print its inferences.
+* Call `reveal_type(x)` to print type inferences for `x` when mypy runs.
 * Escape hatches: `Any`, `cast()`, `# type: ignore`, and `.pyi` stub files (esp. for C extensions).
-* Gradually add types to code, one file at a time, starting with the most heavily used code.
+* Gradually add types to existing code, one file at a time, starting with the most heavily used code.
 * Run the type checker in development and in Continuous Integration. Fix its warnings to defend progress.
-We can tell mypy to disallow untyped functions in particular modules.
-* The config setting `check_untyped_defs = True` will also check the contents of functions that don't
-have types hints. It might find actual bugs.
-* Lambdas don't support type hints, so `def`ine a function when you want typing.
+* We could tell mypy to disallow untyped functions in particular modules.
+* The config setting `check_untyped_defs = True` will also check the contents of functions that
+  don't have types hints. It might find actual bugs.
+* Lambdas don't support type hints, so define a function when you want typing.
 * To punt on types for a difficult functions, just leave out the type annotations or add a
   `@no_type_check` decorator. That treats it as having the most general type possible, i.e. each arg
   type is `Any` (except a method's `self` or `cls` arg) and the result is `Any`. `@no_type_check`
   might also disable type inferences and checking inside the function.
 
 
-## Terminology
+### Terminology
 
 * A _type_ is for type checking, variable annotations, and function annotations.
   A _class_ is a runtime thing. Every _class_ acts like a _type_, and there are additional types like
-  `Union[str, int]` which you can't use as classes.
+  `str | int` which you can't instantiate like a class.
 * Type A is a _subtype_ of B if it has a subset of the values (classification) **and** a superset of the
 methods. A value of a subtype can act like a value from its supertypes.
 * The type `From` _is consistent with_ (assignable to a variable of) type `To` if
   * `From` is a subtype of `To`, _or_
   * `From` or `To` is `Any`.
 * _Type hints_ just enable tools: docs, type checkers, IDE code completion, etc.
-* The type checker only complains about _inconsistent_ types. It does nothing at runtime.
-* Type _annotations_ do the same job as type hint comments, but only in Python 3.
-  These annotations are available at runtime via the `__annotations__` attribute.
+* The type checker is a tool that warns about inconsistent types. It does nothing at runtime.
+* Type _annotations_ do the same job as type hint comments.
 * _Gradual typing_ means adding type hints to existing code, freely mixing code
   with and without have type hints.
 * The type checker can _infer the types_ of local variables, `@property` methods, and more.
-* _Nominal typing_ is based on class **names**. Python types are mostly nominal.
+* _Nominal typing_ is based on class **names**. Python types are mostly "nominal".
 * _Structural typing_ is based on structure such as the duck-type protocol `Typing.Sized`
-  which means "it has a `.__len__()` method".
+  which means "an object that has a `.__len__()` method".
 * Type information on values is _erased_ at runtime.
 
 
-## Covariant and Contravariant types
+### Covariant and Contravariant types
 
-This goes beyond the 80/20 rule but you might need to know about it. See
+This is where types get complicated.
+It goes beyond the 80/20 rule but you might need to know about it. See
 [The Ultimate Guide to Python Type Checking](https://realpython.com/python-type-checking/) for a
-good tutorial that includes this stuff.
+good tutorial that includes this.
 
 Some generic types (_sources_ like Tuple[t1, t2] and FrozenSet[t]) are _covariant_, some are _contravariant_
 (_sinks_ like Callable[[t1], …]), and some are _invariant_ (like List[t]).
@@ -453,25 +479,23 @@ Some generic types (_sources_ like Tuple[t1, t2] and FrozenSet[t]) are _covarian
    * `T = TypeVar('T', contravariant=True)` types are invariant by default.
 
 
-## References
+### References
 
-[PEP 484: Type Hints](https://www.python.org/dev/peps/pep-0484/). Parts of this PEP are worth reading.
+[PEP 484: Type Hints](https://www.python.org/dev/peps/pep-0484/). Worth skimming.
 
-[The "typing" pip](https://docs.python.org/3/library/typing.html).
+[The "typing" module](https://docs.python.org/3/library/typing.html) defines types like `Any`, `Optional`, `Union`, `Iterable`, `Sized`, and `IO`; and functions like `cast()` and `assert_type()`.
 
 [Python type checking tools](https://python-type-checking.readthedocs.io/en/latest/tools.html)
-   * mypy [overview](http://mypy-lang.org/), [docs](http://mypy.readthedocs.org),
-   [blog](http://mypy-lang.blogspot.com), [github](github.com/python/mypy).
+   * mypy [overview](https://mypy-lang.org/), [docs](https://mypy.readthedocs.org),
+   [blog](https://mypy-lang.blogspot.com), [github](https://github.com/python/mypy).
    * PyCharm
      * It can help [add type hints for you](https://www.jetbrains.com/help/pycharm/type-hinting-in-product.html):
      Press Opt-Return (or click the "intention" lightbulb icon) then "Add type hint for ..."
      * [Type Hinting in PyCharm](https://www.jetbrains.com/help/pycharm/type-hinting-in-product.html)
      shows how to use PyCharm features to quickly add type hints, validate them, and eventually convert
-     comment-based type hints to Py3.6 variable annotations once we leave Py2 behind.
+     comment-based type hints to type annotations.
    * [pytype](https://github.com/google/pytype) Google's static analyzer checks types, attribute names, and more.
-   * [Pyre](github.com/facebook/pyre-check) Facebook's static checker is faster on large code bases than mypy
-   * [pyannotate](github.com/dropbox/pyannotate) runtime type info collector
-   * [MonkeyType](github.com/Instagram/MonkeyType) runtime type info collector
+   * [MonkeyType](https://github.com/Instagram/MonkeyType) runtime type info collector
 
 
 # Performance Tips
@@ -482,7 +506,7 @@ Some generic types (_sources_ like Tuple[t1, t2] and FrozenSet[t]) are _covarian
 * Sorting a list using a _sort key_ is faster than using a _comparison function._
 * Mapping a function over a list, or using a list comprehension or generator comprehension, should be faster than a `for` loop since it pushes the loop work into compiled C code.
 * Local variables are faster to access than global variables, builtins, and attribute lookups.
-* Iterators are more memory-friendly and scalable than list operations, so in Python 3 a method like `a_dict.items()` returns an iterator. (Call `list(a_dict.items())` if you need a list.)
+* Iterators are more memory-friendly and scalable than list operations, so a method like `a_dict.items()` returns an iterator. (Call `list(a_dict.items())` if you need a list.)
 * Core building blocks are coded in optimized C, including the builtin datatypes (lists, tuples, sets, and dictionaries) and extension modules like `array`, `itertools`, and `collections.deque`.
 * Builtin functions run faster than hand-built equivalents, e.g. `map(operator.add, v1, v2)` is faster than `map(lambda x, y: x+y, v1, v2)`.
 * For queue applications using `pop(0)` or `insert(0,v)`, `collections.deque()` offers superior `O(1)` performance over a list because it avoids the `O(n)` step of rebuilding a list for each insertion or deletion.


### PR DESCRIPTION
Update `style-guide.md`: update for Python 3.11, clarify, reorg, and rework the co-/contra-/in-variant type explanation.