### PR TITLE
Optional New Gene Data File Incorporation

### DIFF
--- a/docs/misc/add_new_gene.md
+++ b/docs/misc/add_new_gene.md
@@ -3,17 +3,18 @@ Addition of new genes to the chromosome<br>(in progress)
 
 <b>Directions for adding a new gene</b><br>
 
-* Add one directory per genome insertion to (`reconstruction/ecoli/flat/new_gene_data`), following file structure in the `template` subdirectory.  
+* Add one directory per genome insertion to (`reconstruction/ecoli/flat/new_gene_data`)
+  * Begin by copying the `reconstruction/ecoli/flat/new_gene_data/template` subdirectory.  
   * Each directory can have multiple new genes (represented as multiple rows in the tables), but these genes must all be inserted in the same place in the genome.
   * <b>ID of new genes, RNAs, and proteins MUST begin with NG</b>
-  * Necessary data files:
+  * Data files that must be modified:
     * `insertion_location.tsv` - Specify desired genome insertion location
     * `genes.tsv` - List of the genes you would like to insert, with relative coordinates within the sequence to be inserted. Note that only a single contiguous gene insertion is supported at this time.
     * `gene_sequences.tsv` - Sequences of genes to be inserted
     * `rnas.tsv` - RNAs corresponding to those genes
     * `proteins.tsv` - Proteins corresponding to those genes
     *  `rnaseq_rsem_tpm_mean.tsv` - Best practices: set these each to .01 (so that the Parca does not try to correct for the new genes) and modify basal expression levels later via variant (more details below)
-  * Currently supported optional data files:
+  * Data files that must be present in the directory but are optional to modify:
     * `rna_half_lives.tsv` - Can specify if desired, otherwise will default to average of the other RNAs
     * `protein_half_lives_measured` - Can specify if desired, otherwise will default to average of the other proteins
 

--- a/reconstruction/ecoli/flat/new_gene_data/gfp/protein_half_lives_measured.tsv
+++ b/reconstruction/ecoli/flat/new_gene_data/gfp/protein_half_lives_measured.tsv
@@ -1,0 +1,1 @@
+"id"	"half life (units.min)"	"_comments"

--- a/reconstruction/ecoli/flat/new_gene_data/gfp/rna_half_lives.tsv
+++ b/reconstruction/ecoli/flat/new_gene_data/gfp/rna_half_lives.tsv
@@ -1,0 +1,1 @@
+"id"	"half_life (units.min)"


### PR DESCRIPTION
This PR modifies how optional new gene data files should be included in a new gene data subdirectory, in part to prepare for the introduction of new gene associated metabolic reactions in PR #1361. Knowing that optional data files (and their corresponding attributes) always exist will simplify the code, as noted by @1fish2 in a comment on PR #1361. 

This change means that all optional new gene files should be included in every new gene data subdirectory. Flexibility is still maintained - if the user does not want to specify the data represented by that file, e.g. protein half-lives, then they can leave the contents of the file below its header blank. The template new gene data directory and new gene documentation have also been updated to reflect this change.