### PR TITLE
Update variant doubling time histogram plot

### DIFF
--- a/models/ecoli/analysis/variant/doubling_time_histogram.py
+++ b/models/ecoli/analysis/variant/doubling_time_histogram.py
@@ -1,132 +1,160 @@
 """
-Plot doubling time for all generations, early generations, and/or late (i.e. not early) generations
-Plot percentage of simulations that reach a given generation number for each variant
+Plot histograms of doubling times and compares the distributions across
+different variants. Also optionally plots percentage of simulations that reach
+the simultation-specified number of generations without failing.
 """
 
 import numpy as np
 from matplotlib import pyplot as plt
 
 from models.ecoli.analysis import variantAnalysisPlot
-from wholecell.analysis.analysis_tools import exportFigure, read_stacked_columns, stacked_cell_threshold_mask
-from wholecell.analysis.plotting_tools import DEFAULT_MATPLOTLIB_COLORS as COLORS, labeled_indexable_hist
+from wholecell.analysis.analysis_tools import (
+	exportFigure, read_stacked_columns, stacked_cell_threshold_mask)
+from wholecell.analysis.plotting_tools import (
+	DEFAULT_MATPLOTLIB_COLORS as COLORS)
 
-import os.path
+FONT_SIZE = 9
+DOUBLING_TIME_BOUNDS_MINUTES = [0, 180]
+N_BINS = 36
 
-# 1 to exclude cells that took full MAX_CELL_LENGTH, 0 otherwise
-exclude_timeout_cells = 1
+# Set True to exclude cells that hit time limit
+EXCLUDE_TIMEOUT_CELLS = True
 
-"""
-1 to plot early (before MIN_LATE_CELL_INDEX), and late generations in
-addition to all generations
-"""
-exclude_early_gens = 1
+# Set True to plot completion rate
+PLOT_COMPLETION_RATES = True
 
-FONT_SIZE=9
-MAX_VARIANT = 10 # do not include any variant >= this index
-MAX_CELL_INDEX = 8 # do not include any generation >= this index
-
-"""
-Count number of sims that reach this generation (remember index 7 
-corresponds to generation 8)
-"""
-COUNT_INDEX = 7
-
-"""
-generations before this may not be representative of dynamics 
-due to how they are initialized
-"""
-MIN_LATE_CELL_INDEX = 4
-
-MAX_CELL_LENGTH = 180
-if (exclude_timeout_cells==0):
-	MAX_CELL_LENGTH += 1000000
+# Remove first N gens from plot
+IGNORE_FIRST_N_GENS = 4
 
 class Plot(variantAnalysisPlot.VariantAnalysisPlot):
-	def bar(self, ax, data, xlabel, ylabel, xlim=None,ylim=None):
-		for variant, variant_data in data.items():
-			color = COLORS[variant % len(COLORS)]
-			ax.bar(variant, variant_data, color=color, label=f'Var {variant}')
-
-		if xlim:
-			ax.set_xlim(xlim)
-		if ylim:
-			ax.set_ylim(ylim)
-		self.remove_border(ax)
-		ax.set_xlabel(xlabel, fontsize=FONT_SIZE)
-		ax.set_ylabel(ylabel, fontsize=FONT_SIZE)
-		ax.tick_params(labelsize=FONT_SIZE)
-		ax.legend()
-
 	def do_plot(self, inputDir, plotOutDir, plotOutFileName, simDataFile,
 				validationDataFile, metadata):
-		# print("Running analysis script with exclude_timeout_cells=",
-		# 	  exclude_timeout_cells, " and exclude_early_gens=",
-		# 	  exclude_early_gens)
+		max_cell_length = 180  # mins
+		if not EXCLUDE_TIMEOUT_CELLS:
+			max_cell_length += 1000000  # Arbitrary large number
 
 		# Data extraction
 		doubling_times = {}
-		reached_count_gen = {}
-		generations = {}
+		completion_rates = {}
+		n_total_gens = self.ap.n_generation
+		variant_indexes = self.ap.get_variants()
 
-		variants = self.ap.get_variants()
-		for variant in variants:
+		# Loop through all variant indexes
+		for variant_index in variant_indexes:
+			# Get all cells (within the generation range) of this variant index
+			all_cells = self.ap.get_cells(
+				variant=[variant_index],
+				generation=np.arange(IGNORE_FIRST_N_GENS, n_total_gens),
+				only_successful=True)
 
-			if variant >= MAX_VARIANT:
-				continue
-
-			all_cells = self.ap.get_cells(variant=[variant],
-										  only_successful=True)
 			if len(all_cells) == 0:
 				continue
 
+			# Get mask to exclude cells that timed out
 			exclude_timeout_cell_mask = stacked_cell_threshold_mask(
-				all_cells, 'Main', 'time', MAX_CELL_LENGTH,
+				all_cells, 'Main', 'time', max_cell_length,
 				fun=lambda x: (x[-1] - x[0]) / 60.).squeeze()
-			all_cells_gens = np.array([int(os.path.basename(os.path.dirname(
-				cell_path))[-6:]) for cell_path in all_cells])[exclude_timeout_cell_mask]
-			generations[variant] = all_cells_gens
 
-			# Doubling times
-			dt = read_stacked_columns(all_cells, 'Main', 'time',
-									  fun=lambda x: (x[-1] - x[0]) / 60.).squeeze()
-			doubling_times[variant] = dt[exclude_timeout_cell_mask]
+			# Get doubling times from cells with this variant index
+			dt = read_stacked_columns(
+				all_cells, 'Main', 'time',
+				fun=lambda x: (x[-1] - x[0]) / 60.).squeeze()
+			doubling_times[variant_index] = dt[exclude_timeout_cell_mask]
 
 			# Count the number of simulations that reach gen COUNT_INDEX + 1
-			num_count_gen = len(self.ap.get_cells(variant=[variant],
-							  generation = [COUNT_INDEX],
-												  only_successful=True))
-			num_zero_gen = len(self.ap.get_cells(variant=[variant],
-							  generation = [0], only_successful=True))
-			reached_count_gen[variant] = num_count_gen / num_zero_gen
+			num_count_gen = len(
+				self.ap.get_cells(
+					variant=[variant_index], generation=[n_total_gens - 1],
+					only_successful=True)
+				)
 
-		# Plotting
-		std_xlim = [30,185]
-		std_dt_xlab = 'Doubling Time (min)'
-		std_bar_xlab = 'Variant'
-		std_bar_ylab = 'Percentage of Sims that Reached Generation ' \
-					   + str(COUNT_INDEX+1)
+			# Count the number of simulations at generation zero
+			num_zero_gen = len(
+				self.ap.get_cells(
+					variant=[variant_index], generation=[0],
+					only_successful=True)
+				)
 
-		data_start = [0]
-		data_end = [MAX_CELL_INDEX]
-		plot_label = ['_all_gens']
-		if exclude_early_gens:
-			data_start += [0,MIN_LATE_CELL_INDEX]
-			data_end += [MIN_LATE_CELL_INDEX,MAX_CELL_INDEX]
-			plot_label += ['_early_gens', '_late_gens']
+			# Calculate completion rate
+			completion_rates[variant_index] = num_count_gen / num_zero_gen
 
-		for j in range(len(data_start)):
-			_, axes = plt.subplots(2, 1, figsize=(10, 10))
-			labeled_indexable_hist(self, axes[0], doubling_times, generations,
-								   data_start[j], data_end[j], COLORS,
-								   std_dt_xlab)
-			self.bar(axes[1], reached_count_gen, std_bar_xlab, std_bar_ylab)
+		n_variants = len(doubling_times)
+
+		fig = plt.figure(figsize=(8, 2*(n_variants + 1)))
+		bins = np.linspace(
+			DOUBLING_TIME_BOUNDS_MINUTES[0],
+			DOUBLING_TIME_BOUNDS_MINUTES[1],
+			N_BINS + 1
+			)
+
+		# First subplot shows all histograms for each variant
+		ax0 = fig.add_subplot(n_variants + 1, 1, 1)
+		subplots = []
+
+		for i, (variant_index, dt) in enumerate(doubling_times.items()):
+			color = COLORS[i % len(COLORS)]
+			ax0.hist(
+				dt, bins=bins, color=color, alpha=0.5,
+				label=f'Var {variant_index} (n={len(dt)}, {np.mean(dt):.1f} $\pm$ {np.std(dt):.1f})')
+
+			# Add vertical line at mean doubling time
+			ax0.axvline(np.mean(dt), color=color, ls='--', lw=3, alpha=0.5)
+
+			# Later subplots show histograms for each variant separately
+			ax = fig.add_subplot(n_variants + 1, 1, i + 2, sharex=ax0)
+			ax.hist(
+				dt, bins=bins, color=color, alpha=0.5,
+				)
+			ax.tick_params(labelsize=FONT_SIZE)
+			ax.spines["top"].set_visible(False)
+			ax.spines["right"].set_visible(False)
+			subplots.append(ax)
+
+		# Set ylims of all subplots to be equal to the first subplot
+		ax0_ylim = ax0.get_ylim()
+		for ax in subplots:
+			ax.set_ylim(ax0_ylim)
+
+		ax0.legend()
+
+		ax0.set_xlim(*DOUBLING_TIME_BOUNDS_MINUTES)
+		ax0.set_xticks(
+			np.linspace(
+				DOUBLING_TIME_BOUNDS_MINUTES[0],
+				DOUBLING_TIME_BOUNDS_MINUTES[1],
+				10
+				)
+			)
+		ax0.tick_params(labelsize=FONT_SIZE)
+
+		ax0.set_xlabel('Doubling time (min)', fontsize=FONT_SIZE)
+		ax0.spines["top"].set_visible(False)
+		ax0.spines["right"].set_visible(False)
+
+		plt.tight_layout()
+		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
+		plt.close('all')
+
+		# Optionally plot bar plots for completion rates
+		if PLOT_COMPLETION_RATES:
+			fig = plt.figure(figsize=(8, 3))
+			ax = fig.add_subplot(1, 1, 1)
+
+			for i, (variant_index, completion_rate) in enumerate(
+					completion_rates.items()):
+				color = COLORS[i % len(COLORS)]
+				ax.bar(variant_index, completion_rate,
+						color=color, alpha=0.5, label=f'Var {variant_index}')
+
+			self.remove_border(ax)
+			ax.set_xlabel('Variant indexes', fontsize=FONT_SIZE)
+			ax.set_ylabel('Completion rates', fontsize=FONT_SIZE)
+			ax.tick_params(labelsize=FONT_SIZE)
+			ax.legend()
+
 			plt.tight_layout()
-			exportFigure(plt, plotOutDir, plotOutFileName+plot_label[j],
-						 metadata)
-
-			axes[0].set_xlim(std_xlim)
-			exportFigure(plt, plotOutDir, plotOutFileName +
-						 plot_label[j] + '_trimmed', metadata)
+			exportFigure(plt, plotOutDir, plotOutFileName + '_completion_rates', metadata)
+			plt.close('all')
 
 if __name__ == "__main__":
 	Plot().cli()

--- a/models/ecoli/analysis/variant/doubling_time_histogram.py
+++ b/models/ecoli/analysis/variant/doubling_time_histogram.py
@@ -61,8 +61,8 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 				fun=lambda x: (x[-1] - x[0]) / 60.).squeeze()
 			doubling_times[variant_index] = dt[exclude_timeout_cell_mask]
 
-			# Count the number of simulations that reach gen COUNT_INDEX + 1
-			num_count_gen = len(
+			# Count the number of simulations that reach the last generation
+			num_last_gen = len(
 				self.ap.get_cells(
 					variant=[variant_index], generation=[n_total_gens - 1],
 					only_successful=True)
@@ -76,7 +76,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 				)
 
 			# Calculate completion rate
-			completion_rates[variant_index] = num_count_gen / num_zero_gen
+			completion_rates[variant_index] = num_last_gen / num_zero_gen
 
 		n_variants = len(doubling_times)
 
@@ -87,7 +87,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			N_BINS + 1
 			)
 
-		# First subplot shows all histograms for each variant
+		# First subplot overlays the histograms of all variants
 		ax0 = fig.add_subplot(n_variants + 1, 1, 1)
 		subplots = []
 
@@ -100,7 +100,7 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 			# Add vertical line at mean doubling time
 			ax0.axvline(np.mean(dt), color=color, ls='--', lw=3, alpha=0.5)
 
-			# Later subplots show histograms for each variant separately
+			# Later subplots show the histograms for each variant separately
 			ax = fig.add_subplot(n_variants + 1, 1, i + 2, sharex=ax0)
 			ax.hist(
 				dt, bins=bins, color=color, alpha=0.5,


### PR DESCRIPTION
This PR updates the existing `variant` doubling time histogram plot. Major changes I made are:

1. Histograms for each variant are plotted separately below the main plot with all histograms.
2. All histograms now share the same bin counts and sizes for easier comparison.
3. Plot options have been simplified to exclude the first N generations from the histograms as needed.
4. The bar plot for completion rates is now output as a separate file.

Sample plots shown below:

![doubling_time_histogram](https://github.com/CovertLab/wcEcoli/assets/32276711/4e71cc3f-06dd-4947-b69d-938312ba4947)
![doubling_time_histogram_completion_rates](https://github.com/CovertLab/wcEcoli/assets/32276711/2c99d3c1-dfa0-416d-8640-30515774dde3)
