### PR TITLE
Skip rRNA operon structures analysis if using nonstandard rRNA operon structures

### DIFF
--- a/models/ecoli/analysis/parca/rRNA_operon_structures.py
+++ b/models/ecoli/analysis/parca/rRNA_operon_structures.py
@@ -37,6 +37,13 @@ class Plot(parcaAnalysisPlot.ParcaAnalysisPlot):
 		rna_data = sim_data.process.transcription.rna_data
 		rRNA_data = rna_data[rna_data['is_rRNA']]
 		rRNA_ids = rRNA_data['id']
+
+		# If the list of rRNA IDs does not match the rRNA TU IDs, skip analysis
+		# (likely using rRNA operon structure variants)
+		if set(rRNA_ids) != set(TU_ID_TO_RRNA_OPERON_ID.keys()):
+			print('Skipping analysis - this analysis should be run for simulations with WT rRNA operon structures.')
+			return
+
 		rRNA_id_to_index = {rRNA_id: i for (i, rRNA_id) in enumerate(rRNA_ids)}
 		rRNA_start_coordinates = rRNA_data['replication_coordinate']
 		rRNA_lengths = rRNA_data['length'].asNumber(units.nt)

--- a/reconstruction/ecoli/dataclasses/process/two_component_system.py
+++ b/reconstruction/ecoli/dataclasses/process/two_component_system.py
@@ -609,6 +609,9 @@ class TwoComponentSystem(object):
 		response regulators, and ligand-bound histidine kinases for positively oriented
 		networks) to their dependents.
 		'''
+		molecule_name_to_index = {
+			name: i for (i, name) in enumerate(self.molecule_names)}
+
 		dependencyMatrixI = []
 		dependencyMatrixJ = []
 		dependencyMatrixV = []
@@ -622,14 +625,15 @@ class TwoComponentSystem(object):
 			if self.molecule_names[independentMoleculeId] == "ATP[c]":
 				dependencyMatrixATPJ = independentMoleculeIndex
 			else:
-				dependentMoleculeId = int(np.where(self.molecule_names == self.independent_to_dependent_molecules[self.molecule_names[independentMoleculeId]])[0])
+				dependentMoleculeId = molecule_name_to_index[
+					self.independent_to_dependent_molecules[self.molecule_names[independentMoleculeId]]]
 				dependencyMatrixI.append(dependentMoleculeId)
 				dependencyMatrixJ.append(independentMoleculeIndex)
 				dependencyMatrixV.append(-1)
 
 		# ATP dependents: ADP, PI, WATER, PROTON)
 		for ATPdependent in ["ADP[c]", "Pi[c]", "WATER[c]", "PROTON[c]"]:
-			dependencyMatrixI.append(int(np.where(self.molecule_names == ATPdependent)[0]))
+			dependencyMatrixI.append(molecule_name_to_index[ATPdependent])
 			dependencyMatrixJ.append(dependencyMatrixATPJ)
 			if ATPdependent == "WATER[c]":
 				dependencyMatrixV.append(1)
@@ -640,11 +644,11 @@ class TwoComponentSystem(object):
 			if col == dependencyMatrixATPJ:
 				continue
 			else:
-				dependencyMatrixI.append(int(np.where(self.molecule_names == "Pi[c]")[0]))
+				dependencyMatrixI.append(molecule_name_to_index["Pi[c]"])
 				dependencyMatrixJ.append(col)
 				dependencyMatrixV.append(1)
 
-				dependencyMatrixI.append(int(np.where(self.molecule_names == "WATER[c]")[0]))
+				dependencyMatrixI.append(molecule_name_to_index["WATER[c]"])
 				dependencyMatrixJ.append(col)
 				dependencyMatrixV.append(-1)
 


### PR DESCRIPTION
This PR fixes a bug that was causing the optional features builds on Jenkins to fail. We now skip the rRNA operon structures ParCa analysis if the `sim_data` uses nonstandard rRNA operon structures. I also fixed one of the numpy deprecation warnings that were showing up on the same builds.