### PR TITLE
Activate fewer ribosomes to resolve overcrowding if rescaling fails

### DIFF
--- a/models/ecoli/analysis/single/inter_ribosome_distance.py
+++ b/models/ecoli/analysis/single/inter_ribosome_distance.py
@@ -83,13 +83,22 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Sort from shortest to longest
 		sorted_index = avg_inter_ribosome_distance.argsort()
-		sorted_monomer_ids = [monomer_ids_filtered[i] for i in sorted_index]
+		sorted_monomer_ids = np.array([monomer_ids_filtered[i] for i in sorted_index])
 		avg_inter_ribosome_distance.sort()
 
 		# Mark genes with ribosomes that are too close to each other
 		n_too_close = (
 			avg_inter_ribosome_distance[:SAMPLE_SIZE] < ribosome_footprint_size).sum()
 		bar_colors = ["r"]*n_too_close + ["b"]*(SAMPLE_SIZE - n_too_close)
+
+		# Add an asterisk before the name of any mononomers that
+		# have ribosomes too close together and also have a small number of
+		# cistrons. This is to highlight that the average distance between
+		# ribosomes is not statistically representative for these monomers.
+		low_cistron_counts_and_too_close = (
+				avg_cistron_count_per_monomer[sorted_index][:n_too_close] < 20)
+		sorted_monomer_ids[:n_too_close][low_cistron_counts_and_too_close] = np.char.add(
+			'* ', sorted_monomer_ids[:n_too_close][low_cistron_counts_and_too_close])
 
 		# Plot the first n monomers with shortest distances
 		plt.figure(figsize=(8, 6))

--- a/models/ecoli/analysis/single/inter_ribosome_distance.py
+++ b/models/ecoli/analysis/single/inter_ribosome_distance.py
@@ -1,0 +1,101 @@
+"""
+Computes the average distance between translating ribosomes for each
+mRNA, and compares the distance to the known size of the
+molecular footprint of ribosomes.
+"""
+
+import os
+import pickle
+
+from matplotlib import pyplot as plt
+import numpy as np
+
+from models.ecoli.analysis import singleAnalysisPlot
+from wholecell.analysis.analysis_tools import exportFigure
+from wholecell.io.tablereader import TableReader
+from wholecell.utils import units
+
+
+SAMPLE_SIZE = 25  # Number of genes to plot
+
+
+class Plot(singleAnalysisPlot.SingleAnalysisPlot):
+	_suppress_numpy_warnings = True
+
+	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
+		with open(simDataFile, 'rb') as f:
+			sim_data = pickle.load(f)
+
+		# Get ribosome footprint size
+		ribosome_footprint_size = sim_data.process.translation.active_ribosome_footprint_size.asNumber(units.nt)
+
+		# Listeners used
+		main_reader = TableReader(os.path.join(simOutDir, 'Main'))
+		ribosome_data_reader = TableReader(os.path.join(simOutDir, 'RibosomeData'))
+		mRNA_counts_reader = TableReader(os.path.join(simOutDir, 'RNACounts'))
+		monomer_counts_reader = TableReader(os.path.join(simOutDir, 'MonomerCounts'))
+
+		# Load data
+		initial_time = main_reader.readAttribute('initialTime')
+		time = (units.s)*(main_reader.readColumn('time') - initial_time)
+		ribosome_init_event_per_monomer = ribosome_data_reader.readColumn('ribosome_init_event_per_monomer')
+		cistron_counts = mRNA_counts_reader.readColumn('mRNA_cistron_counts')
+		monomer_ids = monomer_counts_reader.readAttribute('monomerIds')
+
+		# Map monomer ids to cistron indices
+		monomer_sim_data = sim_data.process.translation.monomer_data.struct_array
+		monomer_to_cistron_id_dict = dict(
+			zip(monomer_sim_data['id'], monomer_sim_data['cistron_id']))
+		cistron_idx_dict = {rna: i for i, rna in
+			enumerate(mRNA_counts_reader.readAttribute('mRNA_cistron_ids'))}
+		cistron_indices_for_monomers = [
+			cistron_idx_dict[monomer_to_cistron_id_dict[monomer_id]]
+			for monomer_id in monomer_ids]
+		cistron_counts_for_monomers = cistron_counts[:, cistron_indices_for_monomers]
+
+		# Get ribosome elongation rate for this sim condition
+		nutrients = sim_data.conditions[sim_data.condition]["nutrients"]
+		ribosome_elong_rate = sim_data.process.translation.ribosomeElongationRateDict[nutrients]
+
+		# Calculate the total number of initiation events that happen to each
+		# transcript per mRNA throughout the cell cycle
+		n_total_ribosome_init_events_per_mRNA = np.divide(
+			ribosome_init_event_per_monomer[1:, :].astype(np.float64),
+			cistron_counts_for_monomers[1:, :]).sum(axis=0)
+
+		# Divide by length of cell cycle to get average initiation rate
+		avg_init_rate = (1. / time[-1]) * n_total_ribosome_init_events_per_mRNA
+
+		# Divide elongation rate with initiation rate to get average distance
+		# between RNAPs in nucleotides
+		avg_inter_ribosome_distance = (ribosome_elong_rate / avg_init_rate).asNumber(units.nt)
+
+		# Sort from shortest to longest
+		sorted_index = avg_inter_ribosome_distance.argsort()
+		sorted_monomer_ids = [monomer_ids[i] for i in sorted_index]
+		avg_inter_ribosome_distance.sort()
+
+		# Mark genes with RNAPs that are too close to each other
+		n_too_close = (avg_inter_ribosome_distance[:SAMPLE_SIZE] < ribosome_footprint_size).sum()
+		bar_colors = ["r"]*n_too_close + ["b"]*(SAMPLE_SIZE - n_too_close)
+
+		# Plot the first n genes with shortest distances
+		plt.figure(figsize=(8, 6))
+		plt.barh(np.arange(SAMPLE_SIZE), avg_inter_ribosome_distance[:SAMPLE_SIZE],
+			tick_label=sorted_monomer_ids[:SAMPLE_SIZE],
+			color=bar_colors)
+		plt.xlabel("Average distance between ribosomes (nt)")
+		plt.axvline(ribosome_footprint_size, linestyle='--', color='k')
+
+		# Add values to each bar
+		for i, v in enumerate(avg_inter_ribosome_distance[:SAMPLE_SIZE]):
+			if np.isfinite(v):
+				plt.text(v - 1, i, "{0:.1f}".format(v), color='white', fontsize=5,
+					horizontalalignment='right', verticalalignment='center')
+
+		plt.tight_layout()
+		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
+		plt.close('all')
+
+if __name__ == '__main__':
+	Plot().cli()

--- a/models/ecoli/analysis/single/inter_rnap_distance.py
+++ b/models/ecoli/analysis/single/inter_rnap_distance.py
@@ -47,10 +47,9 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 
 		# Calculate the total number of initiation events that happen to each
 		# gene per gene copy throughout the cell cycle
-		n_total_rna_init_events_per_copy = np.divide(
-			n_rna_init_events[1:, :].astype(np.float64),
-			promoter_copy_numbers[1:, :]
-			).sum(axis=0)
+		sum_n_rna_init_events = n_rna_init_events[1:, :].astype(np.float64).sum(axis=0)
+		avg_promoter_copy_number = np.mean(promoter_copy_numbers[1:, :], axis=0)
+		n_total_rna_init_events_per_copy = sum_n_rna_init_events / avg_promoter_copy_number
 
 		# Divide by length of cell cycle to get average initiation rate
 		avg_init_rate = (1./time[-1])*n_total_rna_init_events_per_copy

--- a/models/ecoli/analysis/single/ppgpp_concentration.py
+++ b/models/ecoli/analysis/single/ppgpp_concentration.py
@@ -1,0 +1,40 @@
+"""
+Template for single analysis plots
+"""
+
+import pickle
+import os
+
+from matplotlib import pyplot as plt
+# noinspection PyUnresolvedReferences
+import numpy as np
+
+from models.ecoli.analysis import singleAnalysisPlot
+from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
+from wholecell.io.tablereader import TableReader
+
+
+class Plot(singleAnalysisPlot.SingleAnalysisPlot):
+	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
+		# Listeners used
+		main_reader = TableReader(os.path.join(simOutDir, 'Main'))
+		growth_limits_reader = TableReader(os.path.join(simOutDir, 'GrowthLimits'))
+
+		# Load data
+		initial_time = main_reader.readAttribute('initialTime')
+		time = main_reader.readColumn('time') - initial_time
+
+		ppgpp_concentration = growth_limits_reader.readColumn('ppgpp_conc')
+
+		plt.figure()
+		plt.plot(time / 60., ppgpp_concentration, label='ppGpp concentration')
+		plt.xlabel('Time (min)')
+		plt.ylabel('ppGpp concentration (uM)')
+
+		### Create Plot ###
+		plt.tight_layout()
+		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
+		plt.close('all')
+
+if __name__ == '__main__':
+	Plot().cli()

--- a/models/ecoli/analysis/single/ppgpp_concentration.py
+++ b/models/ecoli/analysis/single/ppgpp_concentration.py
@@ -1,16 +1,12 @@
 """
-Template for single analysis plots
+Plot ppGpp concentration
 """
-
-import pickle
 import os
 
 from matplotlib import pyplot as plt
-# noinspection PyUnresolvedReferences
-import numpy as np
 
 from models.ecoli.analysis import singleAnalysisPlot
-from wholecell.analysis.analysis_tools import exportFigure, read_bulk_molecule_counts
+from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader
 
 
@@ -23,15 +19,13 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 		# Load data
 		initial_time = main_reader.readAttribute('initialTime')
 		time = main_reader.readColumn('time') - initial_time
-
 		ppgpp_concentration = growth_limits_reader.readColumn('ppgpp_conc')
 
+		# Create Plot
 		plt.figure()
 		plt.plot(time / 60., ppgpp_concentration, label='ppGpp concentration')
 		plt.xlabel('Time (min)')
 		plt.ylabel('ppGpp concentration (uM)')
-
-		### Create Plot ###
 		plt.tight_layout()
 		exportFigure(plt, plotOutDir, plotOutFileName, metadata)
 		plt.close('all')

--- a/models/ecoli/listeners/ribosome_data.py
+++ b/models/ecoli/listeners/ribosome_data.py
@@ -68,6 +68,7 @@ class RibosomeData(wholecell.listeners.listener.Listener):
 		self.actual_prob_translation_per_transcript = np.zeros(self.nMonomers,
 														np.float64)
 		self.mRNA_is_overcrowded = np.zeros(self.nMonomers, np.float64)
+		self.is_n_ribosomes_to_activate_reduced = False
 		self.ribosome_init_event_per_monomer = np.zeros(self.nMonomers,
 													   np.int64)
 
@@ -185,4 +186,5 @@ class RibosomeData(wholecell.listeners.listener.Listener):
 			n_ribosomes_on_each_mRNA = self.n_ribosomes_on_each_mRNA,
 			mRNA_TU_index = self.mRNA_TU_index,
 			protein_mass_on_polysomes = self.protein_mass_on_polysomes,
+			is_n_ribosomes_to_activate_reduced = self.is_n_ribosomes_to_activate_reduced,
 			)

--- a/models/ecoli/listeners/ribosome_data.py
+++ b/models/ecoli/listeners/ribosome_data.py
@@ -67,7 +67,7 @@ class RibosomeData(wholecell.listeners.listener.Listener):
 													 np.float64)
 		self.actual_prob_translation_per_transcript = np.zeros(self.nMonomers,
 														np.float64)
-		self.mRNA_is_overcrowded = np.zeros(self.nMonomers, np.float64)
+		self.mRNA_is_overcrowded = np.zeros(self.nMonomers, bool)
 		self.is_n_ribosomes_to_activate_reduced = False
 		self.ribosome_init_event_per_monomer = np.zeros(self.nMonomers,
 													   np.int64)

--- a/models/ecoli/listeners/rna_synth_prob.py
+++ b/models/ecoli/listeners/rna_synth_prob.py
@@ -43,7 +43,7 @@ class RnaSynthProb(wholecell.listeners.listener.Listener):
 
 		self.target_rna_synth_prob = np.zeros(self.n_TU, np.float64)
 		self.actual_rna_synth_prob = np.zeros(self.n_TU, np.float64)
-		self.tu_is_overcrowded = np.zeros(self.n_TU, np.float64)
+		self.tu_is_overcrowded = np.zeros(self.n_TU, bool)
 		self.promoter_copy_number = np.zeros(self.n_TU, np.int16)
 		self.rna_synth_prob_per_cistron = np.zeros(self.n_cistron, np.float64)
 		self.total_rna_init = 0

--- a/models/ecoli/processes/polypeptide_initiation.py
+++ b/models/ecoli/processes/polypeptide_initiation.py
@@ -162,9 +162,9 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 
 		num_rescales = 0
 		while np.any(protein_init_prob > max_p_per_protein):
-			protein_init_prob[is_overcrowded] = max_p_per_protein[
-				is_overcrowded]
 			if protein_init_prob[~is_overcrowded].sum() != 0:
+				protein_init_prob[is_overcrowded] = max_p_per_protein[
+					is_overcrowded]
 				# Resolve overcrowding through rescaling (preferred)
 				scale_the_rest_by = (
 					(1. - protein_init_prob[is_overcrowded].sum())

--- a/models/ecoli/processes/polypeptide_initiation.py
+++ b/models/ecoli/processes/polypeptide_initiation.py
@@ -145,7 +145,6 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 			self.timeStepSec())
 
 		n_ribosomes_to_activate = np.int64(self.activationProb * inactiveRibosomeCount)
-		n_ribosomes_to_activate_OLD = np.copy(n_ribosomes_to_activate)
 
 		if n_ribosomes_to_activate == 0:
 			return
@@ -156,50 +155,41 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 		max_p = (self.ribosomeElongationRate / self.active_ribosome_footprint_size
 			* (units.s) * self.timeStepSec() / 
 			n_ribosomes_to_activate).asNumber()
-		max_p_OLD = np.copy(max_p)
 		max_p_per_protein = max_p*cistron_counts[self.cistron_to_monomer_mapping]
 		is_overcrowded = (protein_init_prob > max_p_per_protein)
 
-		num_rescales = 0
 		while np.any(protein_init_prob > max_p_per_protein):
 			if protein_init_prob[~is_overcrowded].sum() != 0:
+				# Resolve overcrowding through rescaling (preferred)
 				protein_init_prob[is_overcrowded] = max_p_per_protein[
 					is_overcrowded]
-				# Resolve overcrowding through rescaling (preferred)
 				scale_the_rest_by = (
 					(1. - protein_init_prob[is_overcrowded].sum())
 					/ protein_init_prob[~is_overcrowded].sum())
 				protein_init_prob[~is_overcrowded] *= scale_the_rest_by
 				is_overcrowded |= (protein_init_prob > max_p_per_protein)
-				num_rescales += 1
-				print("Num rescales: ", num_rescales)  # TODO: Remove after testing
 			else:
 				# If we cannot resolve the overcrowding through rescaling,
-				# we need to activate fewer ribosomes.
-				# Set the number of ribosomes so that there will be no overcrowding
-				max_index = np.argmax(protein_init_prob[is_overcrowded])
+				# we need to activate fewer ribosomes. Set the number of
+				# ribosomes to activate so that there will be no overcrowding.
+				max_index = np.argmax(
+					protein_init_prob[is_overcrowded] / max_p_per_protein[is_overcrowded])
 				max_init_prob = protein_init_prob[is_overcrowded][max_index]
 				associated_cistron_counts = cistron_counts[
 					self.cistron_to_monomer_mapping][is_overcrowded][max_index]
-				print("Trying to activate fewer ribosomes")  # TODO: Remove after testing
-				print("Num rescales before this: ", num_rescales)  # TODO: Remove after testing
-				print("Original number: ", n_ribosomes_to_activate)  # TODO: Remove after testing
-				print("Original number (COPY): ", n_ribosomes_to_activate_OLD)  # TODO: Remove after testing
 				n_ribosomes_to_activate = np.int64((
 					self.ribosomeElongationRate
 					/ self.active_ribosome_footprint_size
 					* (units.s) * self.timeStepSec() / max_init_prob
 					* associated_cistron_counts).asNumber())
-				print("New number: ", n_ribosomes_to_activate)  # TODO: Remove after testing
-				print("Original max_p: ", max_p)  # TODO: Remove after testing
-				print("Original max_p (COPY): ", max_p_OLD)  # TODO: Remove after testing
-				# Update maximum probabilities based on new number of activated ribosomes
+
+				# Update maximum probabilities based on new number of activated
+				# ribosomes.
 				max_p = (
 					self.ribosomeElongationRate
 					/ self.active_ribosome_footprint_size
 					* (units.s) * self.timeStepSec()
 					/ n_ribosomes_to_activate).asNumber()
-				print("New max_p: ", max_p)  # TODO: Remove after testing
 				max_p_per_protein = max_p * cistron_counts[self.cistron_to_monomer_mapping]
 				is_overcrowded = (protein_init_prob > max_p_per_protein)
 				assert is_overcrowded.sum() == 0 # We expect no overcrowding

--- a/models/ecoli/processes/polypeptide_initiation.py
+++ b/models/ecoli/processes/polypeptide_initiation.py
@@ -158,6 +158,11 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 		max_p_per_protein = max_p*cistron_counts[self.cistron_to_monomer_mapping]
 		is_overcrowded = (protein_init_prob > max_p_per_protein)
 
+		# Initalize flag to record if the number of ribosomes activated at this
+		# time step needed to be reduced to prevent overcrowding
+		is_n_ribosomes_to_activate_reduced = False
+
+		# If needed, resolve overcrowding
 		while np.any(protein_init_prob > max_p_per_protein):
 			if protein_init_prob[~is_overcrowded].sum() != 0:
 				# Resolve overcrowding through rescaling (preferred)
@@ -172,6 +177,7 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 				# If we cannot resolve the overcrowding through rescaling,
 				# we need to activate fewer ribosomes. Set the number of
 				# ribosomes to activate so that there will be no overcrowding.
+				is_n_ribosomes_to_activate_reduced = True
 				max_index = np.argmax(
 					protein_init_prob[is_overcrowded] / max_p_per_protein[is_overcrowded])
 				max_init_prob = protein_init_prob[is_overcrowded][max_index]
@@ -201,6 +207,9 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 			actual_protein_init_prob)
 		self.writeToListener(
 			"RibosomeData", "mRNA_is_overcrowded", is_overcrowded)
+		self.writeToListener(
+			"RibosomeData", "is_n_ribosomes_to_activate_reduced",
+			is_n_ribosomes_to_activate_reduced)
 
 		# Sample multinomial distribution to determine which mRNAs have full
 		# 70S ribosomes initialized on them


### PR DESCRIPTION
This PR resolves #1372 by activating fewer ribosomes to resolve overcrowding when rescaling `protein_init_prob` (which can be thought of as pushing more ribosomes onto mRNAs that aren't overcrowded) fails. The failure of the rescaling does not happen often but has been observed in a handful of seeds for a few parameter combinations that lead to high levels of new gene expression. In these cases where rescaling fails, the new reduced number of ribosomes activated is chosen to be such that no genes are overcrowded. 

Along with this change to the polypeptide initiation process comes a few updates to analysis scripts:
`model/ecoli/analysis/single/inter_rnap_dist.py`
`model/ecoli/analysis/single/inter_ribosome_dist.py`
`model/ecoli/analysis/single/ppgpp_concentration.py`

Example plot outputs attached for a single generation wildtype simulation. 
[PR_reduced_ribos.pdf](https://github.com/CovertLab/wcEcoli/files/14891427/PR_reduced_ribos.pdf)
(You may notice that a couple of monomers have average inter-ribosome distances slightly below the footprint size, but since the mRNA counts for these proteins are very small and this is averaged over only a single generation, this is okay. These monomer ids are marked with a * .)