### PR TITLE
Add listeners for max_p in transcript and polypeptide initiation

### DIFF
--- a/models/ecoli/listeners/ribosome_data.py
+++ b/models/ecoli/listeners/ribosome_data.py
@@ -63,14 +63,16 @@ class RibosomeData(wholecell.listeners.listener.Listener):
 		self.processElongationRate = 0.
 		self.translationSupply = np.zeros(21, np.float64)
 		self.numTrpATerminated = 0.
-		self.target_prob_translation_per_transcript = np.zeros(self.nMonomers,
-													 np.float64)
-		self.actual_prob_translation_per_transcript = np.zeros(self.nMonomers,
-														np.float64)
+		self.max_p = 0.
+		self.max_p_per_protein = np.zeros(self.nMonomers, np.float64)
+		self.target_prob_translation_per_transcript = np.zeros(
+			self.nMonomers, np.float64)
+		self.actual_prob_translation_per_transcript = np.zeros(
+			self.nMonomers, np.float64)
 		self.mRNA_is_overcrowded = np.zeros(self.nMonomers, bool)
 		self.is_n_ribosomes_to_activate_reduced = False
-		self.ribosome_init_event_per_monomer = np.zeros(self.nMonomers,
-													   np.int64)
+		self.ribosome_init_event_per_monomer = np.zeros(
+			self.nMonomers, np.int64)
 
 		# Attributes computed by the listener
 		self.n_ribosomes_per_transcript = np.zeros(self.nMonomers, np.int64)
@@ -133,6 +135,7 @@ class RibosomeData(wholecell.listeners.listener.Listener):
 
 	def tableCreate(self, tableWriter):
 		subcolumns = {
+			'max_p_per_protein': 'monomerIds',
 			'target_prob_translation_per_transcript': 'monomerIds',
 			'actual_prob_translation_per_transcript': 'monomerIds',
 			'mRNA_is_overcrowded': 'monomerIds',
@@ -175,6 +178,8 @@ class RibosomeData(wholecell.listeners.listener.Listener):
 			processElongationRate = self.processElongationRate,
 			translationSupply = self.translationSupply,
 			numTrpATerminated = self.numTrpATerminated,
+			max_p = self.max_p,
+			max_p_per_protein = self.max_p_per_protein,
 			target_prob_translation_per_transcript=self
 			.target_prob_translation_per_transcript,
 			actual_prob_translation_per_transcript=self

--- a/models/ecoli/listeners/rna_synth_prob.py
+++ b/models/ecoli/listeners/rna_synth_prob.py
@@ -41,6 +41,7 @@ class RnaSynthProb(wholecell.listeners.listener.Listener):
 	def allocate(self):
 		super(RnaSynthProb, self).allocate()
 
+		self.max_p = 0.
 		self.target_rna_synth_prob = np.zeros(self.n_TU, np.float64)
 		self.actual_rna_synth_prob = np.zeros(self.n_TU, np.float64)
 		self.tu_is_overcrowded = np.zeros(self.n_TU, bool)
@@ -143,6 +144,7 @@ class RnaSynthProb(wholecell.listeners.listener.Listener):
 			target_rna_synth_prob = self.target_rna_synth_prob,
 			actual_rna_synth_prob =	self.actual_rna_synth_prob,
 			tu_is_overcrowded = self.tu_is_overcrowded,
+			max_p = self.max_p,
 			actual_rna_synth_prob_per_cistron = self.actual_rna_synth_prob_per_cistron,
 			target_rna_synth_prob_per_cistron = self.target_rna_synth_prob_per_cistron,
 			expected_rna_init_per_cistron = self.expected_rna_init_per_cistron,

--- a/models/ecoli/processes/polypeptide_initiation.py
+++ b/models/ecoli/processes/polypeptide_initiation.py
@@ -274,7 +274,7 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 			pos_on_mRNA=positions_on_mRNA,
 		)
 
-		# Decrement free 30S and 70S ribosomal subunit counts
+		# Decrement free 30S and 50S ribosomal subunit counts
 		self.ribosome30S.countDec(n_new_proteins.sum())
 		self.ribosome50S.countDec(n_new_proteins.sum())
 

--- a/models/ecoli/processes/polypeptide_initiation.py
+++ b/models/ecoli/processes/polypeptide_initiation.py
@@ -156,6 +156,9 @@ class PolypeptideInitiation(wholecell.processes.process.Process):
 			* (units.s) * self.timeStepSec() / 
 			n_ribosomes_to_activate).asNumber()
 		max_p_per_protein = max_p*cistron_counts[self.cistron_to_monomer_mapping]
+		self.writeToListener("RibosomeData", "max_p", max_p)
+		self.writeToListener(
+			"RibosomeData", "max_p_per_protein", max_p_per_protein)
 		is_overcrowded = (protein_init_prob > max_p_per_protein)
 
 		# Initalize flag to record if the number of ribosomes activated at this

--- a/models/ecoli/processes/transcript_initiation.py
+++ b/models/ecoli/processes/transcript_initiation.py
@@ -229,6 +229,7 @@ class TranscriptInitiation(wholecell.processes.process.Process):
 		# allowed from the known RNAP footprint sizes
 		max_p = (self.rnaPolymeraseElongationRate / self.active_rnap_footprint_size
 			* (units.s) * self.timeStepSec() / n_RNAPs_to_activate).asNumber()
+		self.writeToListener("RnaSynthProb", "max_p", max_p)
 		is_overcrowded = (self.promoter_init_probs > max_p)
 
 		while np.any(self.promoter_init_probs > max_p):


### PR DESCRIPTION
This PR adds listeners for the `max_p` probability values involved in the overcrowding computations in the transcript initiation and polypeptide initiation processes. Recording these values will be useful in determining the severity of overcrowding via analysis scripts, particularly in simulations with high new gene expression.