### PR TITLE
Skip rRNA gene RNAP density plot if rRNA IDs do not match

### DIFF
--- a/models/ecoli/analysis/variant/rrna_gene_rnap_densities.py
+++ b/models/ecoli/analysis/variant/rrna_gene_rnap_densities.py
@@ -32,6 +32,17 @@ class Plot(variantAnalysisPlot.VariantAnalysisPlot):
 		with open(simDataFile, 'rb') as f:
 			sim_data = pickle.load(f)
 
+		# Load IDs of rRNA transcription units
+		rna_data = sim_data.process.transcription.rna_data
+		rRNA_ids = rna_data['id'][rna_data['is_rRNA']]
+
+		# If the list of rRNA IDs does not match the rRNA TU IDs, skip analysis
+		# (likely using rRNA operon structure variants)
+		if set(rRNA_ids) != set(TU_ID_TO_RRNA_OPERON_ID.keys()):
+			print(
+				'Skipping analysis - this analysis should be run for simulations with WT rRNA operon structures.')
+			return
+
 		rnap_footprint_size = sim_data.process.transcription.active_rnap_footprint_size.asNumber(
 			units.nt)
 

--- a/models/ecoli/processes/chromosome_structure.py
+++ b/models/ecoli/processes/chromosome_structure.py
@@ -386,8 +386,6 @@ class ChromosomeStructure(wholecell.processes.process.Process):
 				else:
 					self.ppi.countDec(-n_ppi_added)
 
-			assert n_initiated_sequences == incomplete_transcription_event.sum()
-
 		# Write to listener
 		self.writeToListener(
 			'RnapData', 'incomplete_transcription_event',


### PR DESCRIPTION
This PR fixes the optional features build failures that we've been seeing in the past week by skipping the `variant` analysis script for rRNA gene RNAP densities if the IDs of the rRNAs listed in the dictionary do not match the IDs in `sim_data`. The analysis script was leading to failures in the no-operon runs of the optional features build and this fix will ensure that this analysis script is skipped for those runs. This PR also removes the `assert` statement in the `ChromosomeStructure` process that was triggering errors in some of @rjuenemann's runs. This statement was being triggered whenever there are RNAPs that are removed by collisions with replication forks that have not advanced at all from their starting locations. I did not think it would be worth the effort to have this statement handle this exception, especially since the statement was already checking something that was relatively trivial (despite this very rare exception).