### PR TITLE
Change from Google Cloud Container Registry to Artifact Registry

### DIFF
--- a/cloud/build-runtime.sh
+++ b/cloud/build-runtime.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # Use Google Cloud Build servers to build a personalized "${ID}-wcm-runtime"
-# Docker Image and store it in the Google Container Registry.
+# Docker Image and store it in a Google Artifact Registry.
 #
 # COMMAND LINE ARGUMENTS:
 #   ARG1: Distinguishing ID prefix for the "${ID}-wcm-runtime" tag for the
-#     Docker Image to build in GCR; defaults to "${USER}". Must be in lower case.
+#     Docker Image to build; defaults to "${USER}". Must be in lower case.
 #
 # ASSUMES: The current working dir is the wcEcoli/ project root.
 
@@ -12,14 +12,17 @@ set -eu
 
 ID="${1:-$USER}"
 
-PROJECT="$(gcloud config get-value core/project)"
+PROJECT="$(gcloud config get core/project)"
+REGION="$(gcloud config get compute/region)"
 WCM_RUNTIME="${ID}-wcm-runtime"
-TAG="gcr.io/${PROJECT}/${WCM_RUNTIME}"
+TAG="${REGION}-docker.pkg.dev/${PROJECT}/wcm/${WCM_RUNTIME}"
 
 echo "=== Cloud-building WCM runtime Docker Image: ${TAG} ==="
 
 # This needs only one payload file so copy it in rather than using a config at
 # the project root which would upload the entire project.
+# --region sets the Cloud Build region while TAG sets the artifact region et al.
 cp requirements.txt cloud/docker/runtime/
-gcloud builds submit --timeout=3h --tag "${TAG}" cloud/docker/runtime/
+gcloud builds submit --timeout=3h --region="${REGION}" \
+    --tag="${TAG}" cloud/docker/runtime/
 rm cloud/docker/runtime/requirements.txt

--- a/cloud/build-wcm.sh
+++ b/cloud/build-wcm.sh
@@ -2,9 +2,6 @@
 # Use Google Cloud Build servers to build a personalized "${ID}-wcm-code" Docker
 # Image and store it in a Google Artifact Registry.
 #
-# TODO: Require and use config artifacts/location, artifacts/repository?
-#       Otherwise check that $REGION is not empty.
-#
 # COMMAND LINE ARGUMENTS:
 #   ARG1: Distinguishing ID prefix for the "wcm-code" Docker Image tag;
 #     defaults to "${USER}".

--- a/cloud/build-wcm.sh
+++ b/cloud/build-wcm.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 # Use Google Cloud Build servers to build a personalized "${ID}-wcm-code" Docker
-# Image and store it in the Google Container Registry.
+# Image and store it in a Google Artifact Registry.
+#
+# TODO: Require and use config artifacts/location, artifacts/repository?
+#       Otherwise check that $REGION is not empty.
 #
 # COMMAND LINE ARGUMENTS:
 #   ARG1: Distinguishing ID prefix for the "wcm-code" Docker Image tag;
 #     defaults to "${USER}".
-#   ARG2: Docker tag for the wcm-runtime Image in GCR to build FROM; defaults to
-#     "${ID}-wcm-runtime".
-#     The named Docker image must already exist in the GCR project.
+#   ARG2: Docker tag for the wcm-runtime Image in Artifact Registry to build FROM;
+#     defaults to "${ID}-wcm-runtime".
+#     The named Docker Image must already exist in the Artifact Registry.
 #
 # ASSUMES: The current working dir is the wcEcoli/ project root.
 
@@ -15,6 +18,7 @@ set -eu
 
 ID="${1:-$USER}"
 
+REGION="$(gcloud config get compute/region)"
 WCM_RUNTIME="${2:-${ID}-wcm-runtime}"
 WCM_CODE="${ID}-wcm-code"
 GIT_HASH=$(git rev-parse HEAD)
@@ -29,7 +33,10 @@ echo "=== git hash ${GIT_HASH}, git branch ${GIT_BRANCH} ==="
 
 # This needs a config file to identify the project files to upload and the
 # Dockerfile to run.
+# --region sets the Cloud Build region.
 gcloud builds submit --timeout=15m --config config-build-2-wcm-code.json \
-    --substitutions="_WCM_RUNTIME=${WCM_RUNTIME},_WCM_CODE=${WCM_CODE},_GIT_HASH=${GIT_HASH},_GIT_BRANCH=${GIT_BRANCH},_TIMESTAMP=${TIMESTAMP}"
+    --region="${REGION}" \
+    --substitutions="_WCM_RUNTIME=${WCM_RUNTIME},_WCM_CODE=${WCM_CODE},\
+_GIT_HASH=${GIT_HASH},_GIT_BRANCH=${GIT_BRANCH},_TIMESTAMP=${TIMESTAMP}"
 
 rm source-info/git_diff.txt

--- a/cloud/build.sh
+++ b/cloud/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Use Google Cloud Build servers to build layered WCM Docker Images and store
-# them in the Google Container Registry.
+# them in a Google Artifact Registry in the current region.
 #
 # ASSUMES: The current working dir is the wcEcoli/ project root.
 

--- a/cloud/docker/runtime/Dockerfile
+++ b/cloud/docker/runtime/Dockerfile
@@ -5,7 +5,7 @@
 #
 #     > docker build -f cloud/docker/runtime/Dockerfile -t ${USER}-wcm-runtime .
 #
-# (To build using the Cloud Build service and store in the Container Registry,
+# (To build using the Cloud Build service and store in an Artifact Registry,
 # run `cloud/build.sh`.)
 #
 # Add option `--build-arg from=ABC` to build from a different base image "ABC"
@@ -53,10 +53,10 @@ ARG NO_AVX2=0
 ENV NO_AVX2="$NO_AVX2"
 
 # Install OpenBLAS for numpy, scipy, and Aesara.
-ENV OPENBLAS_LABEL=v0.3.23
+ENV OPENBLAS_LABEL=v0.3.27
 RUN if [ -f ~/.numpy-site.cfg ]; then \
     (mkdir -p openblas && cd openblas \
-    && curl -SL https://github.com/xianyi/OpenBLAS/archive/${OPENBLAS_LABEL}.tar.gz | tar -xz \
+    && curl -SL https://github.com/OpenMathLib/OpenBLAS/archive/${OPENBLAS_LABEL}.tar.gz | tar -xz \
     && cd OpenBLAS* \
     && echo "Compiling OpenBLAS ${OPENBLAS_LABEL} with NO_AVX2=${NO_AVX2}" \
     && make "NO_AVX2=${NO_AVX2}" FC=gfortran \

--- a/cloud/docker/wholecell/Dockerfile
+++ b/cloud/docker/wholecell/Dockerfile
@@ -9,7 +9,7 @@
 # (If you want to build container image #3 on top of the locally-built base,
 # you'll have to edit that Dockerfile or upload this image.)
 #
-# (To build using the Cloud Build service and store in the Container Registry,
+# (To build using the Cloud Build service and store in an Artifact Registry,
 # run `cloud/build.sh`.)
 #
 # After building locally you can start up a new container from the image:
@@ -18,8 +18,9 @@
 #
 # or if you used build.sh or build-wcm.sh to build using Cloud Build:
 #
-#     > PROJECT="$(gcloud config get-value core/project)"
-#     > TAG="gcr.io/${PROJECT}/${USER}-wcm-code"
+#     > PROJECT="$(gcloud config get core/project)"
+#     > REGION="$(gcloud config get compute/region)"
+#     > TAG="${REGION}-docker.pkg.dev/${PROJECT}/wcm/${USER}-wcm-code"
 #     > docker run --name wholecelltest -it --rm "${TAG}"
 #
 # It will start a shell where you can execute commands:
@@ -46,7 +47,8 @@ LABEL application="Whole Cell Model of Escherichia coli" \
     email="allencentercovertlab@gmail.com" \
     license="https://github.com/CovertLab/WholeCellEcoliRelease/blob/master/LICENSE.md" \
     organization="Covert Lab at Stanford" \
-    website="https://www.covert.stanford.edu/"
+    website="https://www.covert.stanford.edu/" \
+    repository="https://github.com/CovertLab/wcEcoli"
 
 COPY . /wcEcoli
 WORKDIR /wcEcoli

--- a/config-build-2-wcm-code.json
+++ b/config-build-2-wcm-code.json
@@ -4,17 +4,17 @@
         "name": "gcr.io/cloud-builders/docker",
         "args": [
             "build",
-            "--build-arg", "from=gcr.io/${PROJECT_ID}/${_WCM_RUNTIME}",
+            "--build-arg", "from=${LOCATION}-docker.pkg.dev/${PROJECT_ID}/wcm/${_WCM_RUNTIME}",
             "--build-arg", "git_hash=${_GIT_HASH}",
             "--build-arg", "git_branch=${_GIT_BRANCH}",
             "--build-arg", "timestamp=${_TIMESTAMP}",
-            "-t", "gcr.io/${PROJECT_ID}/${_WCM_CODE}",
+            "-t", "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/wcm/${_WCM_CODE}",
             "-f", "cloud/docker/wholecell/Dockerfile",
             "."
         ]
     }
     ],
     "images": [
-        "gcr.io/${PROJECT_ID}/${_WCM_CODE}"
+        "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/wcm/${_WCM_CODE}"
     ]
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,8 +43,8 @@ Docker mechanics.
 
    ```shell script
    cloud/build.sh
-   docker pull gcr.io/${PROJECT}/${USER}-wcm-code
-   docker run --name=wcm -it --rm gcr.io/${PROJECT}/${USER}-wcm-code
+   docker pull ${REGION}-docker.pkg.dev/${PROJECT}/wcm/${USER}-wcm-code
+   docker run --name=wcm -it --rm ${REGION}-docker.pkg.dev/${PROJECT}/wcm/${USER}-wcm-code
    ```
 
    **NOTE:** It's better to build the Docker Image on Linux (e.g. in Google Cloud
@@ -52,7 +52,7 @@ Docker mechanics.
    a Docker bug by disabling AVX2 instructions in OpenBLAS. That change somehow
    makes the computation produce different results and run a little slower.
    An Image built on Linux won't have the AVX2 workaround and yet it runs fine on macOS.
-   See [xianyi/OpenBLAS#2244](https://github.com/xianyi/OpenBLAS/issues/2244#issuecomment-696510557).
+   See [OpenMathLib/OpenBLAS#2244](https://github.com/OpenMathLib/OpenBLAS/issues/2244#issuecomment-696510557).
 
    Once you have a Docker Image, you can run the model's Python programs inside the Container.
    (PyCharm Pro should support debugging into a Docker Container but we haven't tested that.)

--- a/docs/create-pyenv.md
+++ b/docs/create-pyenv.md
@@ -6,7 +6,7 @@ Before you begin all the steps below to install the Python runtime for the Whole
 
 The script `cloud/build-containers-locally.sh` will build a Docker Image on
 your computer if you have Docker Engine or Docker Desktop installed.
-The script `cloud/build.sh` will do the same using Google Container Registry if
+The script `cloud/build.sh` will do the same using Google Artifact Registry if
 you have a Google Cloud project set up.
 
 Either way, you can run the Whole Cell Model (WCM) in a Docker Container, isolated from your computer's operating system, Python versions, binary libraries, and everything else installed.

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -119,9 +119,10 @@ Also see [Borealis: How to run a workflow](https://github.com/CovertLab/borealis
    Cloud Firetasks that start running after you build an Image will "pull" it and use it,
    even Firetasks that were already queued to run. You can do this to update your code
    then use `lpad` commands to restart failed tasks and resume paused tasks.  
-   The full Docker Image path is `gcr.io/$PROJECT/$USER-wcm-code`, where
-   `$PROJECT` is the Google Cloud project name and `$USER` is your local username.
-   You can also "pull" this Image and run it locally.
+   The full Docker Image path is `${REGION}-docker.pkg.dev/${PROJECT}/wcm/${USER}-wcm-code`,
+   where `$REGION` is Artifact Registry region (we usually use `us-west1`),
+   `$PROJECT` is the Google Cloud project name, and `$USER` is your local username.
+   You can also `pull` this Image with Docker to run it locally.
 
 1. Open an ssh tunnel to the project's MongoDB "LaunchPad" server in Google Compute Engine:
 

--- a/runscripts/cloud/custom.py
+++ b/runscripts/cloud/custom.py
@@ -125,7 +125,8 @@ class CustomWorkflow(WorkflowCLI):
 		# the owner_id, timestamp arg, and description arg match.
 		setattr(args, 'storage_basename', 'WCM')
 
-		self.DOCKER_IMAGE = f'gcr.io/{gcp.project()}/{owner_id}-wcm-code'
+		region = gcp.gcloud_get_config('compute/region')
+		self.DOCKER_IMAGE = f'{region}-docker.pkg.dev/{gcp.project()}/wcm/{owner_id}-wcm-code'
 		super().run(args)
 
 

--- a/runscripts/cloud/wcm.py
+++ b/runscripts/cloud/wcm.py
@@ -33,7 +33,7 @@ from runscripts.cloud.util.workflow import (DEFAULT_LPAD_YAML,
 
 
 # ':latest' -- "You keep using that word. I do not think it means what you think it means."
-DOCKER_IMAGE = 'gcr.io/{}/{}-wcm-code'
+DOCKER_IMAGE = '{}-docker.pkg.dev/{}/wcm/{}-wcm-code'
 
 GCE_VM_MACHINE_TYPE = workflow_cli.GCE_VM_MACHINE_TYPE
 
@@ -53,7 +53,8 @@ class WcmWorkflow(Workflow):
 			description=description)
 
 		self.timestamp = timestamp
-		self.image = DOCKER_IMAGE.format(gcp.project(), owner_id)
+		region = gcp.gcloud_get_config('compute/region')
+		self.image = DOCKER_IMAGE.format(region, gcp.project(), owner_id)
 
 		subdir = Workflow.timestamped_description(timestamp, description)
 		self.storage_prefix = pp.join(


### PR DESCRIPTION
* Switch from the deprecated Google Container Registry to Artifact Registry "wcm".
* Update the GitHub xianyi/OpenBLAS repo URL to OpenMathLib/OpenBLAS.
* Update to OpenBLAS v0.3.27 . It has a bunch of bug fixes and support for Apple Silicon.
* TODO: Compile OpenBLAS by default? (Meanwhile I haven't tested OpenBLAS v0.3.27.)
* TODO: Upgrade from Python 3.11.3 to 3.11.8?
* TODO: Use a Python virtual env in the Docker Container? `WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment * instead: https://pip.pypa.io/warnings/venv`
* TODO: Fix runtime deprecation warnings about numpy.distutils, msvccompiler.py, and Blas libraries.

[Sean, take a look if you're feeling up to it.]