### PR TITLE
changed compartment of EG12298-MONOMER, and eliminated protein deg ad…

### DIFF
--- a/reconstruction/ecoli/flat/adjustments/protein_deg_rates_adjustments.tsv
+++ b/reconstruction/ecoli/flat/adjustments/protein_deg_rates_adjustments.tsv
@@ -1,5 +1,3 @@
 # Adjustments to get protein expression for certain enzymes required for metabolism				
 "name"	"value"	"units"	"_source"	"_comments"
-"ADENYLATECYC-MONOMER[c]"	"2.0/600"		"fit_sim_data_1.py"	"CyaA, adenylate cyclase; convert from 2 min to 10 hr half life to get expression in acetate condition (required for cAMP)"
-"SPOT-MONOMER[c]"	"2.0/600"		"fit_sim_data_1.py"	"SpoT, ppGpp phosphatase; convert from 2 min to 10 hr half life to better match expected protein counts"
-"EG12298-MONOMER[p]"	0.1		"fit_sim_data_1.py"	"yibQ, Predicted polysaccharide deacetylase; This protein is fit for the anaerobic condition"
+"EG12298-MONOMER[c]"	0.1		"fit_sim_data_1.py"	"yibQ, Predicted polysaccharide deacetylase; This protein is fit for the anaerobic condition"


### PR DESCRIPTION
Changed the compartment of EG12298-MONOMER from periplasmic to cytosolic. Found that EG12298-MONOMER[p] was not matching any monomers in sim_data.process.translation.monomer_data['id'] during  input_adjustments() applied in fit_sim_data1.py. Additionally, the half life's by N-end rule of ADENYLATECYC-MONOMER and SPOT-MONOMER were computed to be 600 min, not 2 min as previously described in protein_deg_rates_adjustments.tsv. Perhaps the aa sequence changed. Therefore, ADENYLATECYC-MONOMER and SPOT-MONOMER adjustments in this file were removed.