### PR TITLE
update the pyenv setup steps

### DIFF
--- a/docs/create-pyenv.md
+++ b/docs/create-pyenv.md
@@ -58,8 +58,11 @@ This page goes through the Python environment setup steps in more detail and wit
    **On macOS**
 
    ```bash
-   brew install glpk openssl readline swig suite-sparse xz
+   brew install cmake glpk openssl readline swig suite-sparse xz
    ```
+
+   Use the `cmake` native package rather than the `cmake` pip, which can't build
+   `osqp` and `qdldl`.
 
    **On Ubuntu**
 
@@ -97,7 +100,7 @@ This page goes through the Python environment setup steps in more detail and wit
        . "${PI_HOME}/etc/bash_profile"
    fi
 
-   module load git/2.27.0 git-lfs/2.11.
+   module load git/2.45.1 git-lfs/2.11.
    module load wcEcoli/python3
 
    export PYENV_ROOT="${PI_HOME}/pyenv"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,8 @@
 #   cd ~/dev/wcEcoli
 #   pyenv virtualenv 3.11.3 wcEcoli3 && pyenv local wcEcoli3
 #
-## Upgrade this virtual environment's installers:
-#   pip install --upgrade pip setuptools virtualenv virtualenvwrapper virtualenv-clone wheel
+## Upgrade this virtual environment's pip installer:
+#   pip install --upgrade pip
 #
 ## Install numpy (if it's the first time) then all the packages listed in this file (see
 ## docs/create-pyenv.md about whether to create a `~/.numpy-site.cfg` file and add
@@ -39,6 +39,8 @@
 #   python -c "import numpy as np; np.show_config()"
 #   runscripts/debug/numpy_benchmark.py
 #   python -c "import scipy; scipy.__config__.show()"
+#   python -c "import aesara; print(aesara.config.blas.ldflags)"
+#   python runscripts/debug/summarize_environment.py
 #   OPENBLAS_NUM_THREADS=1 python -m wholecell.tests.utils.test_library_performance
 #
 ## Build the Cython code:
@@ -46,7 +48,7 @@
 
 # Installers
 pip>=23.1
-setuptools>=67.6.1
+setuptools==73.0.1  # setuptools>=74.0.0 breaks aesara (via distutils changes?)
 virtualenv>=20.21.0
 virtualenv-clone>=0.5.7
 virtualenvwrapper>=4.8.4

--- a/wholecell/tests/utils/test_blas.py
+++ b/wholecell/tests/utils/test_blas.py
@@ -12,9 +12,10 @@ presumably by changing evaluation order and thus floating point rounding.
 
 Any of these ways works to run this test. The first one is quiet if the test
 passes. The others always show stdout:
-	pytest wholecell/tests/utils/test_blas.py
-	python -m wholecell.tests.utils.test_blas
-	wholecell/tests/utils/test_blas.py
+	pytest wholecell/tests/utils/test_blas.py DOT  # measures a dot product speed
+	pytest wholecell/tests/utils/test_blas.py      # unit tests: time dot products with a range of threads
+	python -m wholecell.tests.utils.test_blas      # unit tests
+	wholecell/tests/utils/test_blas.py             # unit tests
 """
 
 import os
@@ -78,8 +79,10 @@ class Test_blas(unittest.TestCase):
 		# Issue #931: The expected value came from Numpy's copy of openblas on
 		# Intel CPUs on Sherlock, Mac, and Linux. But:
 		#
+		#   * Intel CPU on Mac using Accelerate or OpenBlas computed 0.016683805584112754
 		#   * Apple M1 CPU on Mac computed 0.01668380558411259
 		#   * Intel CPU on WSL on Windows computed 0.016683805584112667
+		#   * Intel CPU on Sherlock using openblas/0.3.28 also computed 0.016683805584112667
 		#
 		# Reproducible simulations require reproducible floating point results,
 		# but that might be unachievable across platforms.


### PR DESCRIPTION
* Manually update pip, then let requirements.txt install the other installers so it can require `setuptools==73.0.1` which is the last version that's compatible with Aesara. It's OK to use some older versions (the pyenv on Sherlock uses 69.0.2) but not `> 73.0.1`.
* macOS: Install cmake via brew on macOS. Thanks to Riley for catching these problems.
* Sherlock: module load git/2.45.1 (git/2.27.0 is no longer available).
* Add comments about the different ways to run `test_blas.py` and more consistent results from openblas/0.3.28 and macOS Accelerate. Newer numpy and scipy releases can use Accelerate by default and maybe openblas/0.3.28, but they're not compatible with Aesara.

**Note:** Aesara is no longer actively maintained. It's not compatible with newer versions of numpy, scipy, and numba. At some point we'll need to replace it. `rna_decay.py` uses its Automatic Differentiation feature. It's likely that PyTorch or TensorFlow can do that, and will remain well maintained.

**Note:** A pytest warning says `It is recommended to use setuptools < 60.0 for those Python versions` (< 3.12) but cvxpy 1.3.2 requires `setuptools > 65.5.1`.