### PR TITLE
Set upper bound for ribosome_crowding.py analysis scripts

### DIFF
--- a/models/ecoli/analysis/single/ribosome_crowding.py
+++ b/models/ecoli/analysis/single/ribosome_crowding.py
@@ -15,6 +15,8 @@ from models.ecoli.analysis import singleAnalysisPlot
 from wholecell.analysis.analysis_tools import exportFigure
 from wholecell.io.tablereader import TableReader
 
+# Set this to ensure maximum figure size of 2^16 pixels is not exceeded
+MAX_NUMBER_OF_MONOMERS_TO_PLOT = 300
 
 class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 	def do_plot(self, simOutDir, plotOutDir, plotOutFileName, simDataFile, validationDataFile, metadata):
@@ -52,10 +54,19 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 			overcrowded_monomer_indexes]
 
 		if n_overcrowded_monomers > 0:
+
+			# Ensure we do not exceed maximum figure size
+			n_overcrowded_monomers_to_plot = n_overcrowded_monomers
+			if n_overcrowded_monomers > MAX_NUMBER_OF_MONOMERS_TO_PLOT:
+				n_overcrowded_monomers_to_plot = MAX_NUMBER_OF_MONOMERS_TO_PLOT
+
 			# Plot the target vs actual rna synthesis probabilites of these mRNAs
-			plt.figure(figsize=(6, 1.5*n_overcrowded_monomers))
+			plt.figure(figsize=(6, 1.5*n_overcrowded_monomers_to_plot))
 
 			for i, monomer_index in enumerate(overcrowded_monomer_indexes):
+				if i > MAX_NUMBER_OF_MONOMERS_TO_PLOT:
+					continue
+
 				target_prob_this_monomer = target_prob_translation_per_transcript[
 				:, monomer_index]
 				actual_prob_this_monomer = actual_prob_translation_per_transcript[
@@ -67,13 +78,21 @@ class Plot(singleAnalysisPlot.SingleAnalysisPlot):
 				ax.set_ylabel(f'{overcrowded_gene_ids[i]}\ntranslation probs')
 
 				if i == 0:
-					ax.set_title(f'Total number of proteins '
-								 f'corresponding to overcrowded mRNAs: '
-								 f'{n_overcrowded_monomers}')
+					if n_overcrowded_monomers > MAX_NUMBER_OF_MONOMERS_TO_PLOT:
+						ax.set_title(f'Total number of proteins '
+									 f'corresponding to overcrowded mRNAs: '
+									 f'{n_overcrowded_monomers} (plotting '
+									 f'first {MAX_NUMBER_OF_MONOMERS_TO_PLOT})')
+					else:
+						ax.set_title(f'Total number of proteins '
+									 f'corresponding to overcrowded mRNAs: '
+									 f'{n_overcrowded_monomers}')
 					ax.legend(loc=1)
 
 				if i == n_overcrowded_monomers - 1:
 					ax.set_xlabel('Time [min]')
+
+				ax.title.set_size(8)
 		else:
 			# Generate empty plot if no overcrowding occurred
 			plt.figure(figsize=(6, 1.5))


### PR DESCRIPTION
This PR sets an upper bound for the total number of overcrowded monomers that can be plotted in `multigen/ribosome_crowding.py` and `single/ribosome_crowding.py`. This is necessary because in some edge cases with atypical cells, there were so many overcrowded monomers that the dynamic figure sizing was leading to a value error in the size of the figure, e.g. ValueError: Image size of 600x201300 pixels is too large. It must be less than 2^16 in each direction. These edge cases were discovered via Jenkins tests for +AA and anaerobic. If the upper bound is exceeded, this will be communicated to the user via the plot title.