### PR TITLE
Transcription factor binding listener update

### DIFF
--- a/models/ecoli/listeners/rna_synth_prob.py
+++ b/models/ecoli/listeners/rna_synth_prob.py
@@ -72,6 +72,10 @@ class RnaSynthProb(wholecell.listeners.listener.Listener):
 		TU_indexes, all_coordinates, all_domains, bound_TFs = promoters.attrs(
 			"TU_index", "coordinates", "domain_index", "bound_TF"
 			)
+
+		# Record the TFs that are bound whenever promoters exist:
+		self.nActualBound = bound_TFs.sum(axis=0)
+
 		genes = self.uniqueMolecules.container.objectsInCollection('gene')
 		cistron_indexes = genes.attr("cistron_index")
 

--- a/models/ecoli/listeners/rna_synth_prob.py
+++ b/models/ecoli/listeners/rna_synth_prob.py
@@ -74,7 +74,7 @@ class RnaSynthProb(wholecell.listeners.listener.Listener):
 			)
 
 		# Record the TFs that are bound whenever promoters exist:
-		self.nActualBound = bound_TFs.sum(axis=0)
+		self.nActualBound = bound_TFs.sum(axis=0, dtype=np.float64)
 
 		genes = self.uniqueMolecules.container.objectsInCollection('gene')
 		cistron_indexes = genes.attr("cistron_index")

--- a/models/ecoli/listeners/rna_synth_prob.py
+++ b/models/ecoli/listeners/rna_synth_prob.py
@@ -73,7 +73,7 @@ class RnaSynthProb(wholecell.listeners.listener.Listener):
 			"TU_index", "coordinates", "domain_index", "bound_TF"
 			)
 
-		# Record the TFs that are bound whenever promoters exist:
+		# TFs currently bound to transcription units/promoters at this timestep:
 		self.nActualBound = bound_TFs.sum(axis=0, dtype=np.float64)
 
 		genes = self.uniqueMolecules.container.objectsInCollection('gene')

--- a/models/ecoli/processes/tf_binding.py
+++ b/models/ecoli/processes/tf_binding.py
@@ -203,8 +203,6 @@ class TfBinding(wholecell.processes.process.Process):
 		self.writeToListener(
 			"RnaSynthProb", "nPromoterBound", nPromotersBound)
 		self.writeToListener(
-			"RnaSynthProb", "nActualBound", nActualBound)
-		self.writeToListener(
 			"RnaSynthProb", "n_available_promoters", n_promoters)
 		self.writeToListener(
 			"RnaSynthProb", "n_bound_TF_per_TU", n_bound_TF_per_TU)

--- a/models/ecoli/processes/tf_binding.py
+++ b/models/ecoli/processes/tf_binding.py
@@ -96,9 +96,6 @@ class TfBinding(wholecell.processes.process.Process):
 				"RnaSynthProb", "nPromoterBound",
 				np.zeros(self.n_TF, dtype=np.float64))
 			self.writeToListener(
-				"RnaSynthProb", "nActualBound",
-				np.zeros(self.n_TF, dtype=np.float64))
-			self.writeToListener(
 				"RnaSynthProb", "n_available_promoters",
 				np.zeros(self.n_TF, dtype=np.float64))
 			self.writeToListener(
@@ -119,7 +116,6 @@ class TfBinding(wholecell.processes.process.Process):
 		# Create vectors for storing values
 		pPromotersBound = np.zeros(self.n_TF, dtype=np.float64)
 		nPromotersBound = np.zeros(self.n_TF, dtype=np.float64)
-		nActualBound = np.zeros(self.n_TF, dtype=np.float64)
 		n_promoters = np.zeros(self.n_TF, dtype=np.float64)
 		n_bound_TF_per_TU = np.zeros((self.n_TU, self.n_TF), dtype=np.int16)
 
@@ -186,7 +182,6 @@ class TfBinding(wholecell.processes.process.Process):
 			# Record values
 			pPromotersBound[tf_idx] = pPromoterBound
 			nPromotersBound[tf_idx] = n_to_bind
-			nActualBound[tf_idx] = bound_locs.sum()
 
 		delta_TF = bound_TF_new.astype(np.int8) - bound_TF.astype(np.int8)
 		mass_diffs = delta_TF.dot(self.active_tf_masses)


### PR DESCRIPTION
At each time step, transcription factors (TFs) bind and unbind from transcription units. When cells are initialized, some transcription factors are already bound to promoters and thus, these bound TFs need to be accounted for at time 0 (similar to how complexation complexes can exist at cell initialization in the model). 

At the initial time step of each cell generation, the count of bound TFs was incorrectly set to zero from how it is set in the initialization() function of `rna_synth_prob.py` because there was nothing else to record the actual current counts of bound TFs at time 0 in the update() function. This caused a discrepancy that could be seen when validating the total monomer counts for monomers that participate in active TFs (that can be seen in the “before” plots pasted in the PDF below): `total counts - complexed counts - free counts ≠ 0`. The total counts already accounted for bound TFs at time zero in the `monomer_counts.py` listener’s update() function (which executes at the initial time step of each cell in a simulation). "Unbound TFs" refers to TF molecules released from DNA back into the bulk molecule pool during that time step. Hence, it's expected for unbinding events to equal zero at time 0, since no unbinding has occurred yet (as unbinding does not occur at initialization steps for cells), and unbinding events can only happen once there are TFs bound.

To accurately track total monomer counts, the `rna_synth_prob.py` listener must account for TFs already bound to transcription units at the start of each cell cycle within the update() function. This ensures that summing all free and complexed forms of each monomer matches the total recorded in the `monomer_counts.py` listener. 

See the attached pdf for some examples of how this change impacts how we record the counts of bound TFs at each time step in the model. 
[TF count update.pdf](https://github.com/user-attachments/files/27210954/TF.count.update.pdf)
